### PR TITLE
fix: remove middleware auth redirect to prevent loop, let pages handle auth

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -40,7 +40,7 @@ export default function Page() {
     } else if (state.status === 'success') {
       setIsSuccessful(true);
       updateSession();
-      router.refresh();
+      router.push('/');
     }
   }, [state.status]);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,23 +24,14 @@ export async function middleware(request: NextRequest) {
   });
 
   if (!token) {
-    // Get the correct host and protocol from headers
-    const host = request.headers.get('host') || request.nextUrl.host;
-    const protocol = request.headers.get('x-forwarded-proto') || request.nextUrl.protocol;
-    const baseUrl = `${protocol}//${host}`;
-    
-    let redirectUrl = request.url;
-    
-    // Fix localhost URLs to use the current host
-    if (redirectUrl.includes('localhost:3000')) {
-      redirectUrl = redirectUrl.replace('http://localhost:3000', baseUrl);
+    // Allow unauthenticated access to login/register pages
+    if (['/login', '/register'].includes(pathname)) {
+      return NextResponse.next();
     }
     
-    const encodedRedirectUrl = encodeURIComponent(redirectUrl);
-    
-    return NextResponse.redirect(
-      new URL(`/api/auth/guest?redirectUrl=${encodedRedirectUrl}`, baseUrl),
-    );
+    // For other pages, let NextAuth handle the redirect to login page
+    // The individual pages (like the main chat page) will handle guest user creation
+    return NextResponse.next();
   }
 
   const isGuest = guestRegex.test(token?.email ?? '');


### PR DESCRIPTION
## Ticket

Resolves authentication redirect loop and login flow issues

## Changes

**Fixed:**
- `middleware.ts` - Removed conflicting auth redirect logic that caused infinite loops
- `app/(auth)/login/page.tsx` - Fixed login success redirect to navigate to main app instead of refreshing login page

## Context for reviewers

This PR fixes authentication flow issues where users got stuck in redirect loops or couldn't complete login.

The middleware was intercepting all unauthenticated requests and redirecting to guest auth, which conflicted with the page-level auth handling. The login page was also refreshing itself instead of redirecting to the main app after successful authentication.

**Root cause:**
- Middleware and page components both tried to handle auth redirects
- Login success handler used `router.refresh()` instead of `router.push('/')`

**Solution:**
- Let individual pages handle their own auth requirements
- Properly redirect to main app after successful login

## Testing

```bash
cd client
pnpm dev
```

1. Visit `/login` - should show login form without redirect loops
2. Register new user - should create account and redirect to main app
3. Login with existing credentials - should authenticate and redirect to main app
4. Visit main page without auth - should redirect to guest auth (handled by page, not middleware)