### PR TITLE
feat: implement client-server Mastra integration with conditional routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,9 @@ AUTH_SECRET=****
 # xAI API Key for chat and image models: https://console.x.ai/
 XAI_API_KEY=****
 
-# Neon PostgreSQL database for Chat SDK (chat history only)
-POSTGRES_URL=****
-
-# GCP Cloud SQL PostgreSQL database for Mastra agents (participants data)
+# GCP Cloud SQL PostgreSQL database - used by both client and Mastra
+# Client: Chat history, votes, documents, user data
+# Mastra: Agent memory, workflows, traces, participants data
 DATABASE_URL=****
 
 # OpenAI API Key (primary AI provider)
@@ -28,9 +27,18 @@ GOOGLE_CLOUD_PROJECT=****
 GCS_BUCKET_NAME=****
 
 # Mastra Backend API for web automation
+# MASTRA_SERVER_URL is used by the client to connect to the Mastra backend
+# For local development: http://localhost:4111
+# For Docker deployment: http://localhost:4111 (external port mapping)
 MASTRA_API_URL=****
 MASTRA_JWT_TOKEN=****
-MASTRA_SERVER_URL=****
+MASTRA_SERVER_URL=http://localhost:4111
+
+# NEXT_PUBLIC_MASTRA_SERVER_URL is required for client-side requests to Mastra
+# This MUST be set at build time for Next.js to embed it in the client bundle
+# For local development: http://localhost:4111
+# For Docker deployment: http://localhost:4111 (external port mapping)
+NEXT_PUBLIC_MASTRA_SERVER_URL=http://localhost:4111
 
 # Instructions to create a Redis store here:
 # https://vercel.com/docs/redis

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -38,7 +38,7 @@ import { ChatSDKError } from '@/lib/errors';
 import type { ChatMessage } from '@/lib/types';
 import type { ChatModel } from '@/lib/ai/models';
 import type { VisibilityType } from '@/components/visibility-selector';
-import { mastra } from '@/lib/mastra';
+// Mastra import removed - web automation now uses chatRoute
 
 export const maxDuration = 300; // 5 minutes for web automation tasks
 
@@ -151,35 +151,9 @@ export async function POST(request: Request) {
     const streamId = generateUUID();
     await createStreamId({ streamId, chatId: id });
 
-    // Handle web automation model with Mastra agent
+    // Web automation model is now handled by Mastra chatRoute
     if (selectedChatModel === 'web-automation-model') {
-      const webAutomationAgent = mastra.getAgent('webAutomationAgent');
-      
-      // Convert UI messages to Mastra format
-      const mastraMessages = uiMessages.map((msg) => ({
-        role: msg.role,
-        content: msg.parts.map(part => part.type === 'text' ? part.text : '').join('\n')
-      }));
-
-      try {
-        const stream = await webAutomationAgent.streamVNext(mastraMessages, {
-          format: 'aisdk', // Enable AI SDK v5 compatibility
-          memory: {
-            thread: id, // Use the chat ID as the thread ID
-            resource: session.user.id, // Use the user ID as the resource ID
-          },
-          onStepFinish: (step: any) => {
-            // Log step details to help debug tool call visibility
-            console.log('Step finished:', JSON.stringify(step, null, 2));
-          }
-        });
-
-        // Return the stream as a UI message stream response
-        return stream.toUIMessageStreamResponse();
-      } catch (error) {
-        console.error('Error with Mastra web automation agent:', error);
-        return new ChatSDKError('internal_server_error:api').toResponse();
-      }
+      return new ChatSDKError('bad_request:api', 'Web automation model should use Mastra chatRoute').toResponse();
     }
 
     // Default handling for other models

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -69,10 +69,14 @@ export function Chat({
     experimental_throttle: 100,
     generateId: generateUUID,
     transport: new DefaultChatTransport({
-      api: '/api/chat',
+      api: initialChatModel === 'web-automation-model' ?
+        (process.env.NEXT_PUBLIC_MASTRA_SERVER_URL ?
+          `${process.env.NEXT_PUBLIC_MASTRA_SERVER_URL}/chat` :
+          'http://mastra-app:4112/chat') :
+        '/api/chat',
       fetch: fetchWithErrorHandlers,
-      prepareSendMessagesRequest({ messages, id, body }) {
-        return {
+      prepareSendMessagesRequest: initialChatModel !== 'web-automation-model' ?
+        ({ messages, id, body }) => ({
           body: {
             id,
             message: messages.at(-1),
@@ -80,8 +84,7 @@ export function Chat({
             selectedVisibilityType: visibilityType,
             ...body,
           },
-        };
-      },
+        }) : undefined,
     }),
     onData: (dataPart) => {
       setDataStream((ds) => (ds ? [...ds, dataPart] : []));

--- a/lib/mastra/index.ts
+++ b/lib/mastra/index.ts
@@ -1,5 +1,7 @@
-// Import the built Mastra app from local client build
-import { ft as builtMastra } from '../../.mastra/output/mastra.mjs';
+// Use MastraClient to connect to the Mastra server
+import { MastraClient } from '@mastra/client-js';
 
-export const mastra = builtMastra;
+export const mastra = new MastraClient({
+  baseUrl: process.env.MASTRA_SERVER_URL || "http://localhost:4111",
+});
 export type { Agent } from '@mastra/core/agent';

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",
-    "build": "pnpm mastra:build && tsx lib/db/migrate && next build",
-    "mastra:build": "npx mastra build --dir ../src/mastra",
+    "build": "tsx lib/db/migrate && next build",
     "start": "next start",
     "lint": "next lint && biome lint --write --unsafe",
     "lint:fix": "next lint --fix && biome lint --write --unsafe",


### PR DESCRIPTION
- Replace embedded Mastra import with MastraClient from @mastra/client-js
- Add conditional chat routing: web-automation-model uses Mastra server, others use local API
- Remove web-automation-model handling from local chat API route
- Update chat component to route requests based on selected model
- Remove mastra:build script as no longer embedding Mastra artifacts