### PR TITLE
feat: Finishing up Chat Modality PRD

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -1,34 +1,31 @@
 'use client';
-
+import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
+import { memo, useState } from 'react';
+import type { Vote } from '@/lib/db/schema';
+import { DocumentToolCall, DocumentToolResult } from './document';
+import { PencilEditIcon, SparklesIcon } from './icons';
+import { Markdown } from './markdown';
+import { MessageActions } from './message-actions';
+import { PreviewAttachment } from './preview-attachment';
+import { Weather } from './weather';
+import equal from 'fast-deep-equal';
+import { cn, sanitizeText } from '@/lib/utils';
+import { Button } from './ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import { MessageEditor } from './message-editor';
+import { DocumentPreview } from './document-preview';
+import { MessageReasoning } from './message-reasoning';
+import type { UseChatHelpers } from '@ai-sdk/react';
+import type { ChatMessage } from '@/lib/types';
+import { useDataStream } from './data-stream-provider';
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from './ui/collapsible';
-import { DocumentToolCall, DocumentToolResult } from './document';
-import { PencilEditIcon, SparklesIcon } from './icons';
-import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
-import { cn, sanitizeText } from '@/lib/utils';
-import { memo, useState } from 'react';
-
-import { Button } from './ui/button';
-import type { ChatMessage } from '@/lib/types';
 import { ChevronDown } from 'lucide-react';
 import { CollapsibleWrapper } from './ui/collapsible-wrapper';
-import { DocumentPreview } from './document-preview';
-import { Markdown } from './markdown';
-import { MessageActions } from './message-actions';
-import { MessageEditor } from './message-editor';
-import { MessageReasoning } from './message-reasoning';
-import { PreviewAttachment } from './preview-attachment';
-import type { UseChatHelpers } from '@ai-sdk/react';
-import type { Vote } from '@/lib/db/schema';
-import { Weather } from './weather';
-import cx from 'classnames';
-import equal from 'fast-deep-equal';
-import { getToolDisplayInfo } from './tool-icon';
-import { useDataStream } from './data-stream-provider';
 
 // Type narrowing is handled by TypeScript's control flow analysis
 // The AI SDK provides proper discriminated unions for tool calls

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -2,32 +2,6 @@
 
 import { AnimatePresence, motion } from 'framer-motion';
 import {
-  ArrowLeft,
-  Brain,
-  Camera,
-  CheckSquare,
-  ChevronDown,
-  Clock,
-  Code,
-  Database,
-  Download,
-  FileText,
-  Globe,
-  Keyboard,
-  Maximize2,
-  MessageCircle,
-  MessageSquare,
-  Monitor,
-  MousePointer,
-  Move,
-  Network,
-  PanelLeft,
-  Search,
-  Type,
-  Upload,
-  X
-} from 'lucide-react';
-import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -40,6 +14,7 @@ import { memo, useState } from 'react';
 
 import { Button } from './ui/button';
 import type { ChatMessage } from '@/lib/types';
+import { ChevronDown } from 'lucide-react';
 import { CollapsibleWrapper } from './ui/collapsible-wrapper';
 import { DocumentPreview } from './document-preview';
 import { Markdown } from './markdown';
@@ -52,90 +27,11 @@ import type { Vote } from '@/lib/db/schema';
 import { Weather } from './weather';
 import cx from 'classnames';
 import equal from 'fast-deep-equal';
+import { getToolDisplayInfo } from './tool-icon';
 import { useDataStream } from './data-stream-provider';
 
 // Type narrowing is handled by TypeScript's control flow analysis
 // The AI SDK provides proper discriminated unions for tool calls
-
-// Icon mapping for tool actions
-const getToolIcon = (toolName: string) => {
-  const cleanToolName = toolName.replace('tool-', '');
-  
-  const iconMap: Record<string, React.ComponentType<any>> = {
-    'playwright_browser_navigate': Globe,
-    'playwright_browser_click': MousePointer,
-    'playwright_browser_type': Type,
-    'playwright_browser_fill_form': FileText,
-    'playwright_browser_select_option': CheckSquare,
-    'playwright_browser_take_screenshot': Camera,
-    'playwright_browser_snapshot': Monitor,
-    'playwright_browser_wait_for': Clock,
-    'playwright_browser_hover': Move,
-    'playwright_browser_drag': Move,
-    'playwright_browser_press_key': Keyboard,
-    'playwright_browser_evaluate': Code,
-    'playwright_browser_close': X,
-    'playwright_browser_resize': Maximize2,
-    'playwright_browser_tabs': PanelLeft,
-    'playwright_browser_console_messages': MessageSquare,
-    'playwright_browser_network_requests': Network,
-    'playwright_browser_handle_dialog': MessageCircle,
-    'playwright_browser_file_upload': Upload,
-    'playwright_browser_install': Download,
-    'playwright_browser_navigate_back': ArrowLeft,
-    'search-participants-by-name': Search,
-    'get-participant-with-household': Database,
-    'updateWorkingMemory': Brain,
-  };
-
-  return iconMap[cleanToolName] || FileText; // Default icon
-};
-
-// Mapping function for tool names to user-friendly descriptions with icons
-const getToolDisplayName = (toolName: string, input?: any): { text: string; icon: React.ComponentType<any> } => {
-  const toolMappings: Record<string, (input?: any) => string> = {
-    'playwright_browser_navigate': (input) => input?.url ? `Navigated to ${input.url}` : 'Navigated to page',
-    'playwright_browser_click': (input) => input?.element ? `Clicked on ${input.element}` : 'Clicked element',
-    'playwright_browser_type': (input) => input?.text ? `Typed "${input.text}"` : 'Typed text',
-    'playwright_browser_fill_form': () => 'Filled form fields',
-    'playwright_browser_select_option': (input) => input?.values ? `Selected "${input.values.join(', ')}"` : 'Selected option',
-    'playwright_browser_take_screenshot': () => 'Took screenshot',
-    'playwright_browser_snapshot': () => 'Captured page snapshot',
-    'playwright_browser_wait_for': (input) => input?.text ? `Waited for "${input.text}"` : 'Waited for element',
-    'playwright_browser_hover': (input) => input?.element ? `Hovered over ${input.element}` : 'Hovered over element',
-    'playwright_browser_drag': () => 'Performed drag and drop',
-    'playwright_browser_press_key': (input) => input?.key ? `Pressed key "${input.key}"` : 'Pressed key',
-    'playwright_browser_evaluate': () => 'Executed JavaScript',
-    'playwright_browser_close': () => 'Closed browser',
-    'playwright_browser_resize': () => 'Resized browser window',
-    'playwright_browser_tabs': () => 'Managed browser tabs',
-    'playwright_browser_console_messages': () => 'Retrieved console messages',
-    'playwright_browser_network_requests': () => 'Retrieved network requests',
-    'playwright_browser_handle_dialog': () => 'Handled dialog',
-    'playwright_browser_file_upload': () => 'Uploaded files',
-    'playwright_browser_install': () => 'Installed browser',
-    'playwright_browser_navigate_back': () => 'Navigated back',
-    'search-participants-by-name': (input) => input?.name ? `Searched for participant "${input.name}"` : 'Searched for participant',
-    'get-participant-with-household': () => 'Retrieved participant data',
-    'updateWorkingMemory': () => 'Updated working memory',
-  };
-
-  const cleanToolName = toolName.replace('tool-', '');
-  const mapper = toolMappings[cleanToolName];
-  
-  let text: string;
-  if (mapper) {
-    text = mapper(input);
-  } else {
-    // Fallback: convert kebab-case to readable format
-    text = cleanToolName.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
-  }
-  
-  return {
-    text,
-    icon: getToolIcon(toolName)
-  };
-};
 
 const PurePreviewMessage = ({
   chatId,
@@ -430,7 +326,7 @@ const PurePreviewMessage = ({
 
                 if (state === 'input-available') {
                   const { input } = part as any;
-                  const { text: displayName, icon } = getToolDisplayName(type, input);
+                  const { text: displayName, icon } = getToolDisplayInfo(type, input);
                   
                   return (
                     <CollapsibleWrapper key={toolCallId} displayName={displayName} input={input} icon={icon} />
@@ -439,7 +335,7 @@ const PurePreviewMessage = ({
 
                 if (state === 'output-available') {
                   const { output, input } = part as any;
-                  const { text: displayName, icon } = getToolDisplayName(type, input);
+                  const { text: displayName, icon } = getToolDisplayInfo(type, input);
 
                   if (output && 'error' in output) {
                     return (

--- a/components/tool-icon.tsx
+++ b/components/tool-icon.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import {
+  ArrowLeft,
+  Brain,
+  Camera,
+  CheckSquare,
+  Clock,
+  Code,
+  Database,
+  Download,
+  FileText,
+  Globe,
+  Keyboard,
+  Maximize2,
+  MessageCircle,
+  MessageSquare,
+  Monitor,
+  MousePointer,
+  Move,
+  Network,
+  PanelLeft,
+  Search,
+  Type,
+  Upload,
+  X
+} from 'lucide-react';
+
+interface ToolIconProps {
+  toolName: string;
+  size?: number;
+  className?: string;
+}
+
+// Icon mapping for tool actions
+const getToolIcon = (toolName: string) => {
+  const cleanToolName = toolName.replace('tool-', '');
+  
+  const iconMap: Record<string, React.ComponentType<any>> = {
+    'playwright_browser_navigate': Globe,
+    'playwright_browser_click': MousePointer,
+    'playwright_browser_type': Type,
+    'playwright_browser_fill_form': FileText,
+    'playwright_browser_select_option': CheckSquare,
+    'playwright_browser_take_screenshot': Camera,
+    'playwright_browser_snapshot': Monitor,
+    'playwright_browser_wait_for': Clock,
+    'playwright_browser_hover': Move,
+    'playwright_browser_drag': Move,
+    'playwright_browser_press_key': Keyboard,
+    'playwright_browser_evaluate': Code,
+    'playwright_browser_close': X,
+    'playwright_browser_resize': Maximize2,
+    'playwright_browser_tabs': PanelLeft,
+    'playwright_browser_console_messages': MessageSquare,
+    'playwright_browser_network_requests': Network,
+    'playwright_browser_handle_dialog': MessageCircle,
+    'playwright_browser_file_upload': Upload,
+    'playwright_browser_install': Download,
+    'playwright_browser_navigate_back': ArrowLeft,
+    'search-participants-by-name': Search,
+    'get-participant-with-household': Database,
+    'updateWorkingMemory': Brain,
+  };
+
+  return iconMap[cleanToolName] || FileText; // Default icon
+};
+
+export const ToolIcon = ({ toolName, size = 12, className = "text-gray-500 flex-shrink-0" }: ToolIconProps) => {
+  const IconComponent = getToolIcon(toolName);
+  
+  return <IconComponent size={size} className={className} />;
+};
+
+// Helper function to get tool display name with icon
+export const getToolDisplayInfo = (toolName: string, input?: any): { text: string; icon: React.ComponentType<any> } => {
+  const toolMappings: Record<string, (input?: any) => string> = {
+    'playwright_browser_navigate': (input) => input?.url ? `Navigated to ${input.url}` : 'Navigated to page',
+    'playwright_browser_click': (input) => input?.element ? `Clicked on ${input.element}` : 'Clicked element',
+    'playwright_browser_type': (input) => input?.text ? `Typed "${input.text}"` : 'Typed text',
+    'playwright_browser_fill_form': () => 'Filled form fields',
+    'playwright_browser_select_option': (input) => input?.values ? `Selected "${input.values.join(', ')}"` : 'Selected option',
+    'playwright_browser_take_screenshot': () => 'Took screenshot',
+    'playwright_browser_snapshot': () => 'Captured page snapshot',
+    'playwright_browser_wait_for': (input) => input?.text ? `Waited for "${input.text}"` : 'Waited for element',
+    'playwright_browser_hover': (input) => input?.element ? `Hovered over ${input.element}` : 'Hovered over element',
+    'playwright_browser_drag': () => 'Performed drag and drop',
+    'playwright_browser_press_key': (input) => input?.key ? `Pressed key "${input.key}"` : 'Pressed key',
+    'playwright_browser_evaluate': () => 'Executed JavaScript',
+    'playwright_browser_close': () => 'Closed browser',
+    'playwright_browser_resize': () => 'Resized browser window',
+    'playwright_browser_tabs': () => 'Managed browser tabs',
+    'playwright_browser_console_messages': () => 'Retrieved console messages',
+    'playwright_browser_network_requests': () => 'Retrieved network requests',
+    'playwright_browser_handle_dialog': () => 'Handled dialog',
+    'playwright_browser_file_upload': () => 'Uploaded files',
+    'playwright_browser_install': () => 'Installed browser',
+    'playwright_browser_navigate_back': () => 'Navigated back',
+    'search-participants-by-name': (input) => input?.name ? `Searched for participant "${input.name}"` : 'Searched for participant',
+    'get-participant-with-household': () => 'Retrieved participant data',
+    'updateWorkingMemory': () => 'Updated working memory',
+  };
+
+  const cleanToolName = toolName.replace('tool-', '');
+  const mapper = toolMappings[cleanToolName];
+  
+  let text: string;
+  if (mapper) {
+    text = mapper(input);
+  } else {
+    // Fallback: convert kebab-case to readable format
+    text = cleanToolName.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  }
+  
+  return {
+    text,
+    icon: getToolIcon(toolName)
+  };
+};

--- a/components/ui/collapsible-wrapper.tsx
+++ b/components/ui/collapsible-wrapper.tsx
@@ -8,8 +8,8 @@ import {
 } from './collapsible';
 
 import { Button } from './button';
-import { CircleCheck } from '@/components/animate-ui/icons/circle-check';
 import { useState } from 'react';
+import { CircleCheck } from '@/components/animate-ui/icons/circle-check';
 
 interface CollapsibleWrapperProps {
   displayName: string;

--- a/components/ui/collapsible-wrapper.tsx
+++ b/components/ui/collapsible-wrapper.tsx
@@ -8,8 +8,8 @@ import {
 } from './collapsible';
 
 import { Button } from './button';
-import { useState } from 'react';
 import { CircleCheck } from '@/components/animate-ui/icons/circle-check';
+import { useState } from 'react';
 
 interface CollapsibleWrapperProps {
   displayName: string;
@@ -17,6 +17,7 @@ interface CollapsibleWrapperProps {
   output?: any;
   isError?: boolean;
   className?: string;
+  icon?: React.ComponentType<any>;
 }
 
 export function CollapsibleWrapper({ 
@@ -24,7 +25,8 @@ export function CollapsibleWrapper({
   input, 
   output, 
   isError = false,
-  className
+  className,
+  icon: Icon
 }: CollapsibleWrapperProps) {
   const [open, setOpen] = useState(false);
   
@@ -35,11 +37,15 @@ export function CollapsibleWrapper({
     <Collapsible open={open} onOpenChange={setOpen} className={finalClassName}>
       <div className="flex items-center justify-between p-3">
         <div className={`text-[10px] leading-[150%] font-ibm-plex-mono text-[#767676] flex items-center gap-2 ${isError ? 'text-red-600' : ''}`}>
+          {Icon && (
+            <Icon size={12} className="text-gray-500 flex-shrink-0" />
+          )}
           {displayName}
           {isError && ' (Error)'}
           {!isError && output && (
-            <CircleCheck size={14} className="text-purple-600 dark:text-purple-400" />
+            <CircleCheck size={14} className="text-custom-purple" />
           )}
+          
         </div>
         <CollapsibleTrigger asChild>
           <Button variant="ghost" size="sm" className="p-1 h-auto">


### PR DESCRIPTION
## Checklist

- [x] Update PR Title to follow this pattern: `[INTENT]:[MESSAGE]`
  > The title will become a one-line commit message in the git log, so be as concise and specific as possible -- refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/). Prepend [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) intent (`fix:`, `feat:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`).

## Ticket

Resolves [ASP-252](https://navalabs.atlassian.net/browse/ASP-252)

## Changes

* Added a mapping of tool names to corresponding icons using Lucide React icons in `message.tsx`, and created the `getToolIcon` function to retrieve the appropriate icon for each tool action.

<img width="704" height="521" alt="Screenshot 2025-10-01 at 3 47 12 PM" src="https://github.com/user-attachments/assets/0f131961-7fdb-4860-a1b8-a42fde33c932" />


## Testing

> Visual Testing at the moment

## Context for reviewers

These changes were based on the PRD received - logical icons that are put in front of the tool calls to make a nicer visual appearance. 

This pull request adds tool-specific icons to the tool action display in chat messages, improving the clarity and visual distinction of different tool actions. The main changes include introducing an icon mapping for tool actions, updating the display logic to include both text and icons, and modifying the `CollapsibleWrapper` component to render the corresponding icon.