### PR TITLE
bug: changes to the tool call messages and edit message icon removal

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -118,7 +118,7 @@ const PurePreviewMessage = ({
                 if (mode === 'view') {
                   return (
                     <div key={key} className="flex flex-row gap-2 items-start">
-                      {message.role === 'user' && !isReadonly && (
+                      {/* {message.role === 'user' && !isReadonly && (
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button
@@ -134,7 +134,7 @@ const PurePreviewMessage = ({
                           </TooltipTrigger>
                           <TooltipContent>Edit message</TooltipContent>
                         </Tooltip>
-                      )}
+                      )} */}
 
                       <div
                         data-testid="message-content"
@@ -317,38 +317,69 @@ const PurePreviewMessage = ({
 
                 if (state === 'input-available') {
                   const { input } = part as any;
-                  const { text: displayName, icon } = getToolDisplayInfo(type, input);
+                  const { text: displayName, icon: Icon } = getToolDisplayInfo(type, input);
 
+                  // Only use CollapsibleWrapper for get-participant-with-household
+                  if (displayName === 'Retrieved participant data') {
+                    return (
+                      <CollapsibleWrapper key={toolCallId} displayName={displayName} input={input} icon={Icon} />
+                    );
+                  }
+
+                  // For all other tools, show simple icon with text
                   return (
-                    <CollapsibleWrapper key={toolCallId} displayName={displayName} input={input} icon={icon} />
+                    <div key={toolCallId} className="flex items-center gap-2 p-3 border-0 rounded-md">
+                      <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-[#767676] flex items-center gap-2">
+                        {Icon && (
+                          <Icon size={12} className="text-gray-500 flex-shrink-0" />
+                        )}
+                        {displayName}
+                      </div>
+                    </div>
                   );
                 }
 
                 if (state === 'output-available') {
                   const { output, input } = part as any;
-                  const { text: displayName, icon } = getToolDisplayInfo(type, input);
+                  const { text: displayName, icon: Icon } = getToolDisplayInfo(type, input);
 
-                  if (output && 'error' in output) {
+                  // Only use CollapsibleWrapper for get-participant-with-household
+                  if (displayName === 'Retrieved participant data') {
+                    if (output && 'error' in output) {
+                      return (
+                        <CollapsibleWrapper 
+                          key={toolCallId} 
+                          displayName={displayName} 
+                          input={input} 
+                          output={output} 
+                          isError={true}
+                          icon={Icon}
+                        />
+                      );
+                    }
+
                     return (
                       <CollapsibleWrapper 
                         key={toolCallId} 
                         displayName={displayName} 
                         input={input} 
-                        output={output} 
-                        isError={true}
-                        icon={icon}
+                        output={output}
+                        icon={Icon}
                       />
                     );
                   }
 
+                  // For all other tools, show simple icon with text
                   return (
-                    <CollapsibleWrapper 
-                      key={toolCallId} 
-                      displayName={displayName} 
-                      input={input} 
-                      output={output}
-                      icon={icon}
-                    />
+                    <div key={toolCallId} className="flex items-center gap-2 p-3 border-0 rounded-md">
+                      <div className={`text-[10px] leading-[150%] font-ibm-plex-mono flex items-center gap-2 ${output && 'error' in output ? 'text-red-600' : 'text-[#767676]'}`}>
+                        {Icon && (
+                          <Icon size={12} className="text-gray-500 flex-shrink-0" />
+                        )}
+                        {displayName}
+                        {output && 'error' in output && ' (Error)'}
+                      </div>
+                    </div>
                   );
                 }
               }


### PR DESCRIPTION
## Fixes

[ASP-379](https://navalabs.atlassian.net/browse/ASP-379)
[ASP-343](https://navalabs.atlassian.net/browse/ASP-343)

## Testing

<img width="880" height="408" alt="Screenshot 2025-10-21 at 3 21 13 PM" src="https://github.com/user-attachments/assets/4f279a81-571f-4328-9f7e-d8073a21f3a5" />

## Changes

* Updated the logic so that only messages with the display name `'Retrieved participant data'` use the `CollapsibleWrapper` component; all other tool messages now display a simplified row with an icon and label. Error states are visually distinguished with red text and an "(Error)" label. 
* Commented out the edit button for user messages in view mode

## Background

This pull request updates the `PurePreviewMessage` component in `components/message.tsx` to improve how tool-related messages are displayed. The main changes are a more consistent and user-friendly rendering of tool icons and labels, and a special collapsible view for participant data retrieval. Additionally, the edit button for user messages is now commented out.