### PR TITLE
feat: removed need for the consent page

### DIFF
--- a/app/(chat)/home/page.tsx
+++ b/app/(chat)/home/page.tsx
@@ -39,7 +39,7 @@ export default function LandingPage() {
             {/* Start Application Button */}
             <div className="mt-auto">
               <Link 
-                href="/consent"
+                href="/"
                 className="inline-block bg-custom-purple text-white font-inter font-medium text-sm leading-6 px-6 sm:px-7 py-2 sm:py-2.5 rounded-lg hover:bg-custom-purple/90 transition-colors"
               >
                 Start new application

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -32,8 +32,9 @@ export function AppSidebar({ user }: { user: User | undefined }) {
           <div className="flex flex-row justify-between items-center">
             <div className="flex flex-row gap-3 items-center">
               <Link
-                href="/"
+                href="/home"
                 onClick={() => {
+                  closeArtifact(setArtifact);
                   setOpenMobile(false);
                 }}
                 className="flex flex-row gap-3 items-center"
@@ -55,7 +56,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                 onClick={() => {
                   setOpenMobile(false);
                   closeArtifact(setArtifact);
-                  router.push('/home');
+                  router.push('/');
                   router.refresh();
                 }}
               >

--- a/components/layout-header.tsx
+++ b/components/layout-header.tsx
@@ -19,7 +19,7 @@ export function LayoutHeader() {
 
   const handleNewChat = () => {
     closeArtifact(setArtifact);
-    router.push('/home');
+    router.push('/');
     router.refresh();
   };
 

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_CHAT_MODEL: string = 'chat-model';
+export const DEFAULT_CHAT_MODEL: string = 'web-automation-model';
 
 export interface ChatModel {
   id: string;


### PR DESCRIPTION
## Changes

- Removed the routing need for consent
- If it is the users initial load, then route to home
- if new chat in any location is clicked, go to new chat window
- if Application Assistant in sidenav is click, go to home
- change default model to web-automation