### PR TITLE
feat: add toolcalls to trigger browser display

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -145,24 +145,30 @@ export function Chat({
       return;
     }
 
-    const hasBrowserToolCall = messages.some(message => 
+    const hasBrowserToolCall = messages.some(message =>
       message.parts?.some(part => {
         const partType = (part as any).type;
         const toolName = (part as any).toolName;
-        
-        // Check for tool-call type with playwright toolName
-        if (partType === 'tool-call' && 
-            (toolName?.startsWith('playwright_browser') || 
-             toolName?.startsWith('mcp_playwright_browser'))) {
+
+        // Check for tool-call type with browser-related toolName
+        // Supports: browser_navigate, playwright_browser_*, mcp_playwright_browser_*, playwright.browser_*
+        if (partType === 'tool-call' &&
+            (toolName?.startsWith('browser_') ||
+             toolName?.startsWith('playwright_browser') ||
+             toolName?.startsWith('mcp_playwright_browser') ||
+             toolName?.startsWith('playwright.browser_') ||
+             toolName?.includes('_browser_'))) {
           return true;
         }
-        
+
         // Check for tool- prefixed types (how tools appear in message parts)
-        if (partType?.startsWith('tool-playwright_browser') ||
-            partType?.startsWith('tool-mcp_playwright_browser')) {
+        if (partType?.startsWith('tool-browser_') ||
+            partType?.startsWith('tool-playwright_browser') ||
+            partType?.startsWith('tool-mcp_playwright_browser') ||
+            partType?.startsWith('tool-playwright.browser_')) {
           return true;
         }
-        
+
         return false;
       })
     );
@@ -193,19 +199,25 @@ export function Chat({
   useEffect(() => {
     // If artifact was visible and now it's not, and we have browser tool calls, user dismissed it
     if (!isArtifactVisible && !browserArtifactDismissed) {
-      const hasBrowserToolCall = messages.some(message => 
+      const hasBrowserToolCall = messages.some(message =>
         message.parts?.some(part => {
           const partType = (part as any).type;
           const toolName = (part as any).toolName;
-          
-          return (partType === 'tool-call' && 
-                  (toolName?.startsWith('playwright_browser') || 
-                   toolName?.startsWith('mcp_playwright_browser'))) ||
-                 (partType?.startsWith('tool-playwright_browser') ||
-                  partType?.startsWith('tool-mcp_playwright_browser'));
+
+          // Supports: browser_navigate, playwright_browser_*, mcp_playwright_browser_*, playwright.browser_*
+          return (partType === 'tool-call' &&
+                  (toolName?.startsWith('browser_') ||
+                   toolName?.startsWith('playwright_browser') ||
+                   toolName?.startsWith('mcp_playwright_browser') ||
+                   toolName?.startsWith('playwright.browser_') ||
+                   toolName?.includes('_browser_'))) ||
+                 (partType?.startsWith('tool-browser_') ||
+                  partType?.startsWith('tool-playwright_browser') ||
+                  partType?.startsWith('tool-mcp_playwright_browser') ||
+                  partType?.startsWith('tool-playwright.browser_'));
         })
       );
-      
+
       if (hasBrowserToolCall && initialChatModel === 'web-automation-model') {
         setBrowserArtifactDismissed(true);
       }

--- a/components/tool-icon.tsx
+++ b/components/tool-icon.tsx
@@ -37,6 +37,29 @@ const getToolIcon = (toolName: string) => {
   const cleanToolName = toolName.replace('tool-', '');
   
   const iconMap: Record<string, React.ComponentType<any>> = {
+    // New toolset format (browser_*)
+    'browser_navigate': Globe,
+    'browser_click': MousePointer,
+    'browser_type': Type,
+    'browser_fill_form': FileText,
+    'browser_select_option': CheckSquare,
+    'browser_take_screenshot': Camera,
+    'browser_snapshot': Monitor,
+    'browser_wait_for': Clock,
+    'browser_hover': Move,
+    'browser_drag': Move,
+    'browser_press_key': Keyboard,
+    'browser_evaluate': Code,
+    'browser_close': X,
+    'browser_resize': Maximize2,
+    'browser_tabs': PanelLeft,
+    'browser_console_messages': MessageSquare,
+    'browser_network_requests': Network,
+    'browser_handle_dialog': MessageCircle,
+    'browser_file_upload': Upload,
+    'browser_install': Download,
+    'browser_navigate_back': ArrowLeft,
+    // Legacy format (playwright_browser_*)
     'playwright_browser_navigate': Globe,
     'playwright_browser_click': MousePointer,
     'playwright_browser_type': Type,
@@ -58,6 +81,7 @@ const getToolIcon = (toolName: string) => {
     'playwright_browser_file_upload': Upload,
     'playwright_browser_install': Download,
     'playwright_browser_navigate_back': ArrowLeft,
+    // Database tools
     'search-participants-by-name': Search,
     'get-participant-with-household': Database,
     'updateWorkingMemory': Brain,
@@ -75,6 +99,29 @@ export const ToolIcon = ({ toolName, size = 12, className = "text-gray-500 flex-
 // Helper function to get tool display name with icon
 export const getToolDisplayInfo = (toolName: string, input?: any): { text: string; icon: React.ComponentType<any> } => {
   const toolMappings: Record<string, (input?: any) => string> = {
+    // New toolset format (browser_*)
+    'browser_navigate': (input) => input?.url ? `Navigated to ${input.url}` : 'Navigated to page',
+    'browser_click': (input) => input?.element ? `Clicked on ${input.element}` : 'Clicked element',
+    'browser_type': (input) => input?.text ? `Typed "${input.text}"` : 'Typed text',
+    'browser_fill_form': () => 'Filled form fields',
+    'browser_select_option': (input) => input?.values ? `Selected "${input.values.join(', ')}"` : 'Selected option',
+    'browser_take_screenshot': () => 'Took screenshot',
+    'browser_snapshot': () => 'Captured page snapshot',
+    'browser_wait_for': (input) => input?.text ? `Waited for "${input.text}"` : 'Waited for element',
+    'browser_hover': (input) => input?.element ? `Hovered over ${input.element}` : 'Hovered over element',
+    'browser_drag': () => 'Performed drag and drop',
+    'browser_press_key': (input) => input?.key ? `Pressed key "${input.key}"` : 'Pressed key',
+    'browser_evaluate': () => 'Executed JavaScript',
+    'browser_close': () => 'Closed browser',
+    'browser_resize': () => 'Resized browser window',
+    'browser_tabs': () => 'Managed browser tabs',
+    'browser_console_messages': () => 'Retrieved console messages',
+    'browser_network_requests': () => 'Retrieved network requests',
+    'browser_handle_dialog': () => 'Handled dialog',
+    'browser_file_upload': () => 'Uploaded files',
+    'browser_install': () => 'Installed browser',
+    'browser_navigate_back': () => 'Navigated back',
+    // Legacy format (playwright_browser_*)
     'playwright_browser_navigate': (input) => input?.url ? `Navigated to ${input.url}` : 'Navigated to page',
     'playwright_browser_click': (input) => input?.element ? `Clicked on ${input.element}` : 'Clicked element',
     'playwright_browser_type': (input) => input?.text ? `Typed "${input.text}"` : 'Typed text',
@@ -96,6 +143,7 @@ export const getToolDisplayInfo = (toolName: string, input?: any): { text: strin
     'playwright_browser_file_upload': () => 'Uploaded files',
     'playwright_browser_install': () => 'Installed browser',
     'playwright_browser_navigate_back': () => 'Navigated back',
+    // Database tools
     'search-participants-by-name': (input) => input?.name ? `Searched for participant "${input.name}"` : 'Searched for participant',
     'get-participant-with-household': () => 'Retrieved participant data',
     'updateWorkingMemory': () => 'Updated working memory',


### PR DESCRIPTION
  ## Summary

  Updates browser artifact detection logic to support new toolset-namespaced tool naming format from Mastra dynamic toolsets implementation.

  ## Problem

  After implementing dynamic MCP client initialization in the main repo (labs-asp PR #60), Playwright tools are now provided via `getToolsets()` which changes the tool naming format:
  - Old format: `playwright_browser_navigate`, `mcp_playwright_browser_navigate`
  - New format: `browser_navigate` (toolset namespace is handled internally by Mastra)

  The client-side browser artifact detection was only looking for the old format, causing the browser display to not open when Playwright tools were used.

  ## Solution

  Updated `client/components/chat.tsx` to detect both old and new tool naming formats:

  ### Changes

  1. **Browser Tool Call Detection** (lines 148-174)
     - Added detection for `browser_*` prefix (new toolset format)
     - Maintained backward compatibility with old formats
     - Added detection for `tool-browser_*` prefix in message parts

  2. **Browser Artifact Dismissal Tracking** (lines 198-225)
     - Updated dismissal detection to recognize new tool naming
     - Ensures artifact doesn't reopen after user manually closes it
     - Maintains same user experience across format changes

  ### Supported Tool Name Formats

  The detection now handles:
  - `browser_navigate` (new toolset format)
  - `playwright_browser_navigate` (legacy format)
  - `mcp_playwright_browser_navigate` (legacy MCP format)
  - `playwright.browser_navigate` (potential future format)
  - Any tool containing `_browser_` (catch-all)

  ### Tool Part Types Detected

  - `tool-call` with matching `toolName`
  - `tool-browser_*` prefix
  - `tool-playwright_browser*` prefix
  - `tool-mcp_playwright_browser*` prefix
  - `tool-playwright.browser_*` prefix

  ## Technical Details

  **How Browser Artifact Opens:**
  1. Chat component monitors incoming messages during streaming
  2. When `status === 'streaming'`, checks message parts for browser tool usage
  3. If browser tool detected and artifact not visible and not dismissed, opens artifact
  4. Sets artifact metadata with session ID, title, and browser kind
  5. Browser artifact component connects to WebSocket streaming service

  **Why This Change:**
  - Mastra's `getToolsets()` returns tools without MCP server prefix
  - Tools are namespaced internally as `serverName.toolName` in Mastra
  - By the time they reach the message stream, they appear as `browser_*`
  - Client detection needs to match this new format

  ## Testing

  - Browser artifact opens correctly when Playwright tools are used
  - Works with both new toolset format and legacy formats
  - Dismissal tracking works correctly
  - No regression in existing functionality

  ## Dependencies

  This PR requires the corresponding backend changes in labs-asp PR #60 to function correctly. Both PRs should be merged together.

  ## Breaking Changes

  None - maintains backward compatibility with old tool naming formats.