### PR TITLE
fix: content changes for landing page and take over

### DIFF
--- a/app/(chat)/home/page.tsx
+++ b/app/(chat)/home/page.tsx
@@ -54,7 +54,7 @@ export default function LandingPage() {
             How it works
           </h2>
           <p className="font-inter text-base sm:text-lg leading-6 text-black dark:text-gray-200 mb-6 sm:mb-8">
-                You&apos;ll see everything the AI assistant is doing, each step of the process
+          This tool uses artificial intelligence (AI) to help you complete applications, while you stay in control.
           </p>
 
           {/* Step Cards */}
@@ -65,10 +65,10 @@ export default function LandingPage() {
                 step 1
               </p>
               <h3 className="font-source-serif text-lg sm:text-xl leading-6 text-black dark:text-white mb-3 sm:mb-4">
-                Start and pre-fill
+                Start and autofill
               </h3>
               <p className="font-inter text-sm sm:text-base leading-6 text-black dark:text-gray-200">
-                AI agents gather what client information it can and pre-fills multiple forms for you.
+              AI autofills the application for you, using client data from your case management system.
               </p>
             </div>
 
@@ -81,7 +81,7 @@ export default function LandingPage() {
                 Fill in any gaps
               </h3>
               <p className="font-inter text-sm sm:text-base leading-6 text-black dark:text-gray-200">
-                If information is missing, the assistant pauses and asks for your input.
+                You review and complete anything that's missing. The AI only adds what's already in your system.
               </p>
             </div>
 
@@ -94,7 +94,7 @@ export default function LandingPage() {
                 Submit with confidence
               </h3>
               <p className="font-inter text-sm sm:text-base leading-6 text-black dark:text-gray-200">
-                Once everything looks right, you submit the application—nothing is submitted automatically.
+              You submit the application once everything looks right. Nothing is submitted automatically.
               </p>
             </div>
           </div>

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -463,9 +463,12 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
           {/* Fullscreen header with controls */}
           <div className="absolute top-0 left-0 right-0 z-10 browser-fullscreen-bg">
             <div className="flex items-center justify-between px-4 py-3">
-              <div className="flex items-center gap-2 text-white">
-                <div className="size-2 bg-red-500 rounded-full animate-pulse status-indicator" />
-                <span className="text-sm font-medium">YOU ARE IN CONTROL</span>
+              <div className="flex flex-col gap-1 text-white">
+                <div className="flex items-center gap-2">
+                  <div className="size-2 bg-red-500 rounded-full animate-pulse status-indicator" />
+                  <span className="text-sm font-medium font-ibm-plex-mono">You're editing manually</span>
+                </div>
+                <span className="text-xs text-muted-foreground font-ibm-plex-mono">The AI will continue with your changes when you give back control.</span>
               </div>
               <div className="flex items-center gap-2">
                 <Button
@@ -475,7 +478,7 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
                   className="px-4 py-2.5 rounded text-sm font-medium leading-5 border-0 hover:bg-custom-purple/90 focus:outline-none focus:ring-2 focus:ring-offset-2 bg-custom-purple"
                 >
                   <div className="flex items-center gap-2 text-white">
-                    Hand back control
+                    Give back control
                   </div>
                 </Button>
               </div>
@@ -571,7 +574,7 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
             <div className="flex items-center justify-between py-2 bg-muted/20">
               <div className="flex items-center gap-2 text-sm">
                   <div className="size-2 bg-green-500 rounded-full animate-pulse status-indicator" />
-                <span className="text-xs text-muted-foreground">AGENT MODE</span>
+                <span className="text-xs text-muted-foreground font-ibm-plex-mono">AI is working</span>
               </div>
               <div className="flex items-center gap-2">
                 <Button

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -40,7 +40,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                 className="flex flex-row gap-3 items-center"
               >
                 <div className="absolute left-[27px] top-[25px] text-[18px] font-bold text-black dark:text-white leading-[1.15] not-italic font-source-serif">
-                  <div>Application</div>
+                  <div>Form-Filling</div>
                   <div>Assistant</div>
                 </div>
               </Link>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -13,10 +13,10 @@ const buttonVariants = cva(
         destructive:
           'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+          'border border-input bg-background hover:bg-custom-purple/20 hover:text-custom-purple',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-custom-purple/20 hover:text-custom-purple',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {

--- a/components/ui/collapsible-wrapper.tsx
+++ b/components/ui/collapsible-wrapper.tsx
@@ -44,7 +44,7 @@ export function CollapsibleWrapper({
           
         </div>
         <CollapsibleTrigger asChild>
-          <Button variant="ghost" size="sm" className="p-1 h-auto text-gray-400 hover:text-gray-600 hover:bg-gray-100">
+          <Button variant="ghost" size="sm" className="p-1 h-auto text-gray-400 hover:text-custom-purple hover:bg-custom-purple/20">
             {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
             <span className="sr-only">Toggle details</span>
           </Button>


### PR DESCRIPTION
This pull request updates UI text and styles to improve clarity and user experience, focusing on communicating the AI assistant's role and user control more clearly. The main changes include revised descriptions on the landing page, improved status indicators and control labels in the browser artifact, a more descriptive sidebar title, and consistent button styling.

## Changes

* Updated descriptions on the landing page (`app/(chat)/home/page.tsx`) 
* Changed the sidebar title from "Application Assistant" to "Form-Filling Assistant" in `components/app-sidebar.tsx` for clearer context.
* Enhanced status indicators and control messages in the browser artifact (`artifacts/browser/client.tsx`): clarified manual vs. AI modes, updated button labels, and added explanatory text to reinforce user control.
* Updated button styles in, getting rid of the wrong purple color

## Testing

<img width="2064" height="1184" alt="Screenshot 2025-11-10 at 4 02 21 PM" src="https://github.com/user-attachments/assets/e62a2b79-1f9e-4e1b-9411-bd1a83d314ce" />
<img width="2124" height="696" alt="Screenshot 2025-11-10 at 4 15 36 PM" src="https://github.com/user-attachments/assets/36775962-d318-473e-b1e4-9d04592cf3ee" />
