### PR TITLE
fix: font and size changes with takeover

### DIFF
--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -463,12 +463,12 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
           {/* Fullscreen header with controls */}
           <div className="absolute top-0 left-0 right-0 z-10 browser-fullscreen-bg">
             <div className="flex items-center justify-between px-4 py-3">
-              <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1 text-white">
                 <div className="flex items-center gap-2">
                   <div className="size-2 bg-red-500 rounded-full animate-pulse status-indicator" />
-                  <span className="text-sm font-medium font-ibm-plex-mono text-white">You're editing manually</span>
+                  <span className="text-sm font-medium font-ibm-plex-mono">You're editing manually</span>
                 </div>
-                <span className="text-sm text-[#B5B5B5] font-inter">The AI will continue with your changes when you give back control.</span>
+                <span className="text-sm text-muted-foreground font-inter">The AI will continue with your changes when you give back control.</span>
               </div>
               <div className="flex items-center gap-2">
                 <Button


### PR DESCRIPTION
## Changes

-change the content for takeover back (it was too dark)

<img width="546" height="86" alt="Screenshot 2025-11-13 at 9 27 00 AM" src="https://github.com/user-attachments/assets/14ca42a2-e403-4b7d-b70c-a8b11fb0eb9e" />
