### PR TITLE
fix: Fix stop issue when stop in the UI - stop in the mastra BE

### DIFF
--- a/app/(chat)/api/mastra-proxy/route.ts
+++ b/app/(chat)/api/mastra-proxy/route.ts
@@ -23,6 +23,29 @@ export async function POST(request: Request) {
     // Forward the request body to Mastra backend
     const body = await request.json();
 
+    // Check if the request is to stop the chat
+    if (body.action === 'stopChat') {
+      // Call the Mastra API to stop the chat with threadId and resourceId
+      console.log('Stopping chat for thread:', body.threadId, 'and resource:', body.resourceId);
+      const stopResponse = await fetch(`${mastraServerUrl}/stop-chat`, {
+          method: 'POST',
+          headers: {
+              'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+              threadId: body.threadId,
+              resourceId: body.resourceId,
+          }),
+      });
+
+      console.log('Stop response:', stopResponse);
+
+      return new Response(stopResponse.body, {
+          status: stopResponse.status,
+          headers: stopResponse.headers,
+      });
+  }
+
     const response = await fetch(`${mastraServerUrl}/chat`, {
       method: 'POST',
       headers: {

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -56,7 +56,7 @@ export function Chat({
     setMessages,
     sendMessage,
     status,
-    stop,
+    stop: originalStop,
     regenerate,
     resumeStream,
   } = useChat<ChatMessage>({
@@ -109,6 +109,31 @@ export function Chat({
       }
     },
   });
+
+  // Custom stop function that sends stopChat action for web automation
+  const stop = async () => {
+    // Always call the original stop to abort the stream
+    originalStop();
+
+    // For web automation model, also send stopChat action to backend
+    if (initialChatModel === 'web-automation-model') {
+      try {
+        await fetch('/api/mastra-proxy', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ 
+            action: 'stopChat',
+            threadId: id,
+            resourceId: session.user.id,
+          }),
+        });
+      } catch (error) {
+        console.error('Error sending stopChat action:', error);
+      }
+    }
+  };
 
   const searchParams = useSearchParams();
   const query = searchParams.get('query');


### PR DESCRIPTION
This pull request introduces a new mechanism for stopping chat sessions, specifically enhancing support for the "web automation" chat model. The main changes include adding a custom stop function in the chat component that sends a `stopChat` action to the backend, and updating the API route to handle this new action by forwarding the stop request to the Mastra backend.

## Changes

* Added a custom `stop` function in `components/chat.tsx` that, for the `web-automation-model`, sends a `stopChat` action to the backend with the relevant `threadId` and `resourceId`, in addition to aborting the chat stream locally.
* Updated the destructuring in `components/chat.tsx` to rename the original `stop` function to `originalStop`, allowing for the custom logic to be added.
* Modified `app/(chat)/api/mastra-proxy/route.ts` to handle requests with `action: 'stopChat'`, forwarding them to the Mastra backend's `/stop-chat` endpoint and returning the backend's response.

## Testing
<img width="1073" height="345" alt="Screenshot 2025-11-18 at 9 56 34 AM" src="https://github.com/user-attachments/assets/bc22f193-0de6-4794-aa3d-779973241a4c" />
