### PR TITLE
feat: add .well-known endpoint for Cloudflare bot verification

### DIFF
--- a/app/.well-known/http-message-signatures-directory/route.ts
+++ b/app/.well-known/http-message-signatures-directory/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+// Public key JWK for Cloudflare Verified Bots
+const jwks = {
+  keys: [
+    {
+      crv: 'Ed25519',
+      x: 'agtde4IbRrr3qKVIUkhDz1daflkQ5Krqjf9tJwzxOWc',
+      kty: 'OKP',
+    },
+  ],
+};
+
+export async function GET() {
+  return NextResponse.json(jwks, {
+    headers: {
+      'Content-Type': 'application/http-message-signatures-directory+json',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}


### PR DESCRIPTION
  - Add HTTP Message Signatures directory endpoint for Cloudflare Verified Bots program
  - Serve Ed25519 public key in JWK format at /.well-known/http-message-signatures-directory
  - Required for Pay Per Crawl beta enrollment as Signed Agent