### PR TITLE
fix: remove all remaining dark purples in buttons

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -52,7 +52,7 @@ export default function Page() {
           <button
             onClick={handleMicrosoftLogin}
             disabled={loadingMethod !== null}
-            className="border border-border border-solid box-border content-stretch flex gap-[8px] items-center justify-center min-h-[36px] px-[16px] py-[7.5px] relative rounded-[8px] shrink-0 w-full hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors bg-card"
+            className="border border-border border-solid box-border content-stretch flex gap-[8px] items-center justify-center min-h-[36px] px-[16px] py-[7.5px] relative rounded-[8px] shrink-0 w-full hover:bg-custom-purple/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors bg-card"
           >
             <div className="relative shrink-0 size-[13.25px]">
               <MicrosoftLogo size={13.25} className="block max-w-none size-full" />
@@ -68,7 +68,7 @@ export default function Page() {
           <button
             onClick={handleGoogleLogin}
             disabled={loadingMethod !== null}
-            className="border border-border border-solid box-border content-stretch flex gap-[8px] items-center justify-center min-h-[36px] px-[16px] py-[7.5px] relative rounded-[8px] shrink-0 w-full hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors bg-card"
+            className="border border-border border-solid box-border content-stretch flex gap-[8px] items-center justify-center min-h-[36px] px-[16px] py-[7.5px] relative rounded-[8px] shrink-0 w-full hover:bg-custom-purple/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors bg-card"
           >
             <div className="relative shrink-0 size-[13.25px]">
               <GoogleLogo size={13.25} className="block max-w-none size-full" />

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -630,7 +630,7 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
                   }}
                 >
                   {metadata.controlMode === 'user' && !metadata.isFocused && (
-                    <div className="absolute inset-0 flex items-center justify-center text-white z-10 pointer-events-none bg-[#B1409299]">
+                    <div className="absolute inset-0 flex items-center justify-center text-white z-10 pointer-events-none bg-custom-purple/60">
                       <h2 className="text-4xl font-bold">Click to activate browser control</h2>
                     </div>
                   )}

--- a/components/consent-modal.tsx
+++ b/components/consent-modal.tsx
@@ -32,7 +32,7 @@ export function ConsentModal({ open, onOpenChange, onContinue }: ConsentModalPro
         <AlertDialogFooter className="px-6 pb-6 pt-5 flex-row justify-end gap-2">
           <AlertDialogCancel 
             onClick={() => onOpenChange(false)}
-            className="bg-transparent border-0 text-[#b14092] text-[14px] font-medium px-4 py-2 rounded-[100px] hover:bg-[#b14092]/10 transition-colors"
+            className="bg-transparent border-0 text-custom-purple text-[14px] font-medium px-4 py-2 rounded-[100px] hover:bg-custom-purple/10 transition-colors"
           >
             Cancel
           </AlertDialogCancel>
@@ -41,7 +41,7 @@ export function ConsentModal({ open, onOpenChange, onContinue }: ConsentModalPro
               onOpenChange(false);
               onContinue();
             }}
-            className="bg-transparent border-0 text-[#b14092] text-[14px] font-medium px-4 py-2 rounded-[100px] hover:bg-[#b14092]/10 transition-colors"
+            className="bg-transparent border-0 text-custom-purple text-[14px] font-medium px-4 py-2 rounded-[100px] hover:bg-custom-purple/10 transition-colors"
           >
             Continue
           </AlertDialogAction>

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -385,7 +385,7 @@ function PureStopButton({
   return (
     <Button
       data-testid="stop-button"
-      className="bg-transparent hover:bg-transparent rounded-[100px] px-3 py-1.5 flex items-center gap-1 text-[#b14092] text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      className="bg-transparent hover:bg-transparent rounded-[100px] px-3 py-1.5 flex items-center gap-1 text-custom-purple text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       onClick={(event) => {
         event.preventDefault();
         stop();

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -36,7 +36,7 @@ export function SidebarUserNav({ user }: { user: User }) {
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             {status === 'loading' ? (
-              <SidebarMenuButton className="data-[state=open]:bg-sidebar-accent bg-background data-[state=open]:text-sidebar-accent-foreground h-10 justify-between">
+              <SidebarMenuButton className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-custom-purple h-10 justify-between">
                 <div className="flex flex-row gap-2">
                   <div className="size-6 bg-zinc-500/30 rounded-full animate-pulse" />
                   <span className="bg-zinc-500/30 text-transparent rounded-md animate-pulse">
@@ -50,7 +50,7 @@ export function SidebarUserNav({ user }: { user: User }) {
             ) : (
               <SidebarMenuButton
                 data-testid="user-nav-button"
-                className="data-[state=open]:bg-sidebar-accent bg-background data-[state=open]:text-sidebar-accent-foreground h-10"
+                className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-custom-purple h-10"
               >
                 <Image
                   src={`https://avatar.vercel.sh/${user.email}`}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-custom-purple/20 data-[state=open]:bg-custom-purple/20 data-[highlighted]:bg-custom-purple/20 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-custom-purple data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-custom-purple data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-custom-purple data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-custom-purple data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-custom-purple data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-custom-purple data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-custom-purple/20 focus:text-custom-purple data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-custom-purple data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}


### PR DESCRIPTION
This pull request updates the color scheme across multiple components to use the new `custom-purple` color variable instead of hardcoded or old accent colors. 

## Solves

[ASP-453](https://navalabs.atlassian.net/browse/ASP-453)

## Changes

* Replaced all instances of the old purple accent color (`#b14092`, `bg-accent`, `bg-sidebar-accent`, etc.) with the new `bg-custom-purple` and related variants (e.g., `/20`, `/60`, `/10`) in button, modal, sidebar, and dropdown menu components (`app/(auth)/login/page.tsx`, `components/consent-modal.tsx`, `components/multimodal-input.tsx`, `components/sidebar-user-nav.tsx`). 
* Updated overlay and highlight backgrounds in the browser artifact and UI controls to use `bg-custom-purple` with transparency instead of hardcoded hex values. (`artifacts/browser/client.tsx`)
* Standardized dropdown menu and select component highlight, focus, and open states to use `custom-purple` for backgrounds and text, replacing previous accent colors. (`components/ui/dropdown-menu.tsx`, `components/ui/select.tsx`) 

