### PR TITLE
feat: exit warning modal when leaving the browser

### DIFF
--- a/app/(chat)/home/page.tsx
+++ b/app/(chat)/home/page.tsx
@@ -16,12 +16,12 @@ export default function LandingPage() {
         <div className="relative bg-[#f4e4f0] dark:bg-[#1a0b1a] rounded-[25px] mb-6 sm:mb-8 overflow-hidden">
           <div className="flex flex-col md:flex-row md:items-end md:justify-between md:min-h-[351px]">
             {/* Image Container - On top for mobile, right side for desktop */}
-            <div className="order-1 md:order-2 w-full md:w-auto md:flex-shrink-0">
+            <div className="order-1 md:order-2 w-full md:w-auto md:shrink-0">
               <div className="relative h-[200px] sm:h-[250px] md:h-[337px] w-full md:w-[350px] lg:w-[439px]">
                 <div className="absolute inset-0 mix-blend-normal overflow-hidden pointer-events-none opacity-80 brightness-100 contrast-110 dark:opacity-60 dark:brightness-75 dark:contrast-120">
                   <Image
                     alt=""
-                    className="absolute h-full w-full object-cover top-4 md:top-0 md:left-[-45%] md:w-[136.47%]"
+                    className="absolute size-full object-cover top-4 md:top-0 md:left-[-45%] md:w-[136.47%]"
                     src={imgImage2}
                     fill
                     style={{ objectFit: 'cover' }}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -19,65 +19,94 @@ import {
 } from '@/components/ui/sidebar';
 import Link from 'next/link';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import { useBrowserSessionExit } from '@/hooks/use-browser-session-exit';
+import { ExitWarningModal } from '@/components/exit-warning-modal';
 
 export function AppSidebar({ user }: { user: User | undefined }) {
   const router = useRouter();
   const { setOpenMobile } = useSidebar();
   const { setArtifact } = useArtifact();
+  const {
+    showExitWarning,
+    setShowExitWarning,
+    interceptNavigation,
+    handleConfirmLeave,
+    handleCancelLeave,
+  } = useBrowserSessionExit();
+
+  const handleHomeClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    interceptNavigation(() => {
+      closeArtifact(setArtifact);
+      setOpenMobile(false);
+      router.push('/home');
+    });
+  };
+
+  const handleNewChatClick = () => {
+    interceptNavigation(() => {
+      setOpenMobile(false);
+      closeArtifact(setArtifact);
+      router.push('/');
+      router.refresh();
+    });
+  };
 
   return (
-    <Sidebar className="group-data-[side=left]:border-r-0 w-[265px]">
-      <SidebarHeader className="relative h-[176px] shrink-0 overflow-hidden">
-        <SidebarMenu>
-          <div className="flex flex-row justify-between items-center">
-            <div className="flex flex-row gap-3 items-center">
-              <Link
-                href="/home"
-                onClick={() => {
-                  closeArtifact(setArtifact);
-                  setOpenMobile(false);
-                }}
-                className="flex flex-row gap-3 items-center"
-              >
-                <div className="absolute left-[27px] top-[25px] text-[18px] font-bold text-black dark:text-white leading-[1.15] not-italic font-source-serif">
-                  <div>Form-Filling</div>
-                  <div>Assistant</div>
-                </div>
-              </Link>
+    <>
+      <Sidebar className="group-data-[side=left]:border-r-0 w-[265px]">
+        <SidebarHeader className="relative h-[176px] shrink-0 overflow-hidden">
+          <SidebarMenu>
+            <div className="flex flex-row justify-between items-center">
+              <div className="flex flex-row gap-3 items-center">
+                <Link
+                  href="/home"
+                  onClick={handleHomeClick}
+                  className="flex flex-row gap-3 items-center"
+                >
+                  <div className="absolute left-[27px] top-[25px] text-[18px] font-bold text-black dark:text-white leading-[1.15] not-italic font-source-serif">
+                    <div>Form-Filling</div>
+                    <div>Assistant</div>
+                  </div>
+                </Link>
+              </div>
+              <div className="absolute top-[24px] right-[27px] z-10">
+                <SidebarToggle />
+              </div>
+              {/* New Chat Button */}
+              <div className="absolute left-[27px] top-[117px]">
+                <Button
+                  variant="outline"
+                  className="w-[214px] h-[40px] bg-[#e6e5dc] dark:bg-gray-700 border-none rounded-[6px] px-[16px] py-[8px] flex items-center justify-center gap-[8px] hover:bg-custom-purple/20 dark:hover:bg-custom-purple/30"
+                  onClick={handleNewChatClick}
+                >
+                  <PlusIcon size={16} />
+                  <span className="text-[14px] font-medium text-black dark:text-white leading-[24px] not-italic font-inter">
+                    New chat
+                  </span>
+                </Button>
+              </div>
             </div>
-            <div className="absolute top-[24px] right-[27px] z-10">
-              <SidebarToggle />
-            </div>
-            {/* New Chat Button */}
-            <div className="absolute left-[27px] top-[117px]">
-              <Button
-                variant="outline"
-                className="w-[214px] h-[40px] bg-[#e6e5dc] dark:bg-gray-700 border-none rounded-[6px] px-[16px] py-[8px] flex items-center justify-center gap-[8px] hover:bg-custom-purple/20 dark:hover:bg-custom-purple/30"
-                onClick={() => {
-                  setOpenMobile(false);
-                  closeArtifact(setArtifact);
-                  router.push('/');
-                  router.refresh();
-                }}
-              >
-                <PlusIcon size={16} />
-                <span className="text-[14px] font-medium text-black dark:text-white leading-[24px] not-italic font-inter">New chat</span>
-              </Button>
-            </div>
+          </SidebarMenu>
+        </SidebarHeader>
+
+        <SidebarContent className="relative overflow-y-auto">
+          {/* Chat History */}
+          <div className="px-[27px] pt-4 w-full">
+            <SidebarHistory user={user} />
           </div>
-        </SidebarMenu>
-      </SidebarHeader>
-      
-      <SidebarContent className="relative overflow-y-auto">
-        {/* Chat History */}
-        <div className="px-[27px] pt-4 w-full">
-          <SidebarHistory user={user} />
-        </div>
-      </SidebarContent>
-      
-      <SidebarFooter className="absolute bottom-0 left-[26px] w-[214px]">
-        {user && <SidebarUserNav user={user} />}
-      </SidebarFooter>
-    </Sidebar>
+        </SidebarContent>
+
+        <SidebarFooter className="absolute bottom-0 left-[26px] w-[214px]">
+          {user && <SidebarUserNav user={user} />}
+        </SidebarFooter>
+      </Sidebar>
+
+      <ExitWarningModal
+        open={showExitWarning}
+        onOpenChange={setShowExitWarning}
+        onLeaveSession={handleConfirmLeave}
+      />
+    </>
   );
 }

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -374,7 +374,7 @@ function PureArtifact({
                     artifactStatus={artifact.status}
                   />
                 </div>
-                <div className="border-t border-gray-200 bg-[#EFD9E9] dark:bg-[#1a0b1a] p-3 sm:p-[18px] sm:pb-[18px]">
+                <div className="border-t border-gray-200 bg-[#EFD9E9] dark:bg-[#1a0b1a] p-3 sm:p-[18px]">
                   <form className="flex gap-2 w-full">
                     <MultimodalInput
                       chatId={chatId}

--- a/components/benefit-applications-landing.tsx
+++ b/components/benefit-applications-landing.tsx
@@ -36,7 +36,7 @@ export function BenefitApplicationsLanding({
   setMessages,
 }: BenefitApplicationsLandingProps) {
   return (
-    <div className="flex-1 flex flex-col items-center justify-center p-4 sm:p-6 md:p-8 lg:p-8 pt-16 lg:pt-8 bg-chat-background">
+    <div className="flex-1 flex flex-col items-center justify-center p-4 sm:p-6 md:p-8 lg:p-8 pt-16 bg-chat-background">
       <div className="max-w-4xl w-full text-left px-2 sm:px-4">
         {/* Main Title */}
         <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-[64px] font-source-serif leading-[1.15] text-black dark:text-white mb-6 sm:mb-8 md:mb-12">

--- a/components/exit-warning-modal.tsx
+++ b/components/exit-warning-modal.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface ExitWarningModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onLeaveSession: () => void;
+}
+
+export function ExitWarningModal({
+  open,
+  onOpenChange,
+  onLeaveSession,
+}: ExitWarningModalProps) {
+  const handleCancel = () => {
+    onOpenChange(false);
+  };
+
+  const handleLeaveSession = () => {
+    onOpenChange(false);
+    onLeaveSession();
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-[512px] bg-white rounded-[6px] border border-slate-300 p-6">
+        <AlertDialogHeader className="gap-2">
+          <AlertDialogTitle className="font-serif text-[20px] font-semibold leading-[28px] text-slate-900 text-left">
+            Leave this application session?
+          </AlertDialogTitle>
+          <AlertDialogDescription className="font-sans text-[18px] font-normal leading-[28px] text-black text-left">
+            If you start a new application or open another one, your current
+            session will end.
+            <br />
+            <br />
+            You'll be able to view it, but you won't be able to continue or
+            submit the application.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-row justify-end gap-2 mt-0">
+          <AlertDialogCancel
+            onClick={handleCancel}
+            className="bg-white border border-slate-200 text-slate-900 text-[14px] font-medium leading-[24px] px-4 py-2 rounded-[6px] hover:bg-slate-50 transition-colors"
+          >
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleLeaveSession}
+            className="bg-[#b14092] text-white text-[14px] font-medium leading-[24px] px-4 py-2 rounded-[6px] hover:bg-[#9a3680] transition-colors border-0"
+          >
+            Leave session
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+

--- a/components/exit-warning-modal.tsx
+++ b/components/exit-warning-modal.tsx
@@ -43,7 +43,7 @@ export function ExitWarningModal({
             session will end.
             <br />
             <br />
-            You'll be able to view it, but you won't be able to continue or
+            You&apos;ll be able to view it, but you won&apos;t be able to continue or
             submit the application.
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/components/layout-header.tsx
+++ b/components/layout-header.tsx
@@ -7,11 +7,19 @@ import { useSidebar } from '@/components/ui/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { closeArtifact, useArtifact } from '@/hooks/use-artifact';
 import { SidebarToggle } from '@/components/sidebar-toggle';
+import { useBrowserSessionExit } from '@/hooks/use-browser-session-exit';
+import { ExitWarningModal } from '@/components/exit-warning-modal';
 
 export function LayoutHeader() {
   const { state, openMobile } = useSidebar();
   const router = useRouter();
   const { setArtifact, artifact, metadata } = useArtifact();
+  const {
+    showExitWarning,
+    setShowExitWarning,
+    interceptNavigation,
+    handleConfirmLeave,
+  } = useBrowserSessionExit();
 
   // Don't show the component when sidebar is expanded (desktop) or open (mobile/tablet) or browser artifact is in fullscreen mode
   if (state === 'expanded' || openMobile || (artifact.kind === 'browser' && metadata?.isFullscreen)) {
@@ -19,9 +27,11 @@ export function LayoutHeader() {
   }
 
   const handleNewChat = () => {
-    closeArtifact(setArtifact);
-    router.push('/');
-    router.refresh();
+    interceptNavigation(() => {
+      closeArtifact(setArtifact);
+      router.push('/');
+      router.refresh();
+    });
   };
 
   return (
@@ -50,6 +60,12 @@ export function LayoutHeader() {
           </TooltipContent>
         </Tooltip>
       </div>
+
+      <ExitWarningModal
+        open={showExitWarning}
+        onOpenChange={setShowExitWarning}
+        onLeaveSession={handleConfirmLeave}
+      />
     </>
   );
 }

--- a/components/sidebar-history-item.tsx
+++ b/components/sidebar-history-item.tsx
@@ -26,6 +26,9 @@ import {
 import { memo } from 'react';
 import { useChatVisibility } from '@/hooks/use-chat-visibility';
 import { closeArtifact, useArtifact } from '@/hooks/use-artifact';
+import { useBrowserSessionExit } from '@/hooks/use-browser-session-exit';
+import { useRouter } from 'next/navigation';
+import { ExitWarningModal } from './exit-warning-modal';
 
 const PureChatItem = ({
   chat,
@@ -43,17 +46,31 @@ const PureChatItem = ({
     initialVisibilityType: chat.visibility,
   });
   const { setArtifact } = useArtifact();
+  const router = useRouter();
+  const {
+    showExitWarning,
+    setShowExitWarning,
+    interceptNavigation,
+    handleConfirmLeave,
+  } = useBrowserSessionExit();
+
+  const handleChatClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    interceptNavigation(() => {
+      setOpenMobile(false);
+      closeArtifact(setArtifact);
+      router.push(`/chat/${chat.id}`);
+    });
+  };
 
   return (
-    <SidebarMenuItem>
-      <SidebarMenuButton asChild isActive={isActive}>
-        <Link href={`/chat/${chat.id}`} onClick={() => {
-          setOpenMobile(false);
-          closeArtifact(setArtifact);
-        }}>
-          <span>{chat.title}</span>
-        </Link>
-      </SidebarMenuButton>
+    <>
+      <SidebarMenuItem>
+        <SidebarMenuButton asChild isActive={isActive}>
+          <Link href={`/chat/${chat.id}`} onClick={handleChatClick}>
+            <span>{chat.title}</span>
+          </Link>
+        </SidebarMenuButton>
 
       <DropdownMenu modal={true}>
         <DropdownMenuTrigger asChild>
@@ -114,6 +131,13 @@ const PureChatItem = ({
         </DropdownMenuContent>
       </DropdownMenu>
     </SidebarMenuItem>
+
+      <ExitWarningModal
+        open={showExitWarning}
+        onOpenChange={setShowExitWarning}
+        onLeaveSession={handleConfirmLeave}
+      />
+    </>
   );
 };
 

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -36,7 +36,7 @@ export function SidebarUserNav({ user }: { user: User }) {
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             {status === 'loading' ? (
-              <SidebarMenuButton className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-custom-purple h-10 justify-between">
+              <SidebarMenuButton className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-custom-purple hover:text-[#000] h-10 justify-between">
                 <div className="flex flex-row gap-2">
                   <div className="size-6 bg-zinc-500/30 rounded-full animate-pulse" />
                   <span className="bg-zinc-500/30 text-transparent rounded-md animate-pulse">
@@ -50,7 +50,7 @@ export function SidebarUserNav({ user }: { user: User }) {
             ) : (
               <SidebarMenuButton
                 data-testid="user-nav-button"
-                className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-custom-purple h-10"
+                className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-[#000] hover:text-[#000] h-10"
               >
                 <Image
                   src={`https://avatar.vercel.sh/${user.email}`}
@@ -82,7 +82,7 @@ export function SidebarUserNav({ user }: { user: User }) {
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">
               <button
                 type="button"
-                className="w-full cursor-pointer"
+                className="w-full cursor-pointer hover:text-[#000]"
                 onClick={() => {
                   if (status === 'loading') {
                     toast({

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -36,7 +36,7 @@ export function SidebarUserNav({ user }: { user: User }) {
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             {status === 'loading' ? (
-              <SidebarMenuButton className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-custom-purple hover:text-[#000] h-10 justify-between">
+              <SidebarMenuButton className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-custom-purple hover:text-black h-10 justify-between">
                 <div className="flex flex-row gap-2">
                   <div className="size-6 bg-zinc-500/30 rounded-full animate-pulse" />
                   <span className="bg-zinc-500/30 text-transparent rounded-md animate-pulse">
@@ -50,7 +50,7 @@ export function SidebarUserNav({ user }: { user: User }) {
             ) : (
               <SidebarMenuButton
                 data-testid="user-nav-button"
-                className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-[#000] hover:text-[#000] h-10"
+                className="data-[state=open]:bg-custom-purple/20 bg-background data-[state=open]:text-black hover:text-black h-10"
               >
                 <Image
                   src={`https://avatar.vercel.sh/${user.email}`}
@@ -82,7 +82,7 @@ export function SidebarUserNav({ user }: { user: User }) {
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">
               <button
                 type="button"
-                className="w-full cursor-pointer hover:text-[#000]"
+                className="w-full cursor-pointer hover:text-black"
                 onClick={() => {
                   if (status === 'loading') {
                     toast({

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-custom-purple/20 data-[state=open]:bg-custom-purple/20 data-[highlighted]:bg-custom-purple/20 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-custom-purple/20 focus:text-[#000] data-[state=open]:bg-custom-purple/20 data-[state=open]:text-[#000] data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-[#000] [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-custom-purple data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-custom-purple data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-[#000] data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-[#000] data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-custom-purple data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-custom-purple data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-[#000] data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-[#000] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-custom-purple data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-custom-purple data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-custom-purple/20 focus:text-[#000] data-[highlighted]:bg-custom-purple/20 data-[highlighted]:text-[#000] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/hooks/use-browser-session-exit.ts
+++ b/hooks/use-browser-session-exit.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useArtifact } from './use-artifact';
+
+/**
+ * Hook to manage browser session exit warnings
+ * Returns methods to check if navigation should be intercepted
+ * and to handle the confirmation flow
+ */
+export function useBrowserSessionExit() {
+  const { artifact, metadata } = useArtifact();
+  const [showExitWarning, setShowExitWarning] = useState(false);
+  const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
+
+  /**
+   * Check if there's an active browser session that requires exit warning
+   */
+  const hasActiveBrowserSession = useCallback(() => {
+    return artifact.kind === 'browser' && metadata?.isConnected === true;
+  }, [artifact.kind, metadata?.isConnected]);
+
+  /**
+   * Intercept navigation and show warning if needed
+   * @param action - The navigation action to perform after confirmation
+   * @returns boolean - true if navigation should proceed immediately, false if intercepted
+   */
+  const interceptNavigation = useCallback((action: () => void) => {
+    if (hasActiveBrowserSession()) {
+      setPendingAction(() => action);
+      setShowExitWarning(true);
+      return false;
+    }
+    // No active session, proceed immediately
+    action();
+    return true;
+  }, [hasActiveBrowserSession]);
+
+  /**
+   * Handle user confirming they want to leave the session
+   */
+  const handleConfirmLeave = useCallback(() => {
+    setShowExitWarning(false);
+    if (pendingAction) {
+      pendingAction();
+      setPendingAction(null);
+    }
+  }, [pendingAction]);
+
+  /**
+   * Handle user canceling the exit
+   */
+  const handleCancelLeave = useCallback(() => {
+    setShowExitWarning(false);
+    setPendingAction(null);
+  }, []);
+
+  return {
+    showExitWarning,
+    setShowExitWarning,
+    hasActiveBrowserSession: hasActiveBrowserSession(),
+    interceptNavigation,
+    handleConfirmLeave,
+    handleCancelLeave,
+  };
+}
+

--- a/tests/client/exit-warning-modal.test.tsx
+++ b/tests/client/exit-warning-modal.test.tsx
@@ -1,0 +1,109 @@
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { ExitWarningModal } from '@/components/exit-warning-modal';
+
+test('ExitWarningModal renders with proper content when open', async () => {
+  const mockOnOpenChange = vi.fn();
+  const mockOnLeaveSession = vi.fn();
+  const { getByText } = render(
+    <ExitWarningModal
+      open={true}
+      onOpenChange={mockOnOpenChange}
+      onLeaveSession={mockOnLeaveSession}
+    />
+  );
+
+  await expect
+    .element(getByText('Leave this application session?'))
+    .toBeInTheDocument();
+  await expect
+    .element(
+      getByText(
+        /If you start a new application or open another one, your current session will end/i
+      )
+    )
+    .toBeInTheDocument();
+  await expect
+    .element(
+      getByText(
+        /You'll be able to view it, but you won't be able to continue or submit the application/i
+      )
+    )
+    .toBeInTheDocument();
+  await expect.element(getByText('Cancel')).toBeInTheDocument();
+  await expect.element(getByText('Leave session')).toBeInTheDocument();
+});
+
+test('ExitWarningModal does not render when closed', async () => {
+  const mockOnOpenChange = vi.fn();
+  const mockOnLeaveSession = vi.fn();
+  const { container } = render(
+    <ExitWarningModal
+      open={false}
+      onOpenChange={mockOnOpenChange}
+      onLeaveSession={mockOnLeaveSession}
+    />
+  );
+
+  expect(container.textContent).not.toContain(
+    'Leave this application session?'
+  );
+});
+
+test('ExitWarningModal cancel button calls onOpenChange with false', async () => {
+  const mockOnOpenChange = vi.fn();
+  const mockOnLeaveSession = vi.fn();
+  const { getByRole } = render(
+    <ExitWarningModal
+      open={true}
+      onOpenChange={mockOnOpenChange}
+      onLeaveSession={mockOnLeaveSession}
+    />
+  );
+
+  const cancelButton = getByRole('button', { name: 'Cancel' });
+  await cancelButton.click();
+
+  expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  expect(mockOnLeaveSession).not.toHaveBeenCalled();
+});
+
+test('ExitWarningModal leave session button calls onOpenChange with false and onLeaveSession', async () => {
+  const mockOnOpenChange = vi.fn();
+  const mockOnLeaveSession = vi.fn();
+  const { getByRole } = render(
+    <ExitWarningModal
+      open={true}
+      onOpenChange={mockOnOpenChange}
+      onLeaveSession={mockOnLeaveSession}
+    />
+  );
+
+  const leaveButton = getByRole('button', { name: 'Leave session' });
+  await leaveButton.click();
+
+  expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  expect(mockOnLeaveSession).toHaveBeenCalledTimes(1);
+});
+
+test('ExitWarningModal has proper accessibility attributes', async () => {
+  const mockOnOpenChange = vi.fn();
+  const mockOnLeaveSession = vi.fn();
+  const { getByRole } = render(
+    <ExitWarningModal
+      open={true}
+      onOpenChange={mockOnOpenChange}
+      onLeaveSession={mockOnLeaveSession}
+    />
+  );
+
+  const dialog = getByRole('alertdialog');
+  await expect.element(dialog).toBeInTheDocument();
+
+  const cancelButton = getByRole('button', { name: 'Cancel' });
+  const leaveButton = getByRole('button', { name: 'Leave session' });
+
+  await expect.element(cancelButton).toBeInTheDocument();
+  await expect.element(leaveButton).toBeInTheDocument();
+});
+

--- a/tests/client/use-browser-session-exit.test.tsx
+++ b/tests/client/use-browser-session-exit.test.tsx
@@ -1,0 +1,227 @@
+import { expect, test, vi } from 'vitest';
+import { renderHook } from 'vitest-browser-react';
+import { useBrowserSessionExit } from '@/hooks/use-browser-session-exit';
+import * as useArtifactModule from '@/hooks/use-artifact';
+
+// Mock the useArtifact hook
+vi.mock('@/hooks/use-artifact', () => ({
+  useArtifact: vi.fn(),
+}));
+
+test('useBrowserSessionExit detects active browser session', () => {
+  // Mock an active browser session
+  vi.mocked(useArtifactModule.useArtifact).mockReturnValue({
+    artifact: {
+      documentId: 'test-123',
+      content: '',
+      kind: 'browser',
+      title: 'Browser',
+      status: 'idle',
+      isVisible: true,
+      boundingBox: { top: 0, left: 0, width: 0, height: 0 },
+    },
+    metadata: {
+      sessionId: 'browser-session-123',
+      isConnected: true,
+      isConnecting: false,
+      controlMode: 'agent',
+      isFocused: false,
+      isFullscreen: false,
+    },
+    setArtifact: vi.fn(),
+    setMetadata: vi.fn(),
+  });
+
+  const { result } = renderHook(() => useBrowserSessionExit());
+
+  expect(result.current.hasActiveBrowserSession).toBe(true);
+  expect(result.current.showExitWarning).toBe(false);
+});
+
+test('useBrowserSessionExit does not detect session when not browser artifact', () => {
+  // Mock a non-browser artifact
+  vi.mocked(useArtifactModule.useArtifact).mockReturnValue({
+    artifact: {
+      documentId: 'test-123',
+      content: '',
+      kind: 'text',
+      title: 'Text',
+      status: 'idle',
+      isVisible: true,
+      boundingBox: { top: 0, left: 0, width: 0, height: 0 },
+    },
+    metadata: null,
+    setArtifact: vi.fn(),
+    setMetadata: vi.fn(),
+  });
+
+  const { result } = renderHook(() => useBrowserSessionExit());
+
+  expect(result.current.hasActiveBrowserSession).toBe(false);
+});
+
+test('useBrowserSessionExit does not detect session when browser not connected', () => {
+  // Mock a browser artifact that is not connected
+  vi.mocked(useArtifactModule.useArtifact).mockReturnValue({
+    artifact: {
+      documentId: 'test-123',
+      content: '',
+      kind: 'browser',
+      title: 'Browser',
+      status: 'idle',
+      isVisible: true,
+      boundingBox: { top: 0, left: 0, width: 0, height: 0 },
+    },
+    metadata: {
+      sessionId: 'browser-session-123',
+      isConnected: false,
+      isConnecting: false,
+      controlMode: 'agent',
+      isFocused: false,
+      isFullscreen: false,
+    },
+    setArtifact: vi.fn(),
+    setMetadata: vi.fn(),
+  });
+
+  const { result } = renderHook(() => useBrowserSessionExit());
+
+  expect(result.current.hasActiveBrowserSession).toBe(false);
+});
+
+test('useBrowserSessionExit intercepts navigation when active session exists', async () => {
+  // Mock an active browser session
+  vi.mocked(useArtifactModule.useArtifact).mockReturnValue({
+    artifact: {
+      documentId: 'test-123',
+      content: '',
+      kind: 'browser',
+      title: 'Browser',
+      status: 'idle',
+      isVisible: true,
+      boundingBox: { top: 0, left: 0, width: 0, height: 0 },
+    },
+    metadata: {
+      sessionId: 'browser-session-123',
+      isConnected: true,
+      isConnecting: false,
+      controlMode: 'agent',
+      isFocused: false,
+      isFullscreen: false,
+    },
+    setArtifact: vi.fn(),
+    setMetadata: vi.fn(),
+  });
+
+  const { result } = renderHook(() => useBrowserSessionExit());
+
+  const mockAction = vi.fn();
+  
+  await result.current.interceptNavigation(mockAction);
+
+  expect(mockAction).not.toHaveBeenCalled();
+});
+
+test('useBrowserSessionExit allows navigation when no active session', () => {
+  // Mock no active browser session
+  vi.mocked(useArtifactModule.useArtifact).mockReturnValue({
+    artifact: {
+      documentId: 'test-123',
+      content: '',
+      kind: 'text',
+      title: 'Text',
+      status: 'idle',
+      isVisible: true,
+      boundingBox: { top: 0, left: 0, width: 0, height: 0 },
+    },
+    metadata: null,
+    setArtifact: vi.fn(),
+    setMetadata: vi.fn(),
+  });
+
+  const { result } = renderHook(() => useBrowserSessionExit());
+
+  const mockAction = vi.fn();
+  const wasIntercepted = result.current.interceptNavigation(mockAction);
+
+  expect(wasIntercepted).toBe(true);
+  expect(result.current.showExitWarning).toBe(false);
+  expect(mockAction).toHaveBeenCalledTimes(1);
+});
+
+test('useBrowserSessionExit executes pending action on confirm', async () => {
+  // Mock an active browser session
+  vi.mocked(useArtifactModule.useArtifact).mockReturnValue({
+    artifact: {
+      documentId: 'test-123',
+      content: '',
+      kind: 'browser',
+      title: 'Browser',
+      status: 'idle',
+      isVisible: true,
+      boundingBox: { top: 0, left: 0, width: 0, height: 0 },
+    },
+    metadata: {
+      sessionId: 'browser-session-123',
+      isConnected: true,
+      isConnecting: false,
+      controlMode: 'agent',
+      isFocused: false,
+      isFullscreen: false,
+    },
+    setArtifact: vi.fn(),
+    setMetadata: vi.fn(),
+  });
+
+  const { result, rerender } = renderHook(() => useBrowserSessionExit());
+
+  const mockAction = vi.fn();
+  
+  // Intercept navigation
+  result.current.interceptNavigation(mockAction);
+  rerender();
+  
+  // Confirm leave
+  result.current.handleConfirmLeave();
+  rerender();
+  
+  expect(mockAction).toHaveBeenCalledTimes(1);
+});
+
+test('useBrowserSessionExit cancels pending action on cancel', async () => {
+  // Mock an active browser session
+  vi.mocked(useArtifactModule.useArtifact).mockReturnValue({
+    artifact: {
+      documentId: 'test-123',
+      content: '',
+      kind: 'browser',
+      title: 'Browser',
+      status: 'idle',
+      isVisible: true,
+      boundingBox: { top: 0, left: 0, width: 0, height: 0 },
+    },
+    metadata: {
+      sessionId: 'browser-session-123',
+      isConnected: true,
+      isConnecting: false,
+      controlMode: 'agent',
+      isFocused: false,
+      isFullscreen: false,
+    },
+    setArtifact: vi.fn(),
+    setMetadata: vi.fn(),
+  });
+
+  const { result } = renderHook(() => useBrowserSessionExit());
+
+  const mockAction = vi.fn();
+  
+  // Intercept navigation
+  await result.current.interceptNavigation(mockAction);
+  
+  // Cancel leave
+  await result.current.handleCancelLeave();
+  
+  expect(mockAction).not.toHaveBeenCalled();
+});
+


### PR DESCRIPTION
## Changes

* Added a new `ExitWarningModal` component that prompts users to confirm before leaving an active browser session, explaining the consequences of ending the session. (`components/exit-warning-modal.tsx`)
* Implemented the `useBrowserSessionExit` hook to detect active browser sessions, intercept navigation actions, and manage the modal confirmation flow. (`hooks/use-browser-session-exit.ts`)
<img width="640" height="363" alt="Screenshot 2025-12-01 at 3 03 23 PM" src="https://github.com/user-attachments/assets/fafbe84b-2990-4d1b-a176-8c8ea487452b" />

* Updated navigation actions in `AppSidebar`, `LayoutHeader`, and `SidebarHistoryItem` to use the exit warning flow, ensuring users see the modal when attempting to leave an active session.

## Ticket

[ASP-477](https://navalabs.atlassian.net/browse/ASP-477)


## Testing

* Added two new test files
* User testing
* [Screen studio link](https://screen.studio/share/dXtxCLxC)

<img width="1059" height="414" alt="Screenshot 2025-12-01 at 3 15 52 PM" src="https://github.com/user-attachments/assets/37b03206-b737-422a-96cf-3b9bf82690c6" />
<img width="637" height="487" alt="Screenshot 2025-12-01 at 3 16 49 PM" src="https://github.com/user-attachments/assets/dc0b90cb-d52f-4b3d-867f-3049bc142f49" />


## Notes

This pull request introduces a browser session exit warning feature to improve user experience when navigating away from an active browser-based application session. The main changes include a new modal component for exit warnings, a custom hook to manage session exit logic, integration of the warning flow into sidebar, header, and chat navigation actions, and comprehensive tests for the modal component.
