### PR TITLE
feat: add HTTP message signature to key directory for Cloudflare veri…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,7 @@ REDIS_URL=****
 AUTH_MICROSOFT_ENTRA_ID_ID=***
 AUTH_MICROSOFT_ENTRA_ID_SECRET=***
 AUTH_MICROSOFT_ENTRA_ID_ISSUER=https://login.microsoftonline.com/common/v2.0
+
+# Cloudflare Verified Bots - Ed25519 private key in PEM format
+# Used to sign the /.well-known/http-message-signatures-directory response
+CLOUDFLARE_BOT_PRIVATE_KEY=****

--- a/app/.well-known/http-message-signatures-directory/route.ts
+++ b/app/.well-known/http-message-signatures-directory/route.ts
@@ -1,21 +1,106 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import nodeCrypto from 'crypto';
+import { directoryResponseHeaders, helpers, MediaType } from 'web-bot-auth';
+import { signerFromJWK } from 'web-bot-auth/crypto';
 
-// Public key JWK for Cloudflare Verified Bots
-const jwks = {
-  keys: [
-    {
-      crv: 'Ed25519',
-      x: 'agtde4IbRrr3qKVIUkhDz1daflkQ5Krqjf9tJwzxOWc',
-      kty: 'OKP',
-    },
-  ],
-};
-
-export async function GET() {
-  return NextResponse.json(jwks, {
-    headers: {
-      'Content-Type': 'application/http-message-signatures-directory+json',
-      'Cache-Control': 'public, max-age=3600',
-    },
+// Convert PEM private key to JWK format
+function pemToJwk(pem: string): JsonWebKey {
+  const privateKey = nodeCrypto.createPrivateKey({
+    key: pem,
+    format: 'pem',
   });
+
+  return privateKey.export({ format: 'jwk' }) as JsonWebKey;
+}
+
+// Get the public JWK from a private JWK
+function getPublicJwk(privateJwk: JsonWebKey): JsonWebKey {
+  // For Ed25519, the public key is just the x parameter (without d)
+  const { d: _d, ...publicJwk } = privateJwk;
+  return publicJwk;
+}
+
+// Calculate JWK thumbprint using the helpers from web-bot-auth
+async function calculateKeyId(jwk: JsonWebKey): Promise<string> {
+  // JWK thumbprint per RFC 7638 - hash the canonical JSON of required members
+  const requiredMembers =
+    jwk.kty === 'OKP'
+      ? { crv: jwk.crv, kty: jwk.kty, x: jwk.x }
+      : { crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y };
+
+  const json = JSON.stringify(requiredMembers);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(json);
+
+  const hash = await helpers.WEBCRYPTO_SHA256(data);
+  return helpers.BASE64URL_DECODE(hash);
+}
+
+export async function GET(request: NextRequest) {
+  const privateKeyPem = process.env.CLOUDFLARE_BOT_PRIVATE_KEY;
+
+  if (!privateKeyPem) {
+    console.error('CLOUDFLARE_BOT_PRIVATE_KEY environment variable not set');
+    return NextResponse.json(
+      { error: 'Server configuration error' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    // Convert PEM to JWK
+    const privateJwk = pemToJwk(privateKeyPem);
+    const publicJwk = getPublicJwk(privateJwk);
+
+    // Calculate the JWK thumbprint for kid
+    const keyId = await calculateKeyId(publicJwk);
+
+    // Build the JWKS with kid included
+    const jwks = {
+      keys: [
+        {
+          ...publicJwk,
+          kid: keyId,
+        },
+      ],
+    };
+
+    // Create a signer from the private key JWK
+    const signer = await signerFromJWK(privateJwk);
+
+    // Create a request-like object for signing
+    // The @authority component is derived from the request URL
+    const requestLike = {
+      method: request.method,
+      url: request.url,
+      headers: Object.fromEntries(request.headers.entries()),
+    };
+
+    // Generate signature headers
+    const now = new Date();
+    const signatureHeaders = await directoryResponseHeaders(
+      requestLike,
+      [signer],
+      {
+        created: now,
+        expires: new Date(now.getTime() + 5 * 60 * 1000), // 5 minutes
+      }
+    );
+
+    // Return the signed response
+    return new NextResponse(JSON.stringify(jwks), {
+      headers: {
+        'Content-Type': MediaType.HTTP_MESSAGE_SIGNATURES_DIRECTORY,
+        'Cache-Control': 'public, max-age=60',
+        Signature: signatureHeaders.Signature,
+        'Signature-Input': signatureHeaders['Signature-Input'],
+      },
+    });
+  } catch (error) {
+    console.error('Error generating signed directory response:', error);
+    return NextResponse.json(
+      { error: 'Failed to generate signed response' },
+      { status: 500 }
+    );
+  }
 }

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^3.1.0",
     "vitest-browser-react": "^1.0.1",
+    "web-bot-auth": "^0.1.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       vitest-browser-react:
         specifier: ^1.0.1
         version: 1.0.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(@vitest/browser@3.2.4)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vitest@3.2.4)
+      web-bot-auth:
+        specifier: ^0.1.1
+        version: 0.1.1
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -3950,6 +3953,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-message-sig@0.1.0:
+    resolution: {integrity: sha512-F3ZRFxqgmo7RhftIr0mMi3yPJfqs7U0VHRlfq45pSbxHEXnh35c2BQoMSPp9Wxy4b5L8OvCNgUlb/pzdNeLM3Q==}
+
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -4203,6 +4209,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonwebkey-thumbprint@0.1.0:
+    resolution: {integrity: sha512-4m/gJEUQH8N2NfvZFjCL8/E+vlt0FlrmHoR4T93CEXQRkC64qwRi6oQri4/eqLVXqEqXYCss0+Q7pLx6vJBqzw==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -5831,6 +5840,9 @@ packages:
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  web-bot-auth@0.1.1:
+    resolution: {integrity: sha512-luRXoRAzeZXU7XnYIvQfxy13Xk5Pw4VdlGn2tXzL3qHBVj+KvJL50nsQzA/VgqaRTvDXWwTIdEKsnjlEYkMlkw==}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -9526,6 +9538,8 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-message-sig@0.1.0: {}
+
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -9775,6 +9789,8 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonwebkey-thumbprint@0.1.0: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -11827,6 +11843,11 @@ snapshots:
   vscode-uri@3.0.8: {}
 
   w3c-keyname@2.2.8: {}
+
+  web-bot-auth@0.1.1:
+    dependencies:
+      http-message-sig: 0.1.0
+      jsonwebkey-thumbprint: 0.1.0
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
  - Sign the /.well-known/http-message-signatures-directory response with Ed25519 per RFC 9421 to satisfy Cloudflare's bot verification requirements
  - Add Signature and Signature-Input headers using the web-bot-auth package from Cloudflare
  - Requires CLOUDFLARE_BOT_PRIVATE_KEY environment variable (already in GCloud secrets as cloudflare-bot-private-key)