### PR TITLE
fix: show 'Executed JavaScript' tool calls in message UI

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -324,7 +324,7 @@ const PurePreviewMessage = ({
                   const { input } = part as any;
                   const { text: displayName, icon: Icon } = getToolDisplayInfo(type, input);
 
-                  if (displayName === 'Updated working memory' || displayName === 'Executed JavaScript') {
+                  if (displayName === 'Updated working memory') {
                     return;
                   }
                   // Only use CollapsibleWrapper for get-participant-with-household
@@ -351,7 +351,7 @@ const PurePreviewMessage = ({
                   const { output, input } = part as any;
                   const { text: displayName, icon: Icon } = getToolDisplayInfo(type, input);
 
-                  if (displayName === 'Updated working memory'|| displayName === 'Executed JavaScript') {
+                  if (displayName === 'Updated working memory') {
                     return;
                   }
 


### PR DESCRIPTION
Reverts part of PR #79 that hid 'Executed JavaScript' tool calls. These should be visible to users to understand what the AI is doing.