### PR TITLE
fix: remove javascript notification

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -324,7 +324,7 @@ const PurePreviewMessage = ({
                   const { input } = part as any;
                   const { text: displayName, icon: Icon } = getToolDisplayInfo(type, input);
 
-                  if (displayName === 'Updated working memory') {
+                  if (displayName === 'Updated working memory' || displayName === 'Executed JavaScript') {
                     return;
                   }
                   // Only use CollapsibleWrapper for get-participant-with-household
@@ -351,7 +351,7 @@ const PurePreviewMessage = ({
                   const { output, input } = part as any;
                   const { text: displayName, icon: Icon } = getToolDisplayInfo(type, input);
 
-                  if (displayName === 'Updated working memory') {
+                  if (displayName === 'Updated working memory' || displayName === 'Executed JavaScript') {
                     return;
                   }
 


### PR DESCRIPTION
This pull request introduces a minor change to the `PurePreviewMessage` component in `components/message.tsx`. The update ensures that messages with the display name 'Executed JavaScript' are now excluded from rendering, in addition to those with 'Updated working memory'.

* Exclude messages with display name 'Executed JavaScript' from rendering in the `PurePreviewMessage` component. [[1]](diffhunk://#diff-119f563915750907b6691f79e59a4486ae1d7e2dc99b18d0b6c425da66dc0a78L327-R327) [[2]](diffhunk://#diff-119f563915750907b6691f79e59a4486ae1d7e2dc99b18d0b6c425da66dc0a78L354-R354)