### PR TITLE
fix: browser session isolation - prevent cross-session visibility

### DIFF
--- a/app/api/browser-stream-proxy/route.ts
+++ b/app/api/browser-stream-proxy/route.ts
@@ -6,7 +6,20 @@ export const runtime = 'nodejs';
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const sessionId = url.searchParams.get('sessionId') || 'default';
+  const sessionId = url.searchParams.get('sessionId');
+
+  // Require sessionId to prevent session collision
+  if (!sessionId) {
+    return new Response(
+      JSON.stringify({
+        error: 'Missing required sessionId query parameter'
+      }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+  }
 
   // Get browser streaming configuration from environment (runtime)
   const streamingPort = process.env.BROWSER_STREAMING_PORT || '8933';

--- a/app/api/browser-stream/route.ts
+++ b/app/api/browser-stream/route.ts
@@ -4,7 +4,17 @@ export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const sessionId = searchParams.get('sessionId') || 'default';
+  const sessionId = searchParams.get('sessionId');
+
+  // Require sessionId to prevent session collision
+  if (!sessionId) {
+    return new Response(JSON.stringify({
+      error: 'Missing required sessionId query parameter'
+    }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
   
   try {
     // Return WebSocket connection info for the browser streaming service

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -30,6 +30,7 @@ import equal from 'fast-deep-equal';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { VisibilityType } from './visibility-selector';
 import type { Attachment, ChatMessage } from '@/lib/types';
+import { useSession } from 'next-auth/react';
 
 export const artifactDefinitions = [
   textArtifact,
@@ -88,6 +89,7 @@ function PureArtifact({
   initialChatModel: string;
 }) {
   const { artifact, setArtifact, metadata, setMetadata } = useArtifact();
+  const { data: session } = useSession();
 
   const {
     data: documents,
@@ -262,10 +264,15 @@ function PureArtifact({
         artifactDefinition.initialize({
           documentId: artifact.documentId,
           setMetadata,
+          // Pass chat context for session isolation (used by browser artifact)
+          chatContext: {
+            chatId,
+            resourceId: session?.user?.id,
+          },
         });
       }
     }
-  }, [artifact.documentId, artifactDefinition, setMetadata]);
+  }, [artifact.documentId, artifactDefinition, setMetadata, chatId, session?.user?.id]);
 
   return (
     <AnimatePresence>

--- a/components/create-artifact.tsx
+++ b/components/create-artifact.tsx
@@ -54,9 +54,18 @@ interface ArtifactContent<M = any> {
   stop?: () => void;
 }
 
+export interface ChatContext {
+  /** The chat/thread ID */
+  chatId: string;
+  /** The user/resource ID for session isolation */
+  resourceId?: string;
+}
+
 interface InitializeParameters<M = any> {
   documentId: string;
   setMetadata: Dispatch<SetStateAction<M>>;
+  /** Optional chat context for session isolation (e.g., browser streaming) */
+  chatContext?: ChatContext;
 }
 
 type ArtifactConfig<T extends string, M = any> = {

--- a/components/side-chat-header.tsx
+++ b/components/side-chat-header.tsx
@@ -61,10 +61,6 @@ function PureSideChatHeader({
           sessionStartTime,
           new Date(),
           { addSuffix: true }
-        )}` : artifactKind === 'browser' && metadata?.sessionId ? `Session started ${formatDistance(
-          new Date(parseInt(metadata.sessionId.split('-').pop() || '0')),
-          new Date(),
-          { addSuffix: true }
         )}` : 'Session started'}
       </p>
     </div>


### PR DESCRIPTION
## Summary
- Fixed browser session isolation bug where users could see each other's browser sessions
- Root cause: Browser streaming service assigned CDP targets by discovery order instead of session identity
- Added `ChatContext` interface to pass `threadId`/`resourceId` to browser artifacts
- Browser artifact now uses same session ID format as Mastra backend (`${chatId}-${resourceId}`)
- Removed all 'default' sessionId fallbacks (returns 400 error instead)

## Test plan
1. Open Chat A, navigate to google.com
2. Open Chat B (different tab/user), navigate to github.com
3. Verify Chat A's browser artifact shows Google
4. Verify Chat B's browser artifact shows GitHub
5. Refresh Chat A - should still show Google, not GitHub
6. Stop Chat A's stream, verify Chat B unaffected
7. Test with 3+ concurrent sessions