### PR TITLE
fix: disable cacheComponents to allow runtime env vars in API routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
+  // cacheComponents disabled to allow runtime env vars in API routes
+  // See: https://github.com/vercel/next.js/discussions/84894
+  cacheComponents: false,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

- Disables `cacheComponents` in Next.js config to fix WebSocket browser streaming

## Problem

The `/api/browser-ws-config` endpoint was returning `{"proxyUrl": null}` even though `BROWSER_WS_PROXY_URL` was correctly set on the Cloud Run service. This caused the browser streaming WebSocket to fall back to `ws://localhost:8933` which doesn't exist in production.

**Root cause**: Next.js 16's `cacheComponents: true` prevents runtime access to environment variables in API routes - they get cached at build time when the env var doesn't exist.

## Solution

Set `cacheComponents: false` to allow API routes to read environment variables at runtime.

Ref: https://github.com/vercel/next.js/discussions/84894

## Testing

- Build succeeds locally
- Verified `BROWSER_WS_PROXY_URL` env var is set on Cloud Run service for PR-132
- Confirmed endpoint currently returns null: `curl https://ai-chatbot-preview-pr-132-qeyqwqsw7a-uc.a.run.app/api/browser-ws-config` → `{"proxyUrl":null}`