### PR TITLE
feat: shared link API for external chat pre-population

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,9 +44,10 @@ MASTRA_SERVER_URL=http://localhost:4111
 # For Docker deployment: http://localhost:4111 (external port mapping)
 NEXT_PUBLIC_MASTRA_SERVER_URL=http://localhost:4111
 
-# Instructions to create a Redis store here:
-# https://vercel.com/docs/redis
-REDIS_URL=****
+# Upstash Redis for shared links
+# Create a Redis database at https://console.upstash.com/
+UPSTASH_REDIS_REST_URL=****
+UPSTASH_REDIS_REST_TOKEN=****
 
 # Microsoft login
 AUTH_MICROSOFT_ENTRA_ID_ID=***

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -7,12 +7,7 @@ import { DataStreamHandler } from '@/components/data-stream-handler';
 import { auth } from '../(auth)/auth';
 import { redirect } from 'next/navigation';
 
-export default async function Page({
-  searchParams,
-}: {
-  searchParams: Promise<{ query?: string }>;
-}) {
-  const { query } = await searchParams;
+export default async function Page() {
   const session = await auth();
 
   if (!session) {
@@ -27,20 +22,12 @@ export default async function Page({
   const sharedLinkCookie = cookieStore.get('shared_link_content');
   const initialQuery = sharedLinkCookie?.value || undefined;
 
-  // Check if this is the first load of the app (no referrer or referrer doesn't indicate internal navigation)
+  // Check if this is the first load of the app (no referrer)
+  // If no referrer and no shared link cookie, redirect to home
   const headersList = await headers();
   const referer = headersList.get('referer');
 
-  // If no referrer or referrer doesn't contain internal routes, this is likely the first load - redirect to home
-  // Exception: if there's a ?query= param or shared link cookie, skip the redirect
-  const isInternalNavigation = referer && (
-    referer.includes('/home') ||
-    referer.includes('/chat/') ||
-    referer.includes('/link/') ||
-    referer.includes('/')
-  );
-
-  if (!isInternalNavigation && !query && !initialQuery) {
+  if (!referer && !initialQuery) {
     redirect('/home');
   }
 

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -7,7 +7,12 @@ import { DataStreamHandler } from '@/components/data-stream-handler';
 import { auth } from '../(auth)/auth';
 import { redirect } from 'next/navigation';
 
-export default async function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ query?: string }>;
+}) {
+  const { query } = await searchParams;
   const session = await auth();
 
   if (!session) {
@@ -23,13 +28,14 @@ export default async function Page() {
   const referer = headersList.get('referer');
   
   // If no referrer or referrer doesn't contain internal routes, this is likely the first load - redirect to home
+  // Exception: if there's a ?query= param (from shared links), skip the redirect
   const isInternalNavigation = referer && (
-    referer.includes('/home') || 
-    referer.includes('/chat/') || 
+    referer.includes('/home') ||
+    referer.includes('/chat/') ||
     referer.includes('/')
   );
-  
-  if (!isInternalNavigation) {
+
+  if (!isInternalNavigation && !query) {
     redirect('/home');
   }
 

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -22,20 +22,25 @@ export default async function Page({
   const cookieStore = await cookies();
   const id = generateUUID();
   const modelIdFromCookie = cookieStore.get('chat-model');
-  
+
+  // Check for shared link content from cookie (set by /link/[token] route)
+  const sharedLinkCookie = cookieStore.get('shared_link_content');
+  const initialQuery = sharedLinkCookie?.value || undefined;
+
   // Check if this is the first load of the app (no referrer or referrer doesn't indicate internal navigation)
   const headersList = await headers();
   const referer = headersList.get('referer');
-  
+
   // If no referrer or referrer doesn't contain internal routes, this is likely the first load - redirect to home
-  // Exception: if there's a ?query= param (from shared links), skip the redirect
+  // Exception: if there's a ?query= param or shared link cookie, skip the redirect
   const isInternalNavigation = referer && (
     referer.includes('/home') ||
     referer.includes('/chat/') ||
+    referer.includes('/link/') ||
     referer.includes('/')
   );
 
-  if (!isInternalNavigation && !query) {
+  if (!isInternalNavigation && !query && !initialQuery) {
     redirect('/home');
   }
 
@@ -51,6 +56,7 @@ export default async function Page({
           isReadonly={false}
           session={session}
           autoResume={false}
+          initialQuery={initialQuery}
         />
         <DataStreamHandler />
       </>
@@ -68,6 +74,7 @@ export default async function Page({
         isReadonly={false}
         session={session}
         autoResume={false}
+        initialQuery={initialQuery}
       />
       <DataStreamHandler />
     </>

--- a/app/api/link/route.ts
+++ b/app/api/link/route.ts
@@ -1,0 +1,43 @@
+import { SignJWT } from 'jose';
+import { createLinkRequestSchema, type CreateLinkResponse } from './schema';
+
+const SECRET = new TextEncoder().encode(process.env.AUTH_SECRET);
+
+export async function POST(request: Request) {
+  try {
+    // Parse and validate request body
+    let requestBody;
+    try {
+      const json = await request.json();
+      requestBody = createLinkRequestSchema.parse(json);
+    } catch {
+      return Response.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const { content, expiresInHours } = requestBody;
+
+    // Create signed JWT with content and expiration
+    const expiresAt = new Date(Date.now() + expiresInHours * 60 * 60 * 1000);
+    const token = await new SignJWT({ content })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime(expiresAt)
+      .setIssuedAt()
+      .sign(SECRET);
+
+    // Build the redirect URL
+    const baseUrl =
+      process.env.NEXTAUTH_URL || request.headers.get('origin') || '';
+    const url = `${baseUrl}/link/${token}`;
+
+    const response: CreateLinkResponse = {
+      url,
+      token,
+      expiresAt: expiresAt.toISOString(),
+    };
+
+    return Response.json(response, { status: 201 });
+  } catch (error) {
+    console.error('Unexpected error in link creation:', error);
+    return Response.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/link/route.ts
+++ b/app/api/link/route.ts
@@ -48,7 +48,9 @@ export async function POST(request: Request) {
     await redis.set(`link:${id}`, encrypted, { ex: ttlSeconds });
 
     // Build the redirect URL
-    const baseUrl = process.env.NEXTAUTH_URL || request.headers.get('origin') || '';
+    // Priority: NEXTAUTH_URL > origin header > x-forwarded-host (Cloud Run)
+    const forwardedHost = request.headers.get('x-forwarded-host');
+    const baseUrl = process.env.NEXTAUTH_URL || request.headers.get('origin') || (forwardedHost ? `https://${forwardedHost}` : '');
     const url = `${baseUrl}/link/${id}`;
     const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
 

--- a/app/api/link/schema.ts
+++ b/app/api/link/schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+// POST /api/link - Create a new shared link
+export const createLinkRequestSchema = z.object({
+  content: z
+    .string()
+    .min(1, 'Content is required')
+    .max(10000, 'Content must be less than 10000 characters'),
+  expiresInHours: z
+    .number()
+    .min(1, 'Expiration must be at least 1 hour')
+    .max(24, 'Expiration cannot exceed 24 hours')
+    .optional()
+    .default(24),
+});
+
+export type CreateLinkRequest = z.infer<typeof createLinkRequestSchema>;
+
+export const createLinkResponseSchema = z.object({
+  url: z.string().url(),
+  token: z.string(),
+  expiresAt: z.string().datetime(),
+});
+
+export type CreateLinkResponse = z.infer<typeof createLinkResponseSchema>;

--- a/app/link/[token]/route.ts
+++ b/app/link/[token]/route.ts
@@ -19,18 +19,25 @@ function decrypt(encryptedData: string): string {
   return decipher.update(encrypted) + decipher.final('utf8');
 }
 
+// Get the base URL for redirects (Cloud Run uses x-forwarded-host)
+function getBaseUrl(request: Request): string {
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  return process.env.NEXTAUTH_URL || (forwardedHost ? `https://${forwardedHost}` : request.url);
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
+  const baseUrl = getBaseUrl(request);
 
   try {
     // Get encrypted content from Redis
     const encrypted = await redis.get<string>(`link:${token}`);
 
     if (!encrypted) {
-      return NextResponse.redirect(new URL('/?error=link_expired', request.url));
+      return NextResponse.redirect(new URL('/?error=link_expired', baseUrl));
     }
 
     // Decrypt content
@@ -38,7 +45,7 @@ export async function GET(
 
     // Set cookie with content and redirect to /
     // Cookie is HttpOnly, secure, and expires in 60 seconds (just enough for redirect)
-    const response = NextResponse.redirect(new URL('/', request.url));
+    const response = NextResponse.redirect(new URL('/', baseUrl));
     response.cookies.set('shared_link_content', content, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
@@ -50,6 +57,6 @@ export async function GET(
     return response;
   } catch (error) {
     console.error('Link retrieval failed:', error);
-    return NextResponse.redirect(new URL('/?error=link_invalid', request.url));
+    return NextResponse.redirect(new URL('/?error=link_invalid', baseUrl));
   }
 }

--- a/app/link/[token]/route.ts
+++ b/app/link/[token]/route.ts
@@ -1,0 +1,28 @@
+import { redirect } from 'next/navigation';
+import { jwtVerify } from 'jose';
+
+const SECRET = new TextEncoder().encode(process.env.AUTH_SECRET);
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+
+  try {
+    // Verify and decode the JWT
+    const { payload } = await jwtVerify(token, SECRET);
+    const content = payload.content as string;
+
+    if (!content) {
+      redirect('/?error=link_invalid');
+    }
+
+    // Redirect to chat with the content pre-populated
+    redirect(`/?query=${encodeURIComponent(content)}`);
+  } catch (error) {
+    // JWT verification failed (expired, invalid signature, etc.)
+    console.error('Link verification failed:', error);
+    redirect('/?error=link_expired');
+  }
+}

--- a/app/link/[token]/route.ts
+++ b/app/link/[token]/route.ts
@@ -39,6 +39,10 @@ export async function GET(
     // Redirect to chat with the content pre-populated
     redirect(`/?query=${encodeURIComponent(content)}`);
   } catch (error) {
+    // Re-throw Next.js redirect errors
+    if (error instanceof Error && error.message.includes('NEXT_REDIRECT')) {
+      throw error;
+    }
     console.error('Link retrieval failed:', error);
     redirect('/?error=link_invalid');
   }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -15,7 +15,6 @@ import { unstable_serialize } from 'swr/infinite';
 import { getChatHistoryPaginationKey } from './sidebar-history';
 import { toast } from './toast';
 import type { Session } from 'next-auth';
-import { useSearchParams } from 'next/navigation';
 import { useChatVisibility } from '@/hooks/use-chat-visibility';
 import { useAutoResume } from '@/hooks/use-auto-resume';
 import { ChatSDKError } from '@/lib/errors';
@@ -137,30 +136,23 @@ export function Chat({
     }
   };
 
-  const searchParams = useSearchParams();
-  const queryFromUrl = searchParams.get('query');
-  // Use initialQuery prop (from cookie) or fall back to URL query param
-  const query = initialQuery || queryFromUrl;
-
   const [hasAppendedQuery, setHasAppendedQuery] = useState(false);
 
   useEffect(() => {
-    if (query && !hasAppendedQuery) {
+    if (initialQuery && !hasAppendedQuery) {
       sendMessage({
         role: 'user' as const,
-        parts: [{ type: 'text', text: query }],
+        parts: [{ type: 'text', text: initialQuery }],
       });
 
       setHasAppendedQuery(true);
 
-      // Clear the shared link cookie if it was used
-      if (initialQuery) {
-        document.cookie = 'shared_link_content=; path=/; max-age=0';
-      }
+      // Clear the shared link cookie
+      document.cookie = 'shared_link_content=; path=/; max-age=0';
 
       window.history.replaceState({}, '', `/chat/${id}`);
     }
-  }, [query, sendMessage, hasAppendedQuery, id, initialQuery]);
+  }, [initialQuery, sendMessage, hasAppendedQuery, id]);
 
   const { data: votes } = useSWR<Array<Vote>>(
     messages.length >= 2 ? `/api/vote?chatId=${id}` : null,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@radix-ui/react-tooltip": "^1.1.3",
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "@types/pg": "^8.15.5",
+    "@upstash/redis": "^1.36.0",
     "@vercel/analytics": "^1.3.1",
     "@vercel/blob": "^0.24.1",
     "@vercel/functions": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@types/pg':
         specifier: ^8.15.5
         version: 8.15.5
+      '@upstash/redis':
+        specifier: ^1.36.0
+        version: 1.36.0
       '@vercel/analytics':
         specifier: ^1.3.1
         version: 1.5.0(next@16.0.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.51.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(react@19.0.1)
@@ -2592,6 +2595,9 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@upstash/redis@1.36.0':
+    resolution: {integrity: sha512-9zN2UV9QJGPnXfWU3yZBLVQaqqENDh7g+Y4J2vJuSxBCi9FQ0aUOtaXlzuFhnsiZvCqM+eS27ic+tgmkWUsfOg==}
 
   '@vercel/analytics@1.5.0':
     resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
@@ -5645,6 +5651,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
@@ -7936,6 +7945,10 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upstash/redis@1.36.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vercel/analytics@1.5.0(next@16.0.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.51.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(react@19.0.1)':
     optionalDependencies:
@@ -11638,6 +11651,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.20.0: {}
 


### PR DESCRIPTION
## Summary
- Add POST `/api/link` endpoint that accepts content and returns a signed redirect URL
- Add GET `/link/[token]` route that verifies JWT and redirects to `/?query={content}`
- Uses existing `AUTH_SECRET` for signing, no database changes required