### PR TITLE
chore: update DATABASE_URL example for local postgres container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,13 @@ GOOGLE_CLIENT_SECRET=****
 # xAI API Key for chat and image models: https://console.x.ai/
 XAI_API_KEY=****
 
-# GCP Cloud SQL PostgreSQL database - used by both client and Mastra
+# PostgreSQL database - used by both client and Mastra
 # Client: Chat history, votes, documents, user data
 # Mastra: Agent memory, workflows, traces, participants data
-DATABASE_URL=****
+# For local development with Docker postgres container:
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/labs_asp_dev"
+# For Docker-to-Docker communication (used inside containers):
+# DATABASE_URL="postgresql://postgres:postgres@postgres:5432/labs_asp_dev"
 
 # OpenAI API Key (primary AI provider)
 OPENAI_API_KEY=****


### PR DESCRIPTION
## Summary
- Updates `.env.example` to show the local Docker postgres container connection string
- Adds comments explaining localhost vs container-to-container URLs