### PR TITLE
feat: add in a captcha alert to take over the browser

### DIFF
--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -586,9 +586,9 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
       window.addEventListener('switch-browser-control', handleSwitchControl as EventListener);
       
       return () => {
-    }, []);
+        window.removeEventListener('switch-browser-control', handleSwitchControl as EventListener);
       };
-    }, [metadata?.sessionId, wsRef.current]);
+    }, [switchControlMode]);
 
     useEffect(() => {
       return () => {

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -574,6 +574,22 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
     }, [metadata?.isFullscreen, metadata?.controlMode]);
 
     // Cleanup on unmount - only disconnect stream, don't kill Chrome
+    // Listen for control mode switch events from confirmation components
+    useEffect(() => {
+      const handleSwitchControl = (event: CustomEvent) => {
+        const { mode } = event.detail;
+        if (mode === 'user' || mode === 'agent') {
+          switchControlMode(mode);
+        }
+      };
+
+      window.addEventListener('switch-browser-control', handleSwitchControl as EventListener);
+      
+      return () => {
+        window.removeEventListener('switch-browser-control', handleSwitchControl as EventListener);
+      };
+    }, [metadata?.sessionId, wsRef.current]);
+
     useEffect(() => {
       return () => {
         if (wsRef.current) {

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -586,7 +586,7 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
       window.addEventListener('switch-browser-control', handleSwitchControl as EventListener);
       
       return () => {
-        window.removeEventListener('switch-browser-control', handleSwitchControl as EventListener);
+    }, []);
       };
     }, [metadata?.sessionId, wsRef.current]);
 

--- a/components/ai-elements/confirmation.tsx
+++ b/components/ai-elements/confirmation.tsx
@@ -5,12 +5,12 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
-interface ApprovalState {
+export interface ApprovalState {
   id: string;
   approved?: boolean;
 }
 
-type ConfirmationState = 'approval-requested' | 'approval-responded' | 'output-denied' | 'output-available';
+export type ConfirmationState = 'approval-requested' | 'approval-responded' | 'output-denied' | 'output-available';
 
 type ConfirmationContextType = {
   approval?: ApprovalState;

--- a/components/ai-elements/confirmation.tsx
+++ b/components/ai-elements/confirmation.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import * as React from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface ApprovalState {
+  id: string;
+  approved?: boolean;
+}
+
+type ConfirmationState = 'approval-requested' | 'approval-responded' | 'output-denied' | 'output-available';
+
+type ConfirmationContextType = {
+  approval?: ApprovalState;
+  state?: ConfirmationState;
+};
+
+const ConfirmationContext = React.createContext<ConfirmationContextType | undefined>(undefined);
+
+const useConfirmationContext = () => {
+  const context = React.useContext(ConfirmationContext);
+  if (!context) {
+    throw new Error('Confirmation components must be used within <Confirmation>');
+  }
+  return context;
+};
+
+interface ConfirmationProps extends React.ComponentProps<typeof Alert> {
+  approval?: ApprovalState;
+  state?: ConfirmationState;
+  children: React.ReactNode;
+}
+
+export function Confirmation({ approval, state, className, children, ...props }: ConfirmationProps) {
+  return (
+    <ConfirmationContext.Provider value={{ approval, state }}>
+      <Alert
+        className={cn(
+          'bg-[rgba(245,228,240,0.25)] border-[#f5e4f0] dark:bg-[rgba(245,228,240,0.1)]',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </Alert>
+    </ConfirmationContext.Provider>
+  );
+}
+
+interface ConfirmationRequestProps {
+  children: React.ReactNode;
+}
+
+export function ConfirmationRequest({ children }: ConfirmationRequestProps) {
+  const { state } = useConfirmationContext();
+  
+  if (state !== 'approval-requested') {
+    return null;
+  }
+
+  return <AlertDescription className="mb-4">{children}</AlertDescription>;
+}
+
+interface ConfirmationAcceptedProps {
+  children: React.ReactNode;
+}
+
+export function ConfirmationAccepted({ children }: ConfirmationAcceptedProps) {
+  const { approval, state } = useConfirmationContext();
+  
+  if (!approval?.approved || (state !== 'approval-responded' && state !== 'output-available')) {
+    return null;
+  }
+
+  return (
+    <AlertDescription className="flex items-center gap-2 text-green-600 dark:text-green-400">
+      {children}
+    </AlertDescription>
+  );
+}
+
+interface ConfirmationRejectedProps {
+  children: React.ReactNode;
+}
+
+export function ConfirmationRejected({ children }: ConfirmationRejectedProps) {
+  const { approval, state } = useConfirmationContext();
+  
+  if (approval?.approved !== false || state !== 'output-denied') {
+    return null;
+  }
+
+  return (
+    <AlertDescription className="flex items-center gap-2 text-red-600 dark:text-red-400">
+      {children}
+    </AlertDescription>
+  );
+}
+
+interface ConfirmationActionsProps extends React.ComponentProps<'div'> {
+  children: React.ReactNode;
+}
+
+export function ConfirmationActions({ className, children, ...props }: ConfirmationActionsProps) {
+  const { state } = useConfirmationContext();
+  
+  if (state !== 'approval-requested') {
+    return null;
+  }
+
+  return (
+    <div className={cn('flex gap-2 mt-4', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+interface ConfirmationActionProps extends React.ComponentProps<typeof Button> {}
+
+export function ConfirmationAction({ className, variant = 'default', ...props }: ConfirmationActionProps) {
+  return (
+    <Button
+      className={cn(
+        variant === 'default' && 'bg-[#a11e83] hover:bg-[#a11e83]/90 text-white',
+        className
+      )}
+      variant={variant}
+      {...props}
+    />
+  );
+}

--- a/components/ai-elements/index.ts
+++ b/components/ai-elements/index.ts
@@ -1,0 +1,10 @@
+export {
+  Confirmation,
+  ConfirmationRequest,
+  ConfirmationAccepted,
+  ConfirmationRejected,
+  ConfirmationActions,
+  ConfirmationAction,
+} from './confirmation';
+
+export { UserActionConfirmation } from './user-action-confirmation';

--- a/components/ai-elements/user-action-confirmation.tsx
+++ b/components/ai-elements/user-action-confirmation.tsx
@@ -8,16 +8,13 @@ import {
   ConfirmationRejected,
   ConfirmationActions,
   ConfirmationAction,
+  ConfirmationState,
+  ApprovalState,
 } from './confirmation';
-
-interface ApprovalState {
-  id: string;
-  approved: boolean | undefined;
-}
 
 interface UserActionConfirmationProps {
   approval?: ApprovalState;
-  state?: 'approval-requested' | 'approval-responded' | 'output-denied';
+  state?: ConfirmationState;
   requestTitle?: string;
   requestMessage: string;
   acceptedMessage?: string;
@@ -37,7 +34,7 @@ export function UserActionConfirmation({
   onReject,
 }: UserActionConfirmationProps) {
   return (
-    <Confirmation approval={approval} state={state as any}>
+    <Confirmation approval={approval} state={state}>
       <ConfirmationRequest>
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-px">

--- a/components/ai-elements/user-action-confirmation.tsx
+++ b/components/ai-elements/user-action-confirmation.tsx
@@ -38,7 +38,7 @@ export function UserActionConfirmation({
       <ConfirmationRequest>
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-px">
-            <div className="font-serif font-normal leading-[1.5] text-[14px] text-[#171717]">
+            <div className="font-source-serif font-normal leading-[1.5] text-[14px] text-[#171717]">
               <p className="font-bold mb-[14px]">{requestTitle}</p>
               <p>{requestMessage}</p>
             </div>
@@ -57,23 +57,25 @@ export function UserActionConfirmation({
       </ConfirmationRejected>
 
       <ConfirmationActions>
+        <ConfirmationAction
+          variant="default"
+          onClick={() => approval?.id && onApprove(approval.id)}
+        >
+          <MousePointerClick className="w-[13.25px] h-[13.25px] mr-1" />
+          <span className="font-inter font-medium text-[14px] leading-[1.5] tracking-[0.07px]">
+            Take control
+          </span>
+        </ConfirmationAction>
         {onReject && (
           <ConfirmationAction
             variant="outline"
             onClick={() => approval?.id && onReject(approval.id)}
           >
-            Reject
+          <span className="font-inter font-medium text-[14px] leading-[1.5] tracking-[0.07px]">
+              Skip for now 
+          </span>
           </ConfirmationAction>
         )}
-        <ConfirmationAction
-          variant="default"
-          onClick={() => approval?.id && onApprove(approval.id)}
-        >
-          <MousePointerClick className="w-[13.25px] h-[13.25px] mr-2" />
-          <span className="font-inter font-medium text-[14px] leading-[1.5] tracking-[0.07px]">
-            Take control
-          </span>
-        </ConfirmationAction>
       </ConfirmationActions>
     </Confirmation>
   );

--- a/components/ai-elements/user-action-confirmation.tsx
+++ b/components/ai-elements/user-action-confirmation.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { MousePointerClick, CheckIcon, XIcon } from 'lucide-react';
+import {
+  Confirmation,
+  ConfirmationRequest,
+  ConfirmationAccepted,
+  ConfirmationRejected,
+  ConfirmationActions,
+  ConfirmationAction,
+} from './confirmation';
+
+interface ApprovalState {
+  id: string;
+  approved: boolean | undefined;
+}
+
+interface UserActionConfirmationProps {
+  approval?: ApprovalState;
+  state?: 'approval-requested' | 'approval-responded' | 'output-denied';
+  requestTitle?: string;
+  requestMessage: string;
+  acceptedMessage?: string;
+  rejectedMessage?: string;
+  onApprove: (approvalId: string) => void;
+  onReject?: (approvalId: string) => void;
+}
+
+export function UserActionConfirmation({
+  approval,
+  state = 'approval-requested',
+  requestTitle = 'Action required',
+  requestMessage,
+  acceptedMessage = 'You approved this action',
+  rejectedMessage = 'You rejected this action',
+  onApprove,
+  onReject,
+}: UserActionConfirmationProps) {
+  return (
+    <Confirmation approval={approval} state={state as any}>
+      <ConfirmationRequest>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-px">
+            <div className="font-serif font-normal leading-[1.5] text-[14px] text-[#171717]">
+              <p className="font-bold mb-[14px]">{requestTitle}</p>
+              <p>{requestMessage}</p>
+            </div>
+          </div>
+        </div>
+      </ConfirmationRequest>
+
+      <ConfirmationAccepted>
+        <CheckIcon className="w-4 h-4" />
+        <span>{acceptedMessage}</span>
+      </ConfirmationAccepted>
+
+      <ConfirmationRejected>
+        <XIcon className="w-4 h-4" />
+        <span>{rejectedMessage}</span>
+      </ConfirmationRejected>
+
+      <ConfirmationActions>
+        {onReject && (
+          <ConfirmationAction
+            variant="outline"
+            onClick={() => approval?.id && onReject(approval.id)}
+          >
+            Reject
+          </ConfirmationAction>
+        )}
+        <ConfirmationAction
+          variant="default"
+          onClick={() => approval?.id && onApprove(approval.id)}
+        >
+          <MousePointerClick className="w-[13.25px] h-[13.25px] mr-2" />
+          <span className="font-inter font-medium text-[14px] leading-[1.5] tracking-[0.07px]">
+            Take control
+          </span>
+        </ConfirmationAction>
+      </ConfirmationActions>
+    </Confirmation>
+  );
+}

--- a/components/artifact-messages.tsx
+++ b/components/artifact-messages.tsx
@@ -59,6 +59,7 @@ function PureArtifactMessages({
           setMessages={setMessages}
           regenerate={regenerate}
           isReadonly={isReadonly}
+          isArtifactVisible={true}
           requiresScrollPadding={
             hasSentMessage && index === messages.length - 1
           }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -154,10 +154,11 @@ export function Chat({
     }
   }, [initialQuery, sendMessage, hasAppendedQuery, id]);
 
-  const { data: votes } = useSWR<Array<Vote>>(
-    messages.length >= 2 ? `/api/vote?chatId=${id}` : null,
-    fetcher,
-  );
+  // const { data: votes } = useSWR<Array<Vote>>(
+  //   messages.length >= 2 ? `/api/vote?chatId=${id}` : null,
+  //   fetcher,
+  // );
+  const votes = undefined;
 
   const [attachments, setAttachments] = useState<Array<Attachment>>([]);
   const isArtifactVisible = useArtifactSelector((state) => state.isVisible);
@@ -256,8 +257,12 @@ export function Chat({
     // If we have new messages and the last message is from user, reset dismissed state
     if (messages.length > 0) {
       const lastMessage = messages[messages.length - 1];
-      if (lastMessage.role === 'user' && browserArtifactDismissed) {
-        setBrowserArtifactDismissed(false);
+      if (lastMessage.role === 'user') {
+        if (browserArtifactDismissed) {
+          setBrowserArtifactDismissed(false);
+        }
+        // Dispatch event to dismiss any UserActionConfirmation components
+        window.dispatchEvent(new CustomEvent('new-user-message'));
       }
     }
   }, [messages, browserArtifactDismissed]);

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -209,7 +209,7 @@ const PurePreviewMessage = ({
                       {message.role === 'assistant' && requiresUserAction && !isReadonly && (
                         <UserActionConfirmation
                           approval={{ id: `action-${message.id}`, approved: undefined }}
-                          state={'approval-requested' as any}
+                          state="approval-requested"
                           requestMessage={
                             textContent.includes('captcha')
                               ? 'Complete the CAPTCHA and submit the application.'

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -65,6 +65,7 @@ const PurePreviewMessage = ({
   setMessages,
   regenerate,
   isReadonly,
+  isArtifactVisible,
   requiresScrollPadding,
 }: {
   chatId: string;
@@ -74,6 +75,7 @@ const PurePreviewMessage = ({
   setMessages: UseChatHelpers<ChatMessage>['setMessages'];
   regenerate: UseChatHelpers<ChatMessage>['regenerate'];
   isReadonly: boolean;
+  isArtifactVisible: boolean;
   requiresScrollPadding: boolean;
 }) => {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
@@ -219,7 +221,7 @@ const PurePreviewMessage = ({
                         </div>
                       </div>
                       
-                      {message.role === 'assistant' && requiresUserAction && !isReadonly && !isLoading && !dismissedActionConfirmations.has(message.id) && (
+                      {message.role === 'assistant' && requiresUserAction && !isReadonly && !isLoading && !dismissedActionConfirmations.has(message.id) && isArtifactVisible && (
                         <UserActionConfirmation
                           approval={{ id: `action-${message.id}`, approved: undefined }}
                           state="approval-requested"
@@ -235,10 +237,10 @@ const PurePreviewMessage = ({
                             });
                             window.dispatchEvent(event);
                           }}
-                          onReject={(approvalId) => {
-                            // Dismiss the confirmation by adding message.id to the dismissed set
-                            setDismissedActionConfirmations((prev) => new Set([...prev, message.id]));
-                          }}
+                          // onReject={(approvalId) => {
+                          //   // Dismiss the confirmation by adding message.id to the dismissed set
+                          //   setDismissedActionConfirmations((prev) => new Set([...prev, message.id]));
+                          // }}
                         />
                       )}
                     </div>
@@ -518,6 +520,7 @@ export const PreviewMessage = memo(
     if (prevProps.message.id !== nextProps.message.id) return false;
     if (prevProps.requiresScrollPadding !== nextProps.requiresScrollPadding)
       return false;
+    if (prevProps.isArtifactVisible !== nextProps.isArtifactVisible) return false;
     if (!equal(prevProps.message.parts, nextProps.message.parts)) return false;
     if (!equal(prevProps.vote, nextProps.vote)) return false;
 

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -28,6 +28,7 @@ import { ChevronDown } from 'lucide-react';
 import { CollapsibleWrapper } from './ui/collapsible-wrapper';
 import { getToolDisplayInfo } from './tool-icon';
 import { Spinner } from './ui/spinner';
+import { UserActionConfirmation } from './ai-elements';
 
 // Responsive min-height calculation that accounts for side-chat-header height
 // This ensures the last message has enough space to scroll properly with the header
@@ -162,37 +163,67 @@ const PurePreviewMessage = ({
                     );
                   }
 
-                  return (
-                    <div key={key} className="flex flex-row gap-2 items-start">
-                      {/* {message.role === 'user' && !isReadonly && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              data-testid="message-edit-button"
-                              variant="ghost"
-                              className="px-2 h-fit rounded-full text-muted-foreground opacity-0 group-hover/message:opacity-100"
-                              onClick={() => {
-                                setMode('edit');
-                              }}
-                            >
-                              <PencilEditIcon />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>Edit message</TooltipContent>
-                        </Tooltip>
-                      )} */}
+                  const textContent = part.text.toLowerCase();
+                  const requiresUserAction = 
+                    textContent.includes('captcha') ||
+                    textContent.includes('action required') ||
+                    textContent.includes('take control') ||
+                    textContent.includes('user intervention') ||
+                    textContent.includes('missing information') ||
+                    textContent.includes('complete the application');
 
-                      <div
-                        data-testid="message-content"
-                        className={cn('flex flex-col gap-4', {
-                          'bg-[#EFD9E9] dark:bg-slate-800 text-black dark:text-slate-100 px-[18px] py-[18px] rounded-xl text-xs leading-[18px] font-inter':
-                            message.role === 'user',
-                          'assistant-message-bubble font-source-serif':
-                            message.role === 'assistant',
-                        })}
-                      >
-                        <Markdown>{sanitizeText(part.text)}</Markdown>
+                  return (
+                    <div key={key} className="flex flex-col gap-3">
+                      <div className="flex flex-row gap-2 items-start">
+                        {/* {message.role === 'user' && !isReadonly && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                data-testid="message-edit-button"
+                                variant="ghost"
+                                className="px-2 h-fit rounded-full text-muted-foreground opacity-0 group-hover/message:opacity-100"
+                                onClick={() => {
+                                  setMode('edit');
+                                }}
+                              >
+                                <PencilEditIcon />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Edit message</TooltipContent>
+                          </Tooltip>
+                        )} */}
+
+                        <div
+                          data-testid="message-content"
+                          className={cn('flex flex-col gap-4', {
+                            'bg-[#EFD9E9] dark:bg-slate-800 text-black dark:text-slate-100 px-[18px] py-[18px] rounded-xl text-xs leading-[18px] font-inter':
+                              message.role === 'user',
+                            'assistant-message-bubble font-source-serif':
+                              message.role === 'assistant',
+                          })}
+                        >
+                          <Markdown>{sanitizeText(part.text)}</Markdown>
+                        </div>
                       </div>
+                      
+                      {message.role === 'assistant' && requiresUserAction && !isReadonly && (
+                        <UserActionConfirmation
+                          approval={{ id: `action-${message.id}`, approved: undefined }}
+                          state={'approval-requested' as any}
+                          requestMessage={
+                            textContent.includes('captcha')
+                              ? 'Complete the CAPTCHA and submit the application.'
+                              : 'Manual action required to proceed.'
+                          }
+                          onApprove={(approvalId) => {
+                            // Trigger browser control switch to user mode
+                            const event = new CustomEvent('switch-browser-control', { 
+                              detail: { mode: 'user' } 
+                            });
+                            window.dispatchEvent(event);
+                          }}
+                        />
+                      )}
                     </div>
                   );
                 }

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -28,6 +28,7 @@ function PureMessages({
   setMessages,
   regenerate,
   isReadonly,
+  isArtifactVisible,
 }: MessagesProps) {
   const {
     containerRef: messagesContainerRef,
@@ -64,6 +65,7 @@ function PureMessages({
           setMessages={setMessages}
           regenerate={regenerate}
           isReadonly={isReadonly}
+          isArtifactVisible={isArtifactVisible}
           requiresScrollPadding={
             hasSentMessage && index === messages.length - 1
           }

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = 'Alert';
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm [&_p]:leading-relaxed', className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertTitle, AlertDescription };

--- a/tests/client/user-action-confirmation.test.tsx
+++ b/tests/client/user-action-confirmation.test.tsx
@@ -8,7 +8,7 @@ test('UserActionConfirmation renders with proper content in approval-requested s
   const { getByText } = render(
     <UserActionConfirmation
       approval={{ id: 'test-1', approved: undefined }}
-      state={'approval-requested' as any}
+      state="approval-requested"
       requestMessage="Complete the CAPTCHA and submit the application."
       onApprove={mockOnApprove}
       onReject={mockOnReject}
@@ -27,7 +27,7 @@ test('UserActionConfirmation calls onApprove when Take control button is clicked
   const { getByRole } = render(
     <UserActionConfirmation
       approval={{ id: 'test-2', approved: undefined }}
-      state={'approval-requested' as any}
+      state="approval-requested"
       requestMessage="Complete the CAPTCHA and submit the application."
       onApprove={mockOnApprove}
       onReject={mockOnReject}
@@ -47,7 +47,7 @@ test('UserActionConfirmation calls onReject when Reject button is clicked', asyn
   const { getByRole } = render(
     <UserActionConfirmation
       approval={{ id: 'test-3', approved: undefined }}
-      state={'approval-requested' as any}
+      state="approval-requested"
       requestMessage="Complete the CAPTCHA and submit the application."
       onApprove={mockOnApprove}
       onReject={mockOnReject}
@@ -67,7 +67,7 @@ test('UserActionConfirmation supports custom messages', async () => {
   const { getByText } = render(
     <UserActionConfirmation
       approval={{ id: 'test-4', approved: undefined }}
-      state={'approval-requested' as any}
+      state="approval-requested"
       requestTitle="Custom Title"
       requestMessage="Custom action required message."
       onApprove={mockOnApprove}
@@ -84,7 +84,7 @@ test('UserActionConfirmation does not show Reject button when onReject is not pr
   const { getByRole, getByText } = render(
     <UserActionConfirmation
       approval={{ id: 'test-5', approved: undefined }}
-      state={'approval-requested' as any}
+      state="approval-requested"
       requestMessage="Complete the CAPTCHA and submit the application."
       onApprove={mockOnApprove}
     />
@@ -104,7 +104,7 @@ test('UserActionConfirmation shows Reject button when onReject is provided', asy
   const { getByRole } = render(
     <UserActionConfirmation
       approval={{ id: 'test-6', approved: undefined }}
-      state={'approval-requested' as any}
+      state="approval-requested"
       requestMessage="Complete the CAPTCHA and submit the application."
       onApprove={mockOnApprove}
       onReject={mockOnReject}

--- a/tests/client/user-action-confirmation.test.tsx
+++ b/tests/client/user-action-confirmation.test.tsx
@@ -1,0 +1,119 @@
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { UserActionConfirmation } from '@/components/ai-elements/user-action-confirmation';
+
+test('UserActionConfirmation renders with proper content in approval-requested state', async () => {
+  const mockOnApprove = vi.fn();
+  const mockOnReject = vi.fn();
+  const { getByText } = render(
+    <UserActionConfirmation
+      approval={{ id: 'test-1', approved: undefined }}
+      state={'approval-requested' as any}
+      requestMessage="Complete the CAPTCHA and submit the application."
+      onApprove={mockOnApprove}
+      onReject={mockOnReject}
+    />
+  );
+
+  await expect.element(getByText('Action required')).toBeInTheDocument();
+  await expect.element(getByText('Complete the CAPTCHA and submit the application.')).toBeInTheDocument();
+  await expect.element(getByText('Take control')).toBeInTheDocument();
+  await expect.element(getByText('Reject')).toBeInTheDocument();
+});
+
+test('UserActionConfirmation calls onApprove when Take control button is clicked', async () => {
+  const mockOnApprove = vi.fn();
+  const mockOnReject = vi.fn();
+  const { getByRole } = render(
+    <UserActionConfirmation
+      approval={{ id: 'test-2', approved: undefined }}
+      state={'approval-requested' as any}
+      requestMessage="Complete the CAPTCHA and submit the application."
+      onApprove={mockOnApprove}
+      onReject={mockOnReject}
+    />
+  );
+
+  const approveButton = getByRole('button', { name: /take control/i });
+  await approveButton.click();
+
+  expect(mockOnApprove).toHaveBeenCalledTimes(1);
+  expect(mockOnApprove).toHaveBeenCalledWith('test-2');
+});
+
+test('UserActionConfirmation calls onReject when Reject button is clicked', async () => {
+  const mockOnApprove = vi.fn();
+  const mockOnReject = vi.fn();
+  const { getByRole } = render(
+    <UserActionConfirmation
+      approval={{ id: 'test-3', approved: undefined }}
+      state={'approval-requested' as any}
+      requestMessage="Complete the CAPTCHA and submit the application."
+      onApprove={mockOnApprove}
+      onReject={mockOnReject}
+    />
+  );
+
+  const rejectButton = getByRole('button', { name: /reject/i });
+  await rejectButton.click();
+
+  expect(mockOnReject).toHaveBeenCalledTimes(1);
+  expect(mockOnReject).toHaveBeenCalledWith('test-3');
+});
+
+test('UserActionConfirmation supports custom messages', async () => {
+  const mockOnApprove = vi.fn();
+  const mockOnReject = vi.fn();
+  const { getByText } = render(
+    <UserActionConfirmation
+      approval={{ id: 'test-4', approved: undefined }}
+      state={'approval-requested' as any}
+      requestTitle="Custom Title"
+      requestMessage="Custom action required message."
+      onApprove={mockOnApprove}
+      onReject={mockOnReject}
+    />
+  );
+
+  await expect.element(getByText('Custom Title')).toBeInTheDocument();
+  await expect.element(getByText('Custom action required message.')).toBeInTheDocument();
+});
+
+test('UserActionConfirmation does not show Reject button when onReject is not provided', async () => {
+  const mockOnApprove = vi.fn();
+  const { getByRole, getByText } = render(
+    <UserActionConfirmation
+      approval={{ id: 'test-5', approved: undefined }}
+      state={'approval-requested' as any}
+      requestMessage="Complete the CAPTCHA and submit the application."
+      onApprove={mockOnApprove}
+    />
+  );
+
+  // Verify Take control button is present
+  const approveButton = getByRole('button', { name: /take control/i });
+  await expect.element(approveButton).toBeInTheDocument();
+  
+  // Verify Reject text is not present (since button shouldn't exist)
+  expect(() => getByText('Reject')).toThrow();
+});
+
+test('UserActionConfirmation shows Reject button when onReject is provided', async () => {
+  const mockOnApprove = vi.fn();
+  const mockOnReject = vi.fn();
+  const { getByRole } = render(
+    <UserActionConfirmation
+      approval={{ id: 'test-6', approved: undefined }}
+      state={'approval-requested' as any}
+      requestMessage="Complete the CAPTCHA and submit the application."
+      onApprove={mockOnApprove}
+      onReject={mockOnReject}
+    />
+  );
+
+  const rejectButton = getByRole('button', { name: /reject/i });
+  await expect.element(rejectButton).toBeInTheDocument();
+  
+  const approveButton = getByRole('button', { name: /take control/i });
+  await expect.element(approveButton).toBeInTheDocument();
+});


### PR DESCRIPTION
This pull request introduces a modular confirmation component system for user action approvals, integrates it into the message rendering flow to prompt manual user intervention when required (e.g., CAPTCHA, missing info), and adds comprehensive tests for the new UI logic. It also establishes an event-based mechanism for switching browser control modes in response to user actions.

## Changes

* Added a suite of reusable confirmation components (`Confirmation`, `ConfirmationRequest`, `ConfirmationAccepted`, `ConfirmationRejected`, `ConfirmationActions`, `ConfirmationAction`) in `components/ai-elements/confirmation.tsx`, enabling flexible UI for approval workflows.
* Created a specialized `UserActionConfirmation` component that utilizes the confirmation primitives to prompt users for manual actions, such as taking control or rejecting an action, with customizable messages and callbacks.
* Updated `components/message.tsx` to detect when assistant messages require user intervention (e.g., CAPTCHA, "action required") and display the `UserActionConfirmation` UI, including logic to dispatch a browser control switch event when the user approves.
* Added a `useEffect` in `artifacts/browser/client.tsx` to listen for `switch-browser-control` events and switch control mode accordingly.
* Implemented a generic `Alert` component (needed for the Confirmation Component)

## Testing

* Added thorough tests for the `UserActionConfirmation` component, covering rendering, button actions, custom messages, and conditional UI logic.
* [Screen Studio](https://screen.studio/share/DhFJtL9Y)