### PR TITLE
fix: prompt changes for apricot data

### DIFF
--- a/components/suggested-actions.tsx
+++ b/components/suggested-actions.tsx
@@ -20,24 +20,24 @@ function PureSuggestedActions({
 }: SuggestedActionsProps) {
   const suggestedActions = [
     {
-      title: 'Help Rosa Flores',
+      title: 'Help Elodi Thomas apply for WIC',
       label: 'ruhealth.org/appointments/apply-4-wic-form',
-      action: 'Help Rosa Flores, date of birth 1988-07-13 apply for WIC at https://www.ruhealth.org/appointments/apply-4-wic-form#. She is pregnant and has a child.',
+      action: 'Help participant ID: 339620 apply for WIC at https://www.ruhealth.org/appointments/apply-4-wic-form#.',
     },
     {
-      title: 'Help Carolina Delgado',
+      title: 'Help Celeste Thomas apply for IHSS',
       label: 'riversideihss.org/Home/IHSSApply',
-      action: 'Help Carolina Delgado, date of birth 1958-03-25 apply for IHSS at https://riversideihss.org/Home/IHSSApply. She has cancer and needs her daughter to help take care of herself.',
+      action: 'Help participant ID: 339619 apply for IHSS at https://riversideihss.org/Home/IHSSApply',
     },
     {
-      title: 'Help Daniela Muñoz',
-      label: 'ruhealth.org/appointments/apply-4-wic-form',
-      action: 'Help Daniela Muñoz, date of birth 2004-03-31 apply WIC at https://www.ruhealth.org/appointments/apply-4-wic-form#. She is pregnant. ',
+      title: 'Help Josephine Thomas apply for IHSS',
+      label: 'riversideihss.org/Home/IHSSApply',
+      action: 'Help participant ID: 339622 apply for IHSS at https://riversideihss.org/Home/IHSSApply',
     },
     {
-      title: 'Help Ana Hernández',
-      label: 'ruhealth.org/appointments/apply-4-wic-form',
-      action: 'Help Ana Hernández, date of birth 1982-04-08 apply for WIC since she is pregnant. Application: https://www.ruhealth.org/appointments/apply-4-wic-form#',
+      title: 'Help Marceline Thomas apply for IHSS',
+      label: 'riversideihss.org/Home/IHSSApply',
+      action: 'Help participant ID: 339624 apply for IHSS at https://riversideihss.org/Home/IHSSApply',
     },
   ];
 


### PR DESCRIPTION
This pull request updates the suggested actions in the `PureSuggestedActions` component to use participant IDs and more generic action descriptions, replacing previous entries that included personal details. The changes also update the names and actions to focus on specific participants and streamline the action text.

Updates to suggested actions:

* Changed the suggested action titles and actions to reference specific participant IDs (e.g., "Help participant ID: 339620") instead of using full names and dates of birth.
* Updated the action URLs and labels to consistently use either the WIC or IHSS application links, and removed extra personal details from the action descriptions.
* Replaced previous participant examples with new ones, focusing on the Thomas family for IHSS applications.