### PR TITLE
fix: redis fix for auth

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -27,12 +27,16 @@ function ErrorHandler() {
 }
 
 function LoginContent() {
+  const searchParams = useSearchParams();
   const [loadingMethod, setLoadingMethod] = useState<'microsoft' | 'google' | null>(null);
+
+  // Use callbackUrl from URL params, default to /home
+  const callbackUrl = searchParams.get('callbackUrl') || '/home';
 
   const handleGoogleLogin = async () => {
     setLoadingMethod('google');
     try {
-      await signIn('google', { callbackUrl: '/home' });
+      await signIn('google', { callbackUrl });
     } catch (error) {
       toast({
         type: 'error',
@@ -45,7 +49,7 @@ function LoginContent() {
   const handleMicrosoftLogin = async () => {
     setLoadingMethod('microsoft');
     try {
-      await signIn('microsoft-entra-id', { callbackUrl: '/home' });
+      await signIn('microsoft-entra-id', { callbackUrl });
     } catch (error) {
       toast({
         type: 'error',
@@ -105,11 +109,9 @@ function LoginContent() {
 
 export default function Page() {
   return (
-    <>
-      <Suspense fallback={null}>
-        <ErrorHandler />
-      </Suspense>
+    <Suspense fallback={null}>
+      <ErrorHandler />
       <LoginContent />
-    </>
+    </Suspense>
   );
 }


### PR DESCRIPTION
This pull request updates the login and link handling flows to improve user experience and ensure users are redirected to their intended destination after authentication. The main changes involve supporting dynamic callback URLs during login and enforcing authentication before accessing protected links.

## Changes

* The login page now reads the `callbackUrl` from the URL parameters, defaulting to `/home` if not specified, and uses it for both Google and Microsoft sign-in methods. This ensures users are redirected to their intended destination after logging in. [[1]](diffhunk://#diff-87bb40e63a4105a08e29f7d5602a447e94a68619080a086bc510bcac0cba6932R30-R39) [[2]](diffhunk://#diff-87bb40e63a4105a08e29f7d5602a447e94a68619080a086bc510bcac0cba6932L48-R52)
* The `/link/[token]` route now checks if the user is authenticated before proceeding. If not, it redirects to the login page with a `callbackUrl` that returns the user to the original link after login. ([app/link/[token]/route.tsR4](diffhunk://#diff-b05284df48200c52ad891b387d002999f2525164588efadc6c2e7e26b2e1cf53R4), [app/link/[token]/route.tsR55-R61](diffhunk://#diff-b05284df48200c52ad891b387d002999f2525164588efadc6c2e7e26b2e1cf53R55-R61))
* Minor cleanup of the login page component structure, removing unnecessary fragments and ensuring proper placement of the `Suspense` component.