### PR TITLE
debug: log actual DB error in saveChat

### DIFF
--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -161,6 +161,7 @@ export async function saveChat({
       visibility,
     });
   } catch (error) {
+    console.error('[saveChat] DB error:', error);
     throw new ChatSDKError('bad_request:database', 'Failed to save chat');
   }
 }


### PR DESCRIPTION
Add console.error to see the actual Postgres error instead of swallowing it.