### PR TITLE
fix: fix for prompt and tasks for tool calls

### DIFF
--- a/components/ai-elements/index.ts
+++ b/components/ai-elements/index.ts
@@ -8,3 +8,11 @@ export {
 } from './confirmation';
 
 export { UserActionConfirmation } from './user-action-confirmation';
+
+export {
+  Task,
+  TaskTrigger,
+  TaskContent,
+  TaskItem,
+  TaskItemFile,
+} from './task';

--- a/components/ai-elements/task.tsx
+++ b/components/ai-elements/task.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, CheckIcon } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+import { Spinner } from "@/components/ui/spinner";
+
+export type TaskItemFileProps = ComponentProps<"div">;
+
+export const TaskItemFile = ({
+  children,
+  className,
+  ...props
+}: TaskItemFileProps) => (
+  <div
+    className={cn(
+      "inline-flex items-center gap-1 rounded-md border bg-secondary px-1.5 py-0.5 text-foreground text-xs",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
+export type TaskItemProps = ComponentProps<"div"> & {
+  icon?: ReactNode;
+};
+
+export const TaskItem = ({ children, className, icon, ...props }: TaskItemProps) => (
+  <div className={cn("text-muted-foreground text-sm flex items-start gap-2", className)} {...props}>
+    {icon && <span className="text-muted-foreground shrink-0 mt-0.5">{icon}</span>}
+    <span>{children}</span>
+  </div>
+);
+
+export type TaskProps = ComponentProps<typeof Collapsible>;
+
+export const Task = ({
+  defaultOpen = true,
+  className,
+  ...props
+}: TaskProps) => (
+  <Collapsible
+    className={cn("bg-[#F8F8F8] dark:bg-muted/50 rounded-lg p-3", className)}
+    defaultOpen={defaultOpen}
+    {...props}
+  />
+);
+
+export type TaskTriggerProps = ComponentProps<typeof CollapsibleTrigger> & {
+  title: string;
+  isLoading?: boolean;
+  isComplete?: boolean;
+  icon?: ReactNode;
+};
+
+export const TaskTrigger = ({
+  children,
+  className,
+  title,
+  isLoading = false,
+  isComplete = false,
+  icon,
+  ...props
+}: TaskTriggerProps) => (
+  <CollapsibleTrigger asChild className={cn("group", className)} {...props}>
+    {children ?? (
+      <div className="flex w-full cursor-pointer items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground">
+        {isLoading ? (
+          <Spinner className="size-4 text-muted-foreground" />
+        ) : isComplete ? (
+          <CheckIcon className="size-4 ext-muted-foreground" />
+        ) : icon ? (
+          <span className="size-4 flex items-center justify-center">{icon}</span>
+        ) : null}
+        <p className="text-sm flex-1">{title}</p>
+        <ChevronDownIcon className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+      </div>
+    )}
+  </CollapsibleTrigger>
+);
+
+export type TaskContentProps = ComponentProps<typeof CollapsibleContent>;
+
+export const TaskContent = ({
+  children,
+  className,
+  ...props
+}: TaskContentProps) => (
+  <CollapsibleContent
+    className={cn(
+      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+      className
+    )}
+    {...props}
+  >
+    <div className="mt-2 space-y-1.5 border-muted border-l pl-4 ml-2">
+      {children}
+    </div>
+  </CollapsibleContent>
+);

--- a/components/benefit-applications-landing.tsx
+++ b/components/benefit-applications-landing.tsx
@@ -67,7 +67,7 @@ export function BenefitApplicationsLanding({
             sendMessage={sendMessage}
             selectedVisibilityType={selectedVisibilityType}
             showStopButton={false}
-            placeholder="Ex. Fill out the WIC form for Jane Doe"
+            placeholder="Ex. Retrieve ID# and fill in https://riversideihss.org/IntakeApp"
             session={session}
           />
         </div>

--- a/components/benefit-applications-landing.tsx
+++ b/components/benefit-applications-landing.tsx
@@ -49,7 +49,7 @@ export function BenefitApplicationsLanding({
         {/* Subheader */}
         {/* TODO: When the suggested actions are gone switch back to mb-6 sm:mb-8 md:mb-12*/}
         <h2 className="text-base sm:text-lg md:text-2xl font-inter text-black dark:text-white mb-4 sm:mb-6 md:mb-8">
-          What&apos;s your client&apos;s name and which program do they need?
+          What&apos;s your client&apos;s Apricot ID number and which program are they applying for?
         </h2>
 
         {/* Input Form */}

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -26,9 +26,9 @@ import {
 } from './ui/collapsible';
 import { ChevronDown } from 'lucide-react';
 import { CollapsibleWrapper } from './ui/collapsible-wrapper';
-import { getToolDisplayInfo } from './tool-icon';
+import { getToolDisplayInfo, getTaskGroupTitle } from './tool-icon';
 import { Spinner } from './ui/spinner';
-import { UserActionConfirmation } from './ai-elements';
+import { UserActionConfirmation, Task, TaskTrigger, TaskContent, TaskItem } from './ai-elements';
 
 // Responsive min-height calculation that accounts for side-chat-header height
 // This ensures the last message has enough space to scroll properly with the header
@@ -141,353 +141,378 @@ const PurePreviewMessage = ({
               </div>
             )}
 
-            {message.parts?.map((part, index) => {
-              const { type } = part;
-              const key = `message-${message.id}-part-${index}`;
+            {/* Group parts into segments: consecutive browser tools become Task groups */}
+            {(() => {
+              type GroupedPart =
+                | { type: 'single'; part: any; index: number }
+                | { type: 'task-group'; parts: any[]; startIndex: number };
 
-              if (type === 'reasoning' && part.text?.trim().length > 0) {
-                return (
-                  <MessageReasoning
-                    key={key}
-                    isLoading={isLoading}
-                    reasoning={part.text}
-                  />
-                );
+              const isBrowserToolPart = (part: any) => {
+                const { type } = part;
+                if (!type.startsWith('tool-')) return false;
+                if (['tool-getWeather', 'tool-createDocument', 'tool-updateDocument', 'tool-requestSuggestions'].includes(type)) return false;
+                const { input } = part as any;
+                const { text: displayName } = getToolDisplayInfo(type, input);
+                if (displayName === 'Updated working memory' || displayName === 'Executed JavaScript' || displayName === 'Retrieved participant data') return false;
+                return true;
+              };
+
+              // Group consecutive browser tool parts together
+              const groupedParts: GroupedPart[] = [];
+              let currentToolGroup: any[] = [];
+              let toolGroupStartIndex = 0;
+
+              message.parts?.forEach((part, index) => {
+                if (isBrowserToolPart(part)) {
+                  if (currentToolGroup.length === 0) {
+                    toolGroupStartIndex = index;
+                  }
+                  currentToolGroup.push(part);
+                } else {
+                  // Flush any accumulated tool group
+                  if (currentToolGroup.length > 0) {
+                    groupedParts.push({ type: 'task-group', parts: currentToolGroup, startIndex: toolGroupStartIndex });
+                    currentToolGroup = [];
+                  }
+                  groupedParts.push({ type: 'single', part, index });
+                }
+              });
+              // Flush remaining tool group
+              if (currentToolGroup.length > 0) {
+                groupedParts.push({ type: 'task-group', parts: currentToolGroup, startIndex: toolGroupStartIndex });
               }
 
-              if (type === 'text') {
-                if (mode === 'view') {
-                  const partnerData = parsePartnerData(part.text);
+              return groupedParts.map((grouped) => {
+                if (grouped.type === 'task-group') {
+                  const { parts: toolParts, startIndex } = grouped;
+                  const hasInProgressTool = toolParts.some((part: any) => part.state === 'input-available');
+                  const allComplete = toolParts.every((part: any) => part.state === 'output-available');
+                  const taskTitle = getTaskGroupTitle(toolParts, allComplete);
 
-                  if (partnerData && message.role === 'user') {
+                  return (
+                    <Task key={`task-group-${startIndex}`} defaultOpen={true}>
+                      <TaskTrigger
+                        title={taskTitle}
+                        isLoading={hasInProgressTool}
+                        isComplete={allComplete}
+                      />
+                      <TaskContent>
+                        {toolParts.map((part: any, idx: number) => {
+                          const { toolCallId, state, input, output } = part;
+                          const { text: displayName, icon: Icon } = getToolDisplayInfo(part.type, input);
+                          const hasError = state === 'output-available' && output && 'error' in output && output.error;
+
+                          return (
+                            <TaskItem
+                              key={toolCallId || idx}
+                              icon={Icon && <Icon size={14} />}
+                              className={hasError ? 'text-red-600' : ''}
+                            >
+                              {displayName}{hasError && ' (Error)'}
+                            </TaskItem>
+                          );
+                        })}
+                      </TaskContent>
+                    </Task>
+                  );
+                }
+
+                // Render single non-tool parts
+                const { part, index } = grouped;
+                const { type } = part;
+                const key = `message-${message.id}-part-${index}`;
+
+                if (type === 'reasoning' && part.text?.trim().length > 0) {
+                  return (
+                    <MessageReasoning
+                      key={key}
+                      isLoading={isLoading}
+                      reasoning={part.text}
+                    />
+                  );
+                }
+
+                if (type === 'text') {
+                  if (mode === 'view') {
+                    const partnerData = parsePartnerData(part.text);
+
+                    if (partnerData && message.role === 'user') {
+                      return (
+                        <div key={key} className="flex flex-col gap-2 items-end w-full">
+                          {partnerData.taskText && (
+                            <div
+                              data-testid="message-content"
+                              className="bg-accent dark:bg-muted text-foreground dark:text-foreground px-[18px] py-[18px] rounded-xl text-xs leading-[18px] font-inter"
+                            >
+                              <Markdown>{sanitizeText(partnerData.taskText)}</Markdown>
+                            </div>
+                          )}
+                          <CollapsibleWrapper
+                            displayName="Participant data from partner"
+                            output={partnerData.participantData}
+                          />
+                        </div>
+                      );
+                    }
+
+                    const textContent = part.text.toLowerCase();
+                    const requiresUserAction =
+                      textContent.includes('captcha') ||
+                      textContent.includes('action required') ||
+                      textContent.includes('take control') ||
+                      textContent.includes('user intervention') ||
+                      textContent.includes('missing information') ||
+                      textContent.includes('complete the application');
+
                     return (
-                      <div key={key} className="flex flex-col gap-2 items-end w-full">
-                        {partnerData.taskText && (
+                      <div key={key} className="flex flex-col gap-3">
+                        <div className="flex flex-row gap-2 items-start">
                           <div
                             data-testid="message-content"
-                            className="bg-accent dark:bg-muted text-foreground dark:text-foreground px-[18px] py-[18px] rounded-xl text-xs leading-[18px] font-inter"
+                            className={cn('flex flex-col gap-4', {
+                              'bg-accent dark:bg-muted text-foreground dark:text-foreground px-[18px] py-[18px] rounded-xl text-xs leading-[18px] font-inter':
+                                message.role === 'user',
+                              'assistant-message-bubble font-source-serif':
+                                message.role === 'assistant',
+                            })}
                           >
-                            <Markdown>{sanitizeText(partnerData.taskText)}</Markdown>
+                            <Markdown>{sanitizeText(part.text)}</Markdown>
                           </div>
-                        )}
-                        <CollapsibleWrapper
-                          displayName="Participant data from partner"
-                          output={partnerData.participantData}
-                        />
-                      </div>
-                    );
-                  }
-
-                  const textContent = part.text.toLowerCase();
-                  const requiresUserAction = 
-                    textContent.includes('captcha') ||
-                    textContent.includes('action required') ||
-                    textContent.includes('take control') ||
-                    textContent.includes('user intervention') ||
-                    textContent.includes('missing information') ||
-                    textContent.includes('complete the application');
-
-                  return (
-                    <div key={key} className="flex flex-col gap-3">
-                      <div className="flex flex-row gap-2 items-start">
-                        {/* {message.role === 'user' && !isReadonly && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                data-testid="message-edit-button"
-                                variant="ghost"
-                                className="px-2 h-fit rounded-full text-muted-foreground opacity-0 group-hover/message:opacity-100"
-                                onClick={() => {
-                                  setMode('edit');
-                                }}
-                              >
-                                <PencilEditIcon />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>Edit message</TooltipContent>
-                          </Tooltip>
-                        )} */}
-
-                        <div
-                          data-testid="message-content"
-                          className={cn('flex flex-col gap-4', {
-                            'bg-accent dark:bg-muted text-foreground dark:text-foreground px-[18px] py-[18px] rounded-xl text-xs leading-[18px] font-inter':
-                              message.role === 'user',
-                            'assistant-message-bubble font-source-serif':
-                              message.role === 'assistant',
-                          })}
-                        >
-                          <Markdown>{sanitizeText(part.text)}</Markdown>
                         </div>
+
+                        {message.role === 'assistant' && requiresUserAction && !isReadonly && !isLoading && !dismissedActionConfirmations.has(message.id) && isArtifactVisible && (
+                          <UserActionConfirmation
+                            approval={{ id: `action-${message.id}`, approved: undefined }}
+                            state="approval-requested"
+                            requestMessage={
+                              textContent.includes('captcha')
+                                ? 'Complete the CAPTCHA and submit the application.'
+                                : 'Manual action required to proceed.'
+                            }
+                            onApprove={(approvalId) => {
+                              const event = new CustomEvent('switch-browser-control', {
+                                detail: { mode: 'user' }
+                              });
+                              window.dispatchEvent(event);
+                            }}
+                          />
+                        )}
                       </div>
-                      
-                      {message.role === 'assistant' && requiresUserAction && !isReadonly && !isLoading && !dismissedActionConfirmations.has(message.id) && isArtifactVisible && (
-                        <UserActionConfirmation
-                          approval={{ id: `action-${message.id}`, approved: undefined }}
-                          state="approval-requested"
-                          requestMessage={
-                            textContent.includes('captcha')
-                              ? 'Complete the CAPTCHA and submit the application.'
-                              : 'Manual action required to proceed.'
-                          }
-                          onApprove={(approvalId) => {
-                            // Trigger browser control switch to user mode
-                            const event = new CustomEvent('switch-browser-control', { 
-                              detail: { mode: 'user' } 
-                            });
-                            window.dispatchEvent(event);
-                          }}
-                          // onReject={(approvalId) => {
-                          //   // Dismiss the confirmation by adding message.id to the dismissed set
-                          //   setDismissedActionConfirmations((prev) => new Set([...prev, message.id]));
-                          // }}
+                    );
+                  }
+
+                  if (mode === 'edit') {
+                    return (
+                      <div key={key} className="flex flex-row gap-2 items-start">
+                        <div className="size-8" />
+                        <MessageEditor
+                          key={message.id}
+                          message={message}
+                          setMode={setMode}
+                          setMessages={setMessages}
+                          regenerate={regenerate}
                         />
-                      )}
-                    </div>
-                  );
+                      </div>
+                    );
+                  }
                 }
 
-                if (mode === 'edit') {
-                  return (
-                    <div key={key} className="flex flex-row gap-2 items-start">
-                      <div className="size-8" />
+                if (type === 'tool-getWeather') {
+                  const { toolCallId, state } = part;
 
-                      <MessageEditor
-                        key={message.id}
-                        message={message}
-                        setMode={setMode}
-                        setMessages={setMessages}
-                        regenerate={regenerate}
-                      />
-                    </div>
-                  );
-                }
-              }
-
-              if (type === 'tool-getWeather') {
-                const { toolCallId, state } = part;
-
-                if (state === 'input-available') {
-                  return (
-                    <div key={toolCallId} className="skeleton">
-                      <Weather />
-                    </div>
-                  );
-                }
-
-                if (state === 'output-available') {
-                  const { output } = part;
-                  return (
-                    <div key={toolCallId}>
-                      <Weather weatherAtLocation={output} />
-                    </div>
-                  );
-                }
-              }
-
-              if (type === 'tool-createDocument') {
-                const { toolCallId, state } = part;
-
-                if (state === 'input-available') {
-                  const { input } = part;
-                  return (
-                    <div key={toolCallId}>
-                      <DocumentPreview isReadonly={isReadonly} args={input} />
-                    </div>
-                  );
-                }
-
-                if (state === 'output-available') {
-                  const { output } = part;
-
-                  if ('error' in output) {
+                  if (state === 'input-available') {
                     return (
-                      <div
-                        key={toolCallId}
-                        className="text-red-500 p-2 border rounded"
-                      >
-                        Error: {String(output.error)}
+                      <div key={toolCallId} className="skeleton">
+                        <Weather />
                       </div>
                     );
                   }
 
-                  return (
-                    <div key={toolCallId}>
-                      <DocumentPreview
-                        isReadonly={isReadonly}
-                        result={output}
-                      />
-                    </div>
-                  );
-                }
-              }
-
-              if (type === 'tool-updateDocument') {
-                const { toolCallId, state } = part;
-
-                if (state === 'input-available') {
-                  const { input } = part;
-
-                  return (
-                    <div key={toolCallId}>
-                      <DocumentToolCall
-                        type="update"
-                        args={input}
-                        isReadonly={isReadonly}
-                      />
-                    </div>
-                  );
-                }
-
-                if (state === 'output-available') {
-                  const { output } = part;
-
-                  if ('error' in output) {
+                  if (state === 'output-available') {
+                    const { output } = part;
                     return (
-                      <div
-                        key={toolCallId}
-                        className="text-red-500 p-2 border rounded"
-                      >
-                        Error: {String(output.error)}
+                      <div key={toolCallId}>
+                        <Weather weatherAtLocation={output} />
+                      </div>
+                    );
+                  }
+                }
+
+                if (type === 'tool-createDocument') {
+                  const { toolCallId, state } = part;
+
+                  if (state === 'input-available') {
+                    const { input } = part;
+                    return (
+                      <div key={toolCallId}>
+                        <DocumentPreview isReadonly={isReadonly} args={input} />
                       </div>
                     );
                   }
 
-                  return (
-                    <div key={toolCallId}>
-                      <DocumentToolResult
-                        type="update"
-                        result={output}
-                        isReadonly={isReadonly}
-                      />
-                    </div>
-                  );
-                }
-              }
+                  if (state === 'output-available') {
+                    const { output } = part;
 
-              if (type === 'tool-requestSuggestions') {
-                const { toolCallId, state } = part;
+                    if ('error' in output) {
+                      return (
+                        <div
+                          key={toolCallId}
+                          className="text-red-500 p-2 border rounded"
+                        >
+                          Error: {String(output.error)}
+                        </div>
+                      );
+                    }
 
-                if (state === 'input-available') {
-                  const { input } = part;
-                  return (
-                    <div key={toolCallId}>
-                      <DocumentToolCall
-                        type="request-suggestions"
-                        args={input}
-                        isReadonly={isReadonly}
-                      />
-                    </div>
-                  );
-                }
-
-                if (state === 'output-available') {
-                  const { output } = part;
-
-                  if ('error' in output) {
                     return (
-                      <div
-                        key={toolCallId}
-                        className="text-red-500 p-2 border rounded"
-                      >
-                        Error: {String(output.error)}
+                      <div key={toolCallId}>
+                        <DocumentPreview
+                          isReadonly={isReadonly}
+                          result={output}
+                        />
+                      </div>
+                    );
+                  }
+                }
+
+                if (type === 'tool-updateDocument') {
+                  const { toolCallId, state } = part;
+
+                  if (state === 'input-available') {
+                    const { input } = part;
+
+                    return (
+                      <div key={toolCallId}>
+                        <DocumentToolCall
+                          type="update"
+                          args={input}
+                          isReadonly={isReadonly}
+                        />
                       </div>
                     );
                   }
 
-                  return (
-                    <div key={toolCallId}>
-                      <DocumentToolResult
-                        type="request-suggestions"
-                        result={output}
-                        isReadonly={isReadonly}
-                      />
-                    </div>
-                  );
+                  if (state === 'output-available') {
+                    const { output } = part;
+
+                    if ('error' in output) {
+                      return (
+                        <div
+                          key={toolCallId}
+                          className="text-red-500 p-2 border rounded"
+                        >
+                          Error: {String(output.error)}
+                        </div>
+                      );
+                    }
+
+                    return (
+                      <div key={toolCallId}>
+                        <DocumentToolResult
+                          type="update"
+                          result={output}
+                          isReadonly={isReadonly}
+                        />
+                      </div>
+                    );
+                  }
                 }
-              }
 
-              // Handle any other tool calls (including web automation tools)
-              if (type.startsWith('tool-') && !['tool-getWeather', 'tool-createDocument', 'tool-updateDocument', 'tool-requestSuggestions'].includes(type)) {
-                const { toolCallId, state } = part as any;
+                if (type === 'tool-requestSuggestions') {
+                  const { toolCallId, state } = part;
 
-                if (state === 'input-available') {
-                  const { input } = part as any;
+                  if (state === 'input-available') {
+                    const { input } = part;
+                    return (
+                      <div key={toolCallId}>
+                        <DocumentToolCall
+                          type="request-suggestions"
+                          args={input}
+                          isReadonly={isReadonly}
+                        />
+                      </div>
+                    );
+                  }
+
+                  if (state === 'output-available') {
+                    const { output } = part;
+
+                    if ('error' in output) {
+                      return (
+                        <div
+                          key={toolCallId}
+                          className="text-red-500 p-2 border rounded"
+                        >
+                          Error: {String(output.error)}
+                        </div>
+                      );
+                    }
+
+                    return (
+                      <div key={toolCallId}>
+                        <DocumentToolResult
+                          type="request-suggestions"
+                          result={output}
+                          isReadonly={isReadonly}
+                        />
+                      </div>
+                    );
+                  }
+                }
+
+                // Handle get-participant-with-household separately (CollapsibleWrapper)
+                if (type.startsWith('tool-') && !['tool-getWeather', 'tool-createDocument', 'tool-updateDocument', 'tool-requestSuggestions'].includes(type)) {
+                  const { toolCallId, state, input } = part as any;
                   const { text: displayName, icon: Icon } = getToolDisplayInfo(type, input);
 
-                  if (displayName === 'Updated working memory' || displayName === 'Executed JavaScript') {
-                    return;
-                  }
-                  // Only use CollapsibleWrapper for get-participant-with-household
                   if (displayName === 'Retrieved participant data') {
-                    return (
-                      <CollapsibleWrapper key={toolCallId} displayName={displayName} input={input} icon={Icon} />
-                    );
+                    if (state === 'input-available') {
+                      return (
+                        <CollapsibleWrapper key={toolCallId} displayName={displayName} input={input} icon={Icon} />
+                      );
+                    }
+                    if (state === 'output-available') {
+                      const { output } = part as any;
+                      const hasParticipantError = output && 'error' in output && output.error;
+                      return (
+                        <CollapsibleWrapper
+                          key={toolCallId}
+                          displayName={displayName}
+                          input={input}
+                          output={output}
+                          isError={hasParticipantError}
+                          icon={Icon}
+                        />
+                      );
+                    }
                   }
-
-                  // For all other tools, show simple icon with text
-                  return (
-                    <div key={toolCallId} className="flex items-center gap-2 p-3 border-0 rounded-md">
-                      <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
-                        {Icon && (
-                          <Icon size={12} className="text-gray-500 shrink-0" />
-                        )}
-                        {displayName}
-                      </div>
-                    </div>
-                  );
                 }
 
-                if (state === 'output-available') {
-                  const { output, input } = part as any;
-                  const { text: displayName, icon: Icon } = getToolDisplayInfo(type, input);
+                return null;
+              });
+            })()}
 
-                  if (displayName === 'Updated working memory' || displayName === 'Executed JavaScript') {
-                    return;
-                  }
-
-                  // Only use CollapsibleWrapper for get-participant-with-household
-                  if (displayName === 'Retrieved participant data') {
-                    // Check for actual error value, not just presence of 'error' key
-                    const hasParticipantError = output && 'error' in output && output.error;
-                    return (
-                      <CollapsibleWrapper
-                        key={toolCallId}
-                        displayName={displayName}
-                        input={input}
-                        output={output}
-                        isError={hasParticipantError}
-                        icon={Icon}
-                      />
-                    );
-                  }
-
-                  // For all other tools, show simple icon with text
-                  // Check for actual error value, not just presence of 'error' key (some tools return { error: null } on success)
-                  const hasError = output && 'error' in output && output.error;
-                  return (
-                    <div key={toolCallId} className="flex items-center gap-2 p-3 border-0 rounded-md">
-                      <div className={`text-[10px] leading-[150%] font-ibm-plex-mono flex items-center gap-2 ${hasError ? 'text-red-600' : 'text-muted-foreground'}`}>
-                        {Icon && (
-                          <Icon size={12} className="text-gray-500 shrink-0" />
-                        )}
-                        {displayName}
-                        {hasError && ' (Error)'}
-                      </div>
-                    </div>
-                  );
-                }
-              }
-            })}
-
-            {isLoading && (
-              <div className="flex items-center gap-2 p-3 border-0 rounded-md">
-                <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
-                  <Spinner className="size-3 shrink-0 text-primary" />
-                  Processing...
+            {/* Only show processing spinner if there are no browser tool parts (they have their own loading state) */}
+            {isLoading && (() => {
+              const hasBrowserToolParts = message.parts.some((part) => {
+                const { type } = part;
+                if (!type.startsWith('tool-')) return false;
+                if (['tool-getWeather', 'tool-createDocument', 'tool-updateDocument', 'tool-requestSuggestions'].includes(type)) return false;
+                const { input } = part as any;
+                const { text: displayName } = getToolDisplayInfo(type, input);
+                if (displayName === 'Updated working memory' || displayName === 'Executed JavaScript' || displayName === 'Retrieved participant data') return false;
+                return true;
+              });
+              if (hasBrowserToolParts) return null;
+              return (
+                <div className="flex items-center gap-2 p-3 border-0 rounded-md">
+                  <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
+                    <Spinner className="size-3 shrink-0 text-primary" />
+                    Processing...
+                  </div>
                 </div>
-              </div>
-            )}
+              );
+            })()}
 
             {/* {!isReadonly && (
               <MessageActions

--- a/components/tool-icon.tsx
+++ b/components/tool-icon.tsx
@@ -227,7 +227,7 @@ export const getToolDisplayInfo = (toolName: string, input?: any): { text: strin
   };
 
   const mapper = toolMappings[cleanToolName];
-  
+
   let text: string;
   if (mapper) {
     text = mapper(input);
@@ -235,9 +235,56 @@ export const getToolDisplayInfo = (toolName: string, input?: any): { text: strin
     // Fallback: convert kebab-case to readable format
     text = cleanToolName.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
   }
-  
+
   return {
     text,
     icon: getToolIcon(toolName)
   };
+};
+
+// Tool action categories for determining task group titles
+const formFillingActions = ['Typing', 'Filling', 'Selecting', 'Checking', 'Unchecking', 'Typed', 'Filled', 'Selected'];
+const navigationActions = ['Opening', 'Navigated', 'Going back', 'Going forward', 'Reloading'];
+const readingActions = ['Reading page', 'Taking screenshot', 'Captured page snapshot', 'Took screenshot'];
+
+// Determine the task group title based on the tool calls
+// Returns both in-progress and completed titles
+export const getTaskGroupTitle = (toolParts: any[], isComplete: boolean = false): string => {
+  if (toolParts.length === 0) return isComplete ? 'Completed' : 'Working ...';
+
+  let hasFormFilling = false;
+  let hasNavigation = false;
+  let hasReading = false;
+
+  for (const part of toolParts) {
+    const { text: displayName } = getToolDisplayInfo(part.type, part.input);
+
+    if (formFillingActions.some(action => displayName.startsWith(action))) {
+      hasFormFilling = true;
+    }
+    if (navigationActions.some(action => displayName.startsWith(action))) {
+      hasNavigation = true;
+    }
+    if (readingActions.some(action => displayName.startsWith(action))) {
+      hasReading = true;
+    }
+  }
+
+  // Prioritize form filling if any form actions are present
+  if (hasFormFilling) {
+    return isComplete ? 'Filled out form' : 'Filling the form ...';
+  }
+
+  // Navigation actions
+  if (hasNavigation && !hasReading) {
+    return isComplete ? 'Navigated' : 'Navigating ...';
+  }
+
+  // Reading/analyzing the page
+  if (hasReading && !hasNavigation) {
+    return isComplete ? 'Read page' : 'Reading page ...';
+  }
+
+  // Mixed or other actions
+  return isComplete ? 'Completed' : 'Working on page ...';
 };

--- a/lib/apricot-api.ts
+++ b/lib/apricot-api.ts
@@ -30,12 +30,12 @@ export type {
 } from './models/apricot-models';
 
 // ===== Configuration =====
-// Use 'api' for production only (https://labs-asp.navateam.com), 'sandbox' for all other environments including dev
-const env = process.env.NEXTAUTH_URL?.includes('://labs-asp.navateam.com') ? 'api' : 'sandbox';
+// Use 'api' for production only (ENVIRONMENT=prod), 'sandbox' for all other environments including dev
+const env = process.env.ENVIRONMENT === 'prod' ? 'api' : 'sandbox';
 
 // Log environment on module load for debugging
-console.log(`[Apricot API] Environment: "${env}" | NEXTAUTH_URL: "${process.env.NEXTAUTH_URL || 'undefined'}"`);
-console.log(`[Apricot API] Expected: prod (labs-asp.navateam.com) → "api", dev (dev.labs-asp.navateam.com) → "sandbox"`);
+console.log(`[Apricot API] Environment: "${env}" | ENVIRONMENT: "${process.env.ENVIRONMENT || 'undefined'}"`);
+console.log(`[Apricot API] Expected: prod (ENVIRONMENT=prod) → "api", all others → "sandbox"`);
 
 // API configuration from environment variables
 const baseUrl = process.env.APRICOT_API_BASE_URL;
@@ -97,9 +97,7 @@ export const authenticate = async (): Promise<string> => {
   }
 
   try {
-    const authUrl = `${baseUrl}/${env}/oauth/token`;
-    console.log(`[Apricot API] Authenticating via: ${authUrl}`);
-    const response = await fetch(authUrl, {
+    const response = await fetch(`${baseUrl}/${env}/oauth/token`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -131,8 +129,6 @@ export const authenticate = async (): Promise<string> => {
     const expiresInMs = (data.expires_in || 3600) * 1000;
     // Subtract 60 seconds as a buffer to avoid using expired tokens
     tokenExpiry = Date.now() + expiresInMs - 60000;
-
-    console.log(`[Apricot API] Successfully authenticated with "${env}" environment`);
 
     return cachedToken;
   } catch (error) {

--- a/lib/apricot-api.ts
+++ b/lib/apricot-api.ts
@@ -33,6 +33,10 @@ export type {
 // Use 'api' for production only (https://labs-asp.navateam.com), 'sandbox' for all other environments including dev
 const env = process.env.NEXTAUTH_URL?.includes('://labs-asp.navateam.com') ? 'api' : 'sandbox';
 
+// Log environment on module load for debugging
+console.log(`[Apricot API] Environment: "${env}" | NEXTAUTH_URL: "${process.env.NEXTAUTH_URL || 'undefined'}"`);
+console.log(`[Apricot API] Expected: prod (labs-asp.navateam.com) → "api", dev (dev.labs-asp.navateam.com) → "sandbox"`);
+
 // API configuration from environment variables
 const baseUrl = process.env.APRICOT_API_BASE_URL;
 const clientId = process.env.APRICOT_CLIENT_ID;
@@ -93,7 +97,9 @@ export const authenticate = async (): Promise<string> => {
   }
 
   try {
-    const response = await fetch(`${baseUrl}/${env}/oauth/token`, {
+    const authUrl = `${baseUrl}/${env}/oauth/token`;
+    console.log(`[Apricot API] Authenticating via: ${authUrl}`);
+    const response = await fetch(authUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -125,6 +131,8 @@ export const authenticate = async (): Promise<string> => {
     const expiresInMs = (data.expires_in || 3600) * 1000;
     // Subtract 60 seconds as a buffer to avoid using expired tokens
     tokenExpiry = Date.now() + expiresInMs - 60000;
+
+    console.log(`[Apricot API] Successfully authenticated with "${env}" environment`);
 
     return cachedToken;
   } catch (error) {


### PR DESCRIPTION
This pull request introduces a significant UI/UX improvement to how tool actions (especially browser automation tools) are displayed in chat messages, grouping related tool actions into collapsible "task" sections for clarity. It also includes several smaller improvements and code cleanups.

## Changes

**1. Enhanced Tool Action Grouping and Display in Messages**
- Tool actions (especially browser automation tools) are now grouped into collapsible "task" sections in chat messages, making multi-step automated actions more understandable and visually organized. Each group receives a dynamic title based on the types of actions performed (e.g., "Filling the form ...", "Navigating ..."), and individual steps are shown as items within the task. 
- The display logic for tool actions was refactored to avoid redundant or confusing output, and browser tool loading states are now shown at the group level instead of per-step.

**2. New Reusable UI Components for Task Grouping**
- Introduced new components: `Task`, `TaskTrigger`, `TaskContent`, `TaskItem`, and `TaskItemFile` in `components/ai-elements/task.tsx` to provide a consistent and accessible UI for grouped tool actions. These components use collapsible panels and support icons, loading, and completion states.

**3. Improved Tool Action Titles**
- Added `getTaskGroupTitle` in `components/tool-icon.tsx` to generate context-aware titles for grouped tool actions, making it clear to users what kind of automated work the assistant is performing. 

## Testing

