### PR TITLE
feat: use ENVIRONMENT variable for Apricot API environment detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,9 +62,12 @@ AUTH_MICROSOFT_ENTRA_ID_ISSUER=https://login.microsoftonline.com/common/v2.0
 CLOUDFLARE_BOT_PRIVATE_KEY=****
 
 # Apricot API Information
+# Prod and sandbox require separate credentials (different client_id/secret for each)
+# The correct credentials are selected based on ENVIRONMENT variable
 APRICOT_API_BASE_URL=https://f5r-api.iws.sidekick.solutions/apricot
 APRICOT_ORG_ID_SANDBOX=****
 APRICOT_ORG_ID_PROD=****
+# For local dev, use sandbox credentials:
 APRICOT_CLIENT_ID=****
 APRICOT_CLIENT_SECRET=****
 

--- a/lib/apricot-api.ts
+++ b/lib/apricot-api.ts
@@ -30,8 +30,12 @@ export type {
 } from './models/apricot-models';
 
 // ===== Configuration =====
-// Use 'api' for production only (https://labs-asp.navateam.com), 'sandbox' for all other environments including dev
-const env = process.env.NEXTAUTH_URL?.includes('://labs-asp.navateam.com') ? 'api' : 'sandbox';
+// Use 'api' for production only (ENVIRONMENT=prod), 'sandbox' for all other environments including dev
+const env = process.env.ENVIRONMENT === 'prod' ? 'api' : 'sandbox';
+
+// Log environment on module load for debugging
+console.log(`[Apricot API] Environment: "${env}" | ENVIRONMENT: "${process.env.ENVIRONMENT || 'undefined'}"`);
+console.log(`[Apricot API] Expected: prod (ENVIRONMENT=prod) → "api", all others → "sandbox"`);
 
 // API configuration from environment variables
 const baseUrl = process.env.APRICOT_API_BASE_URL;


### PR DESCRIPTION
- Switch from NEXTAUTH_URL to ENVIRONMENT variable for determining prod vs sandbox
- Add debug logging for environment detection
- Update .env.example with documentation about separate credentials