### PR TITLE
fix: use Redis for distributed browser session storage

### DIFF
--- a/app/api/kernel-browser/route.ts
+++ b/app/api/kernel-browser/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: Request) {
     }
 
     if (action === 'getLiveView') {
-      const url = getLiveViewUrl(sessionId);
+      const url = await getLiveViewUrl(sessionId);
       return Response.json({ liveViewUrl: url });
     }
 

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -2,7 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { createKernelBrowser, getCdpUrl } from '@/lib/kernel/browser';
+import { createKernelBrowser } from '@/lib/kernel/browser';
 
 const execAsync = promisify(exec);
 


### PR DESCRIPTION
## Summary
- Fix session conflicts where users see other users' browser sessions during load testing
- Cloud Run scales to multiple instances, each with its own in-memory browser map
- Now uses Upstash Redis (already configured) for shared session storage

## Changes
- Replace in-memory Map with Redis storage (`kernel-browser:{sessionId}`)
- Add TTL auto-expiry (10 minutes) using Redis EXPIRE
- Keep per-instance pending map for race condition prevention
- Add double-check after pending wait for cross-instance safety
- Make `getLiveViewUrl`/`getCdpUrl`/`hasActiveBrowser`/`listActiveBrowsers` async

## Test plan
- [ ] Run load test with multiple concurrent users
- [ ] Verify each user sees only their own browser session
- [ ] Verify browser sessions are properly cleaned up after TTL