### PR TITLE
feat: add gap analysis and tool grouping UI

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -42,6 +42,7 @@ import type { VisibilityType } from '@/components/visibility-selector';
 // AI SDK web automation imports (used when USE_AI_SDK_AGENT=true)
 import { apricotTools } from '@/lib/ai/tools/apricot';
 import { createBrowserTool } from '@/lib/ai/tools/browser';
+import { gapAnalysis } from '@/lib/ai/tools/gap-analysis';
 import { webAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
 
 // Feature flag for AI SDK agent vs Mastra
@@ -179,6 +180,7 @@ export async function POST(request: Request) {
             messages: await convertToModelMessages(uiMessages),
             tools: {
               ...apricotTools,
+              gapAnalysis,
               browser: createBrowserTool(sessionId),
             },
             stopWhen: stepCountIs(100),

--- a/components/ai-elements/gap-analysis-card.tsx
+++ b/components/ai-elements/gap-analysis-card.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+import { useState } from 'react';
+import { Check } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import type { UseChatHelpers } from '@ai-sdk/react';
+import type { ChatMessage } from '@/lib/types';
+
+interface AvailableField {
+  field: string;
+  value: string;
+}
+
+interface MissingField {
+  field: string;
+  options?: string[];
+  inputType?: string;
+  multiSelect?: boolean;
+  condition?: string;
+}
+
+interface GapAnalysisCardProps {
+  formName?: string;
+  availableFields: AvailableField[];
+  missingFields: MissingField[];
+  sendMessage?: UseChatHelpers<ChatMessage>['sendMessage'];
+  isSubmitted?: boolean;
+  className?: string;
+}
+
+export function GapAnalysisCard({
+  formName,
+  availableFields,
+  missingFields,
+  sendMessage,
+  isSubmitted: initialSubmitted = false,
+  className,
+}: GapAnalysisCardProps) {
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+  const [submitted, setSubmitted] = useState(initialSubmitted);
+
+  const disabled = submitted;
+
+  function updateAnswer(field: string, value: string | string[]) {
+    setAnswers((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function toggleCheckbox(field: string, option: string, checked: boolean) {
+    setAnswers((prev) => {
+      const current = (prev[field] as string[]) ?? [];
+      return {
+        ...prev,
+        [field]: checked
+          ? [...current, option]
+          : current.filter((v) => v !== option),
+      };
+    });
+  }
+
+  function handleSubmit() {
+    if (!sendMessage) return;
+
+    const lines: string[] = [];
+    if (formName) {
+      lines.push(`Answers for ${formName}:`);
+    } else {
+      lines.push('Answers for gap analysis:');
+    }
+
+    for (const field of missingFields) {
+      const answer = answers[field.field];
+      if (answer !== undefined && answer !== '') {
+        const value = Array.isArray(answer) ? answer.join(', ') : answer;
+        if (value) {
+          const separator = field.field.endsWith('?') ? '' : ':';
+          lines.push(`- ${field.field}${separator} ${value}`);
+        }
+      }
+    }
+
+    if (lines.length <= 1) return;
+
+    sendMessage({
+      role: 'user',
+      parts: [{ type: 'text', text: lines.join('\n') }],
+    });
+    setSubmitted(true);
+  }
+
+  function renderField(field: MissingField) {
+    const { field: name, options, inputType, multiSelect, condition } = field;
+
+    // multiSelect with options → checkbox group
+    if (multiSelect && options && options.length > 0) {
+      const selected = (answers[name] as string[]) ?? [];
+      return (
+        <fieldset key={name} className="space-y-2">
+          <Label className="font-semibold">{name}</Label>
+          {condition && (
+            <p className="text-xs text-muted-foreground italic">{condition}</p>
+          )}
+          <div className="flex flex-col gap-2">
+            {options.map((option) => (
+              <div key={option} className="flex items-center gap-2">
+                <Checkbox
+                  id={`${name}-${option}`}
+                  checked={selected.includes(option)}
+                  onCheckedChange={(checked) =>
+                    toggleCheckbox(name, option, !!checked)
+                  }
+                  disabled={disabled}
+                />
+                <Label
+                  htmlFor={`${name}-${option}`}
+                  className="font-normal cursor-pointer"
+                >
+                  {option}
+                </Label>
+              </div>
+            ))}
+          </div>
+        </fieldset>
+      );
+    }
+
+    // boolean → radio Yes/No
+    if (inputType === 'boolean') {
+      return (
+        <div key={name} className="space-y-2">
+          <Label className="font-semibold">{name}</Label>
+          {condition && (
+            <p className="text-xs text-muted-foreground italic">{condition}</p>
+          )}
+          <RadioGroup
+            value={(answers[name] as string) ?? ''}
+            onValueChange={(value) => updateAnswer(name, value)}
+            disabled={disabled}
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="Yes" id={`${name}-yes`} />
+              <Label htmlFor={`${name}-yes`} className="font-normal cursor-pointer">
+                Yes
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="No" id={`${name}-no`} />
+              <Label htmlFor={`${name}-no`} className="font-normal cursor-pointer">
+                No
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+      );
+    }
+
+    // select (single) with options → dropdown
+    if (inputType === 'select' && options && options.length > 0) {
+      return (
+        <div key={name} className="space-y-2">
+          <Label className="font-semibold">{name}</Label>
+          {condition && (
+            <p className="text-xs text-muted-foreground italic">{condition}</p>
+          )}
+          <Select
+            value={(answers[name] as string) ?? ''}
+            onValueChange={(value) => updateAnswer(name, value)}
+            disabled={disabled}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select an option" />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      );
+    }
+
+    // textarea
+    if (inputType === 'textarea') {
+      return (
+        <div key={name} className="space-y-2">
+          <Label className="font-semibold">{name}</Label>
+          {condition && (
+            <p className="text-xs text-muted-foreground italic">{condition}</p>
+          )}
+          <Textarea
+            value={(answers[name] as string) ?? ''}
+            onChange={(e) => updateAnswer(name, e.target.value)}
+            placeholder={`Enter ${name.toLowerCase()}`}
+            disabled={disabled}
+          />
+        </div>
+      );
+    }
+
+    // date
+    if (inputType === 'date') {
+      return (
+        <div key={name} className="space-y-2">
+          <Label className="font-semibold">{name}</Label>
+          {condition && (
+            <p className="text-xs text-muted-foreground italic">{condition}</p>
+          )}
+          <Input
+            type="date"
+            value={(answers[name] as string) ?? ''}
+            onChange={(e) => updateAnswer(name, e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+      );
+    }
+
+    // text / default → text input
+    return (
+      <div key={name} className="space-y-2">
+        <Label className="font-semibold">{name}</Label>
+        {condition && (
+          <p className="text-xs text-muted-foreground italic">{condition}</p>
+        )}
+        <Input
+          type="text"
+          value={(answers[name] as string) ?? ''}
+          onChange={(e) => updateAnswer(name, e.target.value)}
+          placeholder={`Enter ${name.toLowerCase()}`}
+          disabled={disabled}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <Alert
+      className={cn(
+        'bg-accent/25 border-accent dark:bg-accent/10',
+        className,
+      )}
+    >
+      <AlertDescription>
+        <div className="flex flex-col gap-px">
+          <div className="font-source-serif font-normal leading-[1.5] text-[14px] text-foreground">
+            <p className="font-bold mb-[14px]">
+              Gap Analysis{formName ? `: ${formName}` : ''}
+            </p>
+
+            {availableFields.length > 0 && (
+              <div className="mb-[14px]">
+                <p className="font-semibold mb-1">Available from Database</p>
+                {availableFields.map((item, i) => (
+                  <p key={i} className="flex items-center gap-1.5">
+                    <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400 shrink-0" />
+                    <span>
+                      {item.field}: {item.value}
+                    </span>
+                  </p>
+                ))}
+              </div>
+            )}
+
+            {missingFields.length > 0 && (
+              <div className="mb-[14px] space-y-4">
+                <p className="font-semibold mb-1">Needs Your Input</p>
+                {missingFields.map((field) => renderField(field))}
+              </div>
+            )}
+
+            {submitted ? (
+              <p className="text-muted-foreground flex items-center gap-1.5">
+                <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400 shrink-0" />
+                Answers submitted
+              </p>
+            ) : (
+              missingFields.length > 0 &&
+              sendMessage && (
+                <Button onClick={handleSubmit} className="mt-2">
+                  Submit Answers
+                </Button>
+              )
+            )}
+          </div>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/components/ai-elements/index.ts
+++ b/components/ai-elements/index.ts
@@ -8,3 +8,5 @@ export {
 } from './confirmation';
 
 export { UserActionConfirmation } from './user-action-confirmation';
+
+export { GapAnalysisCard } from './gap-analysis-card';

--- a/components/artifact-messages.tsx
+++ b/components/artifact-messages.tsx
@@ -15,6 +15,7 @@ interface ArtifactMessagesProps {
   messages: ChatMessage[];
   setMessages: UseChatHelpers<ChatMessage>['setMessages'];
   regenerate: UseChatHelpers<ChatMessage>['regenerate'];
+  sendMessage: UseChatHelpers<ChatMessage>['sendMessage'];
   isReadonly: boolean;
   artifactStatus: UIArtifact['status'];
 }
@@ -26,6 +27,7 @@ function PureArtifactMessages({
   messages,
   setMessages,
   regenerate,
+  sendMessage,
   isReadonly,
 }: ArtifactMessagesProps) {
   const {
@@ -58,6 +60,7 @@ function PureArtifactMessages({
           }
           setMessages={setMessages}
           regenerate={regenerate}
+          sendMessage={sendMessage}
           isReadonly={isReadonly}
           isArtifactVisible={true}
           requiresScrollPadding={

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -380,6 +380,7 @@ function PureArtifact({
                     messages={messages}
                     setMessages={setMessages}
                     regenerate={regenerate}
+                    sendMessage={sendMessage}
                     isReadonly={isReadonly}
                     artifactStatus={artifact.status}
                   />

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -342,6 +342,7 @@ export function Chat({
               messages={messages}
               setMessages={setMessages}
               regenerate={regenerate}
+              sendMessage={sendMessage}
               isReadonly={isReadonly}
               isArtifactVisible={isArtifactVisible}
             />

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -28,7 +28,7 @@ import { ChevronDown } from 'lucide-react';
 import { CollapsibleWrapper } from './ui/collapsible-wrapper';
 import { getToolDisplayInfo } from './tool-icon';
 import { Spinner } from './ui/spinner';
-import { UserActionConfirmation } from './ai-elements';
+import { UserActionConfirmation, GapAnalysisCard } from './ai-elements';
 
 // Responsive min-height calculation that accounts for side-chat-header height
 // This ensures the last message has enough space to scroll properly with the header
@@ -64,6 +64,7 @@ const PurePreviewMessage = ({
   isLoading,
   setMessages,
   regenerate,
+  sendMessage,
   isReadonly,
   isArtifactVisible,
   requiresScrollPadding,
@@ -74,6 +75,7 @@ const PurePreviewMessage = ({
   isLoading: boolean;
   setMessages: UseChatHelpers<ChatMessage>['setMessages'];
   regenerate: UseChatHelpers<ChatMessage>['regenerate'];
+  sendMessage: UseChatHelpers<ChatMessage>['sendMessage'];
   isReadonly: boolean;
   isArtifactVisible: boolean;
   requiresScrollPadding: boolean;
@@ -407,8 +409,24 @@ const PurePreviewMessage = ({
                 }
               }
 
+              if ((type as string) === 'tool-gapAnalysis') {
+                const { toolCallId, state, input } = part as any;
+
+                if (state === 'input-available' || state === 'output-available') {
+                  return (
+                    <GapAnalysisCard
+                      key={toolCallId}
+                      formName={input?.formName}
+                      availableFields={input?.availableFields ?? []}
+                      missingFields={input?.missingFields ?? []}
+                      sendMessage={sendMessage}
+                    />
+                  );
+                }
+              }
+
               // Handle any other tool calls (including web automation tools)
-              if (type.startsWith('tool-') && !['tool-getWeather', 'tool-createDocument', 'tool-updateDocument', 'tool-requestSuggestions'].includes(type)) {
+              if (type.startsWith('tool-') && !['tool-getWeather', 'tool-createDocument', 'tool-updateDocument', 'tool-requestSuggestions', 'tool-gapAnalysis'].includes(type)) {
                 const { toolCallId, state } = part as any;
 
                 if (state === 'input-available') {

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -1,7 +1,7 @@
 'use client';
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
-import { memo, useState, useRef, useEffect } from 'react';
+import { memo, useMemo, useState, useRef, useEffect } from 'react';
 import type { Vote } from '@/lib/db/schema';
 import { DocumentToolCall, DocumentToolResult } from './document';
 import { PencilEditIcon, SparklesIcon } from './icons';
@@ -29,6 +29,7 @@ import { CollapsibleWrapper } from './ui/collapsible-wrapper';
 import { getToolDisplayInfo } from './tool-icon';
 import { Spinner } from './ui/spinner';
 import { UserActionConfirmation, GapAnalysisCard } from './ai-elements';
+import { groupMessageParts, ToolCallGroup } from './tool-call-group';
 
 // Responsive min-height calculation that accounts for side-chat-header height
 // This ensures the last message has enough space to scroll properly with the header
@@ -87,6 +88,12 @@ const PurePreviewMessage = ({
     (part) => part.type === 'file',
   );
 
+  // Suppress "action required" card when the message contains a gap analysis tool
+  // (the gap analysis card itself IS the user action — don't show a duplicate prompt)
+  const hasGapAnalysis = message.parts.some(
+    (part) => (part.type as string) === 'tool-gapAnalysis',
+  );
+
   useDataStream();
 
   // Dismiss all action confirmations when user sends a new message
@@ -100,6 +107,28 @@ const PurePreviewMessage = ({
       window.removeEventListener('new-user-message', handleNewUserMessage);
     };
   }, [message.id]);
+
+  const processedParts = useMemo(
+    () => {
+      const result = groupMessageParts(message.parts ?? []);
+      // DEBUG: remove after verifying grouping works
+      const toolParts = (message.parts ?? []).filter((p) => p.type.startsWith('tool-'));
+      if (toolParts.length > 1) {
+        console.log('[tool-group] message', message.id, {
+          totalParts: (message.parts ?? []).length,
+          toolParts: toolParts.length,
+          partTypes: (message.parts ?? []).map((p) => p.type),
+          processed: result.map((r) =>
+            r.kind === 'tool-group'
+              ? `GROUP(${r.parts.length})`
+              : `pass:${r.part.type}`,
+          ),
+        });
+      }
+      return result;
+    },
+    [message.parts],
+  );
 
   return (
     <AnimatePresence>
@@ -143,7 +172,20 @@ const PurePreviewMessage = ({
               </div>
             )}
 
-            {message.parts?.map((part, index) => {
+            {processedParts.map((processed) => {
+              if (processed.kind === 'tool-group') {
+                return (
+                  <ToolCallGroup
+                    key={`message-${message.id}-group-${processed.startIndex}`}
+                    parts={processed.parts as any}
+                    messageId={message.id}
+                    startIndex={processed.startIndex}
+                  />
+                );
+              }
+
+              const { index } = processed;
+              const part = processed.part as ChatMessage['parts'][number];
               const { type } = part;
               const key = `message-${message.id}-part-${index}`;
 
@@ -223,7 +265,7 @@ const PurePreviewMessage = ({
                         </div>
                       </div>
                       
-                      {message.role === 'assistant' && requiresUserAction && !isReadonly && !isLoading && !dismissedActionConfirmations.has(message.id) && isArtifactVisible && (
+                      {message.role === 'assistant' && requiresUserAction && !hasGapAnalysis && !isReadonly && !isLoading && !dismissedActionConfirmations.has(message.id) && isArtifactVisible && (
                         <UserActionConfirmation
                           approval={{ id: `action-${message.id}`, approved: undefined }}
                           state="approval-requested"

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -16,6 +16,7 @@ interface MessagesProps {
   messages: ChatMessage[];
   setMessages: UseChatHelpers<ChatMessage>['setMessages'];
   regenerate: UseChatHelpers<ChatMessage>['regenerate'];
+  sendMessage: UseChatHelpers<ChatMessage>['sendMessage'];
   isReadonly: boolean;
   isArtifactVisible: boolean;
 }
@@ -27,6 +28,7 @@ function PureMessages({
   messages,
   setMessages,
   regenerate,
+  sendMessage,
   isReadonly,
   isArtifactVisible,
 }: MessagesProps) {
@@ -64,6 +66,7 @@ function PureMessages({
           }
           setMessages={setMessages}
           regenerate={regenerate}
+          sendMessage={sendMessage}
           isReadonly={isReadonly}
           isArtifactVisible={isArtifactVisible}
           requiresScrollPadding={

--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, Layers } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { getToolDisplayInfo } from './tool-icon';
+import { Spinner } from './ui/spinner';
+import { cn } from '@/lib/utils';
+
+// --- Types ---
+
+type MessagePart = {
+  type: string;
+  toolCallId?: string;
+  state?: string;
+  input?: any;
+  output?: any;
+  text?: string;
+  [key: string]: any;
+};
+
+export type ProcessedPart =
+  | { kind: 'tool-group'; parts: MessagePart[]; startIndex: number }
+  | { kind: 'passthrough'; part: MessagePart; index: number };
+
+// --- Constants ---
+
+// Special tools that get their own custom rendering — never grouped
+const EXCLUDED_TOOL_TYPES = new Set([
+  'tool-getWeather',
+  'tool-createDocument',
+  'tool-updateDocument',
+  'tool-requestSuggestions',
+  'tool-gapAnalysis',
+]);
+
+// Tools that are hidden or have special rendering via CollapsibleWrapper
+const HIDDEN_DISPLAY_NAMES = new Set([
+  'Updated working memory',
+  'Executed JavaScript',
+  'Retrieved participant data',
+]);
+
+// Short narration text threshold — text parts shorter than this that appear
+// between tool calls get absorbed into the group instead of breaking it.
+const NARRATION_MAX_LENGTH = 80;
+
+// Map present-participle verbs from getToolDisplayInfo → noun forms for summary
+const VERB_TO_NOUN: Record<string, string> = {
+  'clicking': 'click',
+  'clicked': 'click',
+  'filling': 'fill',
+  'filled': 'fill',
+  'selecting': 'select',
+  'selected': 'select',
+  'scrolling': 'scroll',
+  'scrolling to': 'scroll',
+  'navigating': 'navigate',
+  'navigated': 'navigate',
+  'typing': 'type',
+  'typed': 'type',
+  'pressing': 'press',
+  'pressed': 'press',
+  'hovering': 'hover',
+  'hovered': 'hover',
+  'waiting': 'wait',
+  'waited': 'wait',
+  'opening': 'navigate',
+  'reading page': 'snapshot',
+  'captured': 'snapshot',
+  'took': 'screenshot',
+  'taking screenshot': 'screenshot',
+  'double-clicking': 'click',
+  'focusing': 'focus',
+  'dragging': 'drag',
+  'performed': 'drag',
+  'uploading': 'upload',
+  'uploaded': 'upload',
+  'running script': 'evaluate',
+  'executed': 'evaluate',
+  'going back': 'navigate',
+  'going forward': 'navigate',
+  'reloading': 'navigate',
+  'closing': 'close',
+  'closed': 'close',
+  'resized': 'resize',
+  'managed': 'tabs',
+  'retrieved': 'retrieve',
+  'handled': 'dialog',
+  'installed': 'install',
+  'getting': 'get',
+  'searched': 'search',
+  'browser': 'action',
+};
+
+// --- Grouping function ---
+
+function isGroupableTool(part: MessagePart): boolean {
+  if (!part.type.startsWith('tool-')) return false;
+  if (EXCLUDED_TOOL_TYPES.has(part.type)) return false;
+
+  const { text: displayName } = getToolDisplayInfo(part.type, part.input);
+  if (HIDDEN_DISPLAY_NAMES.has(displayName)) return false;
+
+  return true;
+}
+
+// Part types that are invisible/structural and should never break a group
+const TRANSPARENT_PART_TYPES = new Set([
+  'step-start',
+  'step-finish',
+  'source',
+]);
+
+/** Parts that should be absorbed into a group without breaking it. */
+function isAbsorbable(part: MessagePart): boolean {
+  // Structural parts (step-start, step-finish) are always transparent
+  if (TRANSPARENT_PART_TYPES.has(part.type)) return true;
+  // Short narration text between tool calls gets absorbed
+  if (part.type === 'text') {
+    const text = (part.text ?? '').trim();
+    return text.length > 0 && text.length <= NARRATION_MAX_LENGTH;
+  }
+  return false;
+}
+
+export function groupMessageParts(parts: MessagePart[]): ProcessedPart[] {
+  const result: ProcessedPart[] = [];
+  // Only tool parts go into the group (text parts are absorbed/skipped, not stored)
+  let currentGroupTools: MessagePart[] = [];
+  let groupStartIndex = 0;
+  // Buffer for text parts that might be absorbed if a tool follows
+  let pendingText: { part: MessagePart; index: number } | null = null;
+
+  function flushGroup() {
+    if (currentGroupTools.length === 0) return;
+    if (currentGroupTools.length === 1) {
+      result.push({
+        kind: 'passthrough',
+        part: currentGroupTools[0],
+        index: groupStartIndex,
+      });
+    } else {
+      result.push({
+        kind: 'tool-group',
+        parts: currentGroupTools,
+        startIndex: groupStartIndex,
+      });
+    }
+    currentGroupTools = [];
+  }
+
+  function flushPendingText() {
+    if (pendingText) {
+      result.push({ kind: 'passthrough', part: pendingText.part, index: pendingText.index });
+      pendingText = null;
+    }
+  }
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+
+    if (isGroupableTool(part)) {
+      // A tool follows — absorb any pending text (don't emit it)
+      pendingText = null;
+      if (currentGroupTools.length === 0) {
+        groupStartIndex = i;
+      }
+      currentGroupTools.push(part);
+    } else if (isAbsorbable(part)) {
+      if (currentGroupTools.length > 0) {
+        // Inside a group — hold text in case a tool follows; skip structural parts
+        if (part.type === 'text') {
+          pendingText = { part, index: i };
+        }
+        // step-start/step-finish/source: silently skip
+      } else {
+        // Not in a group — pass through as normal
+        result.push({ kind: 'passthrough', part, index: i });
+      }
+    } else {
+      // Non-absorbable part: flush everything and pass through
+      flushGroup();
+      flushPendingText();
+      result.push({ kind: 'passthrough', part, index: i });
+    }
+  }
+
+  flushGroup();
+  flushPendingText();
+  return result;
+}
+
+// --- Summary generation ---
+
+function extractVerb(displayText: string): string {
+  const lower = displayText.toLowerCase();
+
+  // Try matching the longest prefix first
+  const sortedVerbs = Object.keys(VERB_TO_NOUN).sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const verb of sortedVerbs) {
+    if (lower.startsWith(verb)) {
+      return VERB_TO_NOUN[verb];
+    }
+  }
+
+  // Fallback: use first word
+  const firstWord = lower.split(/\s+/)[0];
+  return VERB_TO_NOUN[firstWord] || firstWord;
+}
+
+export function generateGroupSummary(parts: MessagePart[]): { noun: string; count: number }[] {
+  const counts: Record<string, number> = {};
+
+  for (const part of parts) {
+    const { text } = getToolDisplayInfo(part.type, part.input);
+    const noun = extractVerb(text);
+    counts[noun] = (counts[noun] || 0) + 1;
+  }
+
+  return Object.entries(counts).map(([noun, count]) => ({ noun, count }));
+}
+
+// --- Component ---
+
+interface ToolCallGroupProps {
+  parts: MessagePart[];
+  messageId: string;
+  startIndex: number;
+}
+
+export function ToolCallGroup({
+  parts,
+  messageId,
+  startIndex,
+}: ToolCallGroupProps) {
+  const [open, setOpen] = useState(false);
+
+  // Deduplicate: keep only the latest state per toolCallId
+  const deduped = deduplicateParts(parts);
+
+  // Single part → render as-is (no card wrapper)
+  if (deduped.length === 1) {
+    return <SingleToolLine part={deduped[0]} />;
+  }
+
+  // If the latest tool is still running, show it separately below the summary.
+  // Otherwise all tools are done — include everything in the summary counts.
+  const lastTool = deduped[deduped.length - 1];
+  const isLastRunning = lastTool.state === 'input-available';
+  const summaryParts = isLastRunning ? deduped.slice(0, -1) : deduped;
+
+  const summary = generateGroupSummary(summaryParts);
+
+  return (
+    <Alert className="bg-accent/25 border-accent dark:bg-accent/10 p-3">
+      <AlertDescription>
+        <Collapsible open={open} onOpenChange={setOpen}>
+          {/* Summary line — always visible, clickable to expand */}
+          <CollapsibleTrigger className="flex items-start justify-between w-full cursor-pointer gap-2">
+            <div className="flex items-start gap-2 min-w-0">
+              <Layers size={12} className="text-gray-500 shrink-0 mt-1" />
+              <div className="flex flex-wrap gap-x-1.5 gap-y-1">
+                {summary.map(({ noun, count }) => (
+                  <span
+                    key={noun}
+                    className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground whitespace-nowrap border border-accent dark:border-accent/50 rounded px-1.5 py-0.5"
+                  >
+                    {count} {count === 1 ? noun : noun + 's'}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <ChevronDown
+              size={14}
+              className={cn(
+                'text-muted-foreground transition-transform duration-200 shrink-0 mt-0.5',
+                open && 'rotate-180',
+              )}
+            />
+          </CollapsibleTrigger>
+
+          {/* Expanded: full sequential list */}
+          <CollapsibleContent>
+            <div className="flex flex-col gap-0 mt-2 border-t border-accent pt-1">
+              {(isLastRunning ? summaryParts : deduped).map((part) => (
+                <SingleToolLine
+                  key={part.toolCallId}
+                  part={part}
+                  compact
+                />
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+
+        {/* Current tool — only shown while still running */}
+        {isLastRunning && (
+          <div className="mt-1">
+            <SingleToolLine
+              part={lastTool}
+              compact
+              isRunning
+            />
+          </div>
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+// --- Helpers ---
+
+function deduplicateParts(parts: MessagePart[]): MessagePart[] {
+  const byId = new Map<string, MessagePart>();
+  for (const part of parts) {
+    const id = part.toolCallId;
+    if (!id) {
+      byId.set(`__no_id_${byId.size}`, part);
+      continue;
+    }
+    byId.set(id, part);
+  }
+  return Array.from(byId.values());
+}
+
+function SingleToolLine({
+  part,
+  compact = false,
+  isRunning = false,
+}: {
+  part: MessagePart;
+  compact?: boolean;
+  isRunning?: boolean;
+}) {
+  const { text: displayName, icon: Icon } = getToolDisplayInfo(
+    part.type,
+    part.input,
+  );
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 border-0 rounded-md',
+        compact ? 'px-1 py-1.5' : 'p-3',
+      )}
+    >
+      <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
+        {isRunning ? (
+          <Spinner className="size-3 shrink-0 text-primary" />
+        ) : (
+          Icon && <Icon size={12} className="text-gray-500 shrink-0" />
+        )}
+        {displayName}
+      </div>
+    </div>
+  );
+}

--- a/components/tool-icon.tsx
+++ b/components/tool-icon.tsx
@@ -85,6 +85,7 @@ const getToolIcon = (toolName: string) => {
     'search-participants-by-name': Search,
     'get-participant-with-household': Database,
     'updateWorkingMemory': Brain,
+    'gapAnalysis': FileText,
   };
 
   return iconMap[cleanToolName] || FileText; // Default icon
@@ -224,6 +225,7 @@ export const getToolDisplayInfo = (toolName: string, input?: any): { text: strin
     'search-participants-by-name': (input) => input?.name ? `Searched for participant "${input.name}"` : 'Searched for participant',
     'get-participant-with-household': () => 'Retrieved participant data',
     'updateWorkingMemory': () => 'Updated working memory',
+    'gapAnalysis': () => 'Gap analysis',
   };
 
   const mapper = toolMappings[cleanToolName];

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -52,9 +52,13 @@ Before filling any fields, do this:
 1. Snapshot the form to see ALL required fields
 2. Compare against the participant data you have
 3. Identify the gap: which required fields have NO matching data in the database
-4. Present ALL missing fields to the caseworker in a single message BEFORE filling anything
-5. Wait for the caseworker to provide the missing data
-6. Then fill the entire form in one pass
+4. Call the \`gapAnalysis\` tool with:
+   - \`formName\`: the name of the form (e.g. "WIC Application")
+   - \`availableFields\`: array of \`{ field, value }\` for data you have
+   - \`missingFields\`: array of \`{ field, options?, inputType?, condition? }\` for data you need
+5. **Do NOT repeat or summarize the gap analysis in a text message — the tool renders a card in the UI automatically. Any text you write after calling the tool will appear as a separate message below the card.**
+6. Wait for the caseworker to provide the missing data in the chat
+7. Then fill the entire form in one pass
 
 This prevents back-and-forth where the agent fills some fields, discovers gaps, asks, fills more, discovers more gaps, asks again.
 

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -56,9 +56,10 @@ Before filling any fields, do this:
    - \`formName\`: the name of the form (e.g. "WIC Application")
    - \`availableFields\`: array of \`{ field, value }\` for data you have
    - \`missingFields\`: array of \`{ field, options?, inputType?, condition? }\` for data you need
-5. **Do NOT repeat or summarize the gap analysis in a text message — the tool renders a card in the UI automatically. Any text you write after calling the tool will appear as a separate message below the card.**
-6. Wait for the caseworker to provide the missing data in the chat
-7. Then fill the entire form in one pass
+5. **CRITICAL: Do NOT write any text listing the available or missing fields — before OR after calling gapAnalysis. The tool renders an interactive card that already shows all of this. Any text you write listing "Data I have" / "Missing required data" will be duplicate. Just call the tool silently.**
+6. After calling gapAnalysis, write only a single short sentence like "Please provide the missing info above so I can complete the form."
+7. **STOP. Do NOT fill any fields yet. Do NOT call any browser tools after gapAnalysis. You MUST wait for the caseworker to reply with the missing data before proceeding. Your turn ends after the gap analysis message.**
+8. Once the caseworker responds with the missing data, fill the ENTIRE form in one pass (both the data you already had and the newly provided answers)
 
 This prevents back-and-forth where the agent fills some fields, discovers gaps, asks, fills more, discovers more gaps, asks again.
 

--- a/lib/ai/tools/gap-analysis.ts
+++ b/lib/ai/tools/gap-analysis.ts
@@ -1,0 +1,47 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export const gapAnalysis = tool({
+  description:
+    'Display a gap analysis card showing which participant fields are available from the database and which fields the caseworker needs to provide before filling a form. Call this BEFORE filling any form fields.',
+  inputSchema: z.object({
+    formName: z
+      .string()
+      .optional()
+      .describe('Name of the form being filled, e.g. "WIC Application"'),
+    availableFields: z
+      .array(
+        z.object({
+          field: z.string().describe('Field label'),
+          value: z.string().describe('Value from the database'),
+        }),
+      )
+      .describe('Fields we already have data for from the database'),
+    missingFields: z
+      .array(
+        z.object({
+          field: z.string().describe('Field label'),
+          options: z
+            .array(z.string())
+            .optional()
+            .describe('Possible answer options, if applicable'),
+          inputType: z
+            .enum(['text', 'select', 'date', 'boolean', 'textarea'])
+            .optional()
+            .describe('Expected input type'),
+          multiSelect: z
+            .boolean()
+            .optional()
+            .describe('Whether multiple options can be selected'),
+          condition: z
+            .string()
+            .optional()
+            .describe(
+              'Condition under which this field is required, e.g. "if pregnant"',
+            ),
+        }),
+      )
+      .describe('Fields that need caseworker input'),
+  }),
+  execute: async (input) => input,
+});


### PR DESCRIPTION
   - **Tool call grouping** — Consecutive browser automation calls (clicks, fills, selects, snapshots) collapse into a       
   single card with verb-count chips like `3 fills` `2 clicks` `1 snapshot`. Expands to show individual tools. Current
   tool shows with a spinner while running; once done, folds into the counts.                                                
     - New `tool-call-group.tsx` with `groupMessageParts()` and `ToolCallGroup` component
     - Absorbs `step-start` structural parts and short narration text between tools so they don't break groups
     - Special tools (gapAnalysis, getWeather, etc.) and hidden tools (working memory, eval) pass through unchanged

   - **Gap analysis card** — Interactive card the agent calls before filling any form. Shows available data from the
   database and collects missing fields from the caseworker via inputs, dropdowns, radios, and checkboxes.
     - New `gap-analysis-card.tsx` component and `gap-analysis.ts` tool definition
     - Registered in the AI SDK agent route

   - **Agent prompt fixes** — Agent no longer dumps a wall of text repeating the gap analysis data, stops after calling
   gapAnalysis to wait for user input, and the "action required" card no longer falsely triggers on gap analysis messages.
     - Strengthened gap analysis instructions in `web-automation.ts`
     - Added `hasGapAnalysis` guard in `message.tsx` to suppress false action-required cards

https://screen.studio/share/nKf5ii9p