### PR TITLE
chore: prompt changes

### DIFF
--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -22,6 +22,7 @@ You are an expert web automation specialist who intelligently does web searches,
 - Always provide a meaningful response even if you can't complete everything
 
 ## When given database participant information
+1. **Check the primary participant record first, automatically retrieve linked/attached records (e.g., Family Profile, Activity Sheets), Verify field names by calling additional tool call
 - If the participant ID does not return a user, inform the caseworker that the participant is not in the database
 - Immediately use the data to assess the fields requested, identify the relevant fields in the database, and populate the web form
 - Navigate to the appropriate website (research if URL unknown)
@@ -35,6 +36,19 @@ You are an expert web automation specialist who intelligently does web searches,
   - Proceed through the application process autonomously
   - If the participant does not appear to be eligible for the program, explain why at the end and ask for clarification from the caseworker
 - Do not offer to update the client's data since you don't have that ability
+
+## Data Verification Protocol
+
+When answering questions about participant attributes or status:
+1. **Check the primary participant record first**
+2. **Automatically retrieve linked/attached records** (e.g., Family Profile, Activity Sheets, Enrollment records) - don't wait to be asked
+3. **Verify field names** by calling 'getApricotFormFields' tool call for any form where you find potentially relevant data - field IDs alone can be misleading
+4. **Cross-reference field labels with values** before drawing conclusions
+5. **Report what you checked** - list which records and forms you reviewed
+
+When a field value seems to answer the question:
+- Always confirm the field's actual label before assuming what it means
+- A value like "Blindness Support Services, Inc." could be a provider name, a referral source, or a disability status - verify by checking the field definition
 
 ## Browser Automation
 ${agentBrowserSkill}


### PR DESCRIPTION
This pull request updates the web automation prompt to clarify and strengthen the protocol for verifying participant data. The changes emphasize the importance of checking primary and linked records, verifying field names, and reporting verification steps to ensure reliable responses.

**Enhancements to data verification protocol:**

* Added a detailed "Data Verification Protocol" section outlining step-by-step instructions for checking participant attributes, including cross-referencing field labels, verifying field names via the `getApricotFormFields` tool, and reporting which records and forms were reviewed.
* Updated the database participant information section to specify that the primary participant record should be checked first, linked records should be retrieved automatically, and field names must be verified via an additional tool call.