### PR TITLE
fix: fix for stop chat, kernel and tool calls

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -187,7 +187,7 @@ export async function POST(request: Request) {
             tools: {
               ...apricotTools,
               gapAnalysis,
-              browser: createBrowserTool(sessionId, session.user.id),
+              browser: createBrowserTool(sessionId, session.user.id, id),
             },
             stopWhen: stepCountIs(100),
             abortSignal: abortController.signal,

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -25,7 +25,7 @@ import { updateDocument } from '@/lib/ai/tools/update-document';
 import { requestSuggestions } from '@/lib/ai/tools/request-suggestions';
 import { getWeather } from '@/lib/ai/tools/get-weather';
 import { isProductionEnvironment } from '@/lib/constants';
-import { myProvider, webAutomationModel } from '@/lib/ai/providers';
+import { myProvider, webAutomationModel, localWebAutomationModel } from '@/lib/ai/providers';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
 import { postRequestBodySchema, type PostRequestBody } from './schema';
 import { geolocation } from '@vercel/functions';
@@ -44,6 +44,7 @@ import { apricotTools } from '@/lib/ai/tools/apricot';
 import { createBrowserTool } from '@/lib/ai/tools/browser';
 import { gapAnalysis } from '@/lib/ai/tools/gap-analysis';
 import { webAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
+import { registerAbortController, cleanupAbortController, signalAbort } from '@/lib/ai/abort-registry';
 
 // Feature flag for AI SDK agent vs Mastra
 const useAiSdkAgent = process.env.USE_AI_SDK_AGENT === 'true';
@@ -172,18 +173,23 @@ export async function POST(request: Request) {
       // Create session ID for browser isolation
       const sessionId = `${id}-${session.user.id}`;
 
+      // Register abort controller - this will abort any previous request for this chat
+      const abortController = await registerAbortController(id);
+
       const stream = createUIMessageStream({
         execute: async ({ writer: dataStream }) => {
           const result = streamText({
+            // model: localWebAutomationModel,
             model: webAutomationModel,
             system: webAutomationSystemPrompt,
             messages: await convertToModelMessages(uiMessages),
             tools: {
               ...apricotTools,
               gapAnalysis,
-              browser: createBrowserTool(sessionId),
+              browser: createBrowserTool(sessionId, id),
             },
             stopWhen: stepCountIs(100),
+            abortSignal: abortController.signal,
             experimental_telemetry: {
               isEnabled: isProductionEnvironment,
               functionId: 'web-automation-agent',
@@ -195,6 +201,8 @@ export async function POST(request: Request) {
         },
         generateId: generateUUID,
         onFinish: async ({ messages }) => {
+          // Clean up abort controller on normal completion
+          await cleanupAbortController(id);
           await saveMessages({
             messages: messages.map((message) => ({
               id: message.id,
@@ -207,6 +215,8 @@ export async function POST(request: Request) {
           });
         },
         onError: () => {
+          // Clean up abort controller on error
+          cleanupAbortController(id).catch(console.error);
           return 'Oops, an error occurred!';
         },
       });

--- a/app/(chat)/api/chat/stop/route.ts
+++ b/app/(chat)/api/chat/stop/route.ts
@@ -1,0 +1,29 @@
+import { auth } from '@/app/(auth)/auth';
+import { signalAbort } from '@/lib/ai/abort-registry';
+import { ChatSDKError } from '@/lib/errors';
+
+export async function POST(request: Request) {
+  try {
+    const { chatId } = await request.json();
+
+    if (!chatId) {
+      return new ChatSDKError('bad_request:api', 'chatId is required').toResponse();
+    }
+
+    const session = await auth();
+
+    if (!session?.user) {
+      return new ChatSDKError('unauthorized:chat').toResponse();
+    }
+
+    console.log(`[chat/stop] Stopping chat ${chatId} for user ${session.user.id}`);
+
+    // Signal abort for this chat (works across distributed instances)
+    await signalAbort(chatId);
+
+    return Response.json({ success: true });
+  } catch (error) {
+    console.error('Error stopping chat:', error);
+    return new ChatSDKError('internal_server_error:api').toResponse();
+  }
+}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -121,7 +121,25 @@ export function Chat({
 
   // Custom stop function that sends stopChat action for web automation
   const stop = async () => {
-    // Always call the original stop to abort the stream
+    // For web automation, signal abort to server FIRST and WAIT for it
+    // This ensures the abort is registered in Redis before any more tool calls can start
+    if (initialChatModel === 'web-automation-model' && useAiSdkAgent) {
+      try {
+        await fetch('/api/chat/stop', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            chatId: id,
+          }),
+        });
+      } catch (error) {
+        console.error('Error sending stop action:', error);
+      }
+    }
+
+    // Call the original stop to abort the stream
     originalStop();
 
     // Mark any running tool calls as stopped in the UI
@@ -138,39 +156,22 @@ export function Chat({
       })) as ChatMessage[]
     );
 
-    if (initialChatModel === 'web-automation-model') {
-      if (useAiSdkAgent) {
-        // For AI SDK agent, call the stop endpoint to abort server-side operations
-        try {
-          await fetch('/api/chat/stop', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              chatId: id,
-            }),
-          });
-        } catch (error) {
-          console.error('Error sending stop action:', error);
-        }
-      } else {
-        // For Mastra backend, send stopChat action
-        try {
-          await fetch('/api/mastra-proxy', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              action: 'stopChat',
-              threadId: id,
-              resourceId: session?.user?.id,
-            }),
-          });
-        } catch (error) {
-          console.error('Error sending stopChat action:', error);
-        }
+    // For Mastra backend (non-AI SDK agent), send stopChat action
+    if (initialChatModel === 'web-automation-model' && !useAiSdkAgent) {
+      try {
+        await fetch('/api/mastra-proxy', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            action: 'stopChat',
+            threadId: id,
+            resourceId: session?.user?.id,
+          }),
+        });
+      } catch (error) {
+        console.error('Error sending stopChat action:', error);
       }
     }
   };

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -124,23 +124,53 @@ export function Chat({
     // Always call the original stop to abort the stream
     originalStop();
 
-    // For web automation model using Mastra backend, also send stopChat action
-    // When using AI SDK agent, the AbortController handles stopping
-    if (initialChatModel === 'web-automation-model' && !useAiSdkAgent) {
-      try {
-        await fetch('/api/mastra-proxy', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            action: 'stopChat',
-            threadId: id,
-            resourceId: session?.user?.id,
-          }),
-        });
-      } catch (error) {
-        console.error('Error sending stopChat action:', error);
+    // Mark any running tool calls as stopped in the UI
+    setMessages((prevMessages) =>
+      prevMessages.map((msg) => ({
+        ...msg,
+        parts: msg.parts.map((part) => {
+          // If this is a tool part that's still running (input-available), mark it as stopped
+          if (part.type?.startsWith('tool-') && (part as any).state === 'input-available') {
+            return { ...part, state: 'stopped' } as unknown as typeof part;
+          }
+          return part;
+        }),
+      })) as ChatMessage[]
+    );
+
+    if (initialChatModel === 'web-automation-model') {
+      if (useAiSdkAgent) {
+        // For AI SDK agent, call the stop endpoint to abort server-side operations
+        try {
+          await fetch('/api/chat/stop', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              chatId: id,
+            }),
+          });
+        } catch (error) {
+          console.error('Error sending stop action:', error);
+        }
+      } else {
+        // For Mastra backend, send stopChat action
+        try {
+          await fetch('/api/mastra-proxy', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              action: 'stopChat',
+              threadId: id,
+              resourceId: session?.user?.id,
+            }),
+          });
+        } catch (error) {
+          console.error('Error sending stopChat action:', error);
+        }
       }
     }
   };

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -24,7 +24,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from './ui/collapsible';
-import { ChevronDown } from 'lucide-react';
+import { X } from 'lucide-react';
 import { CollapsibleWrapper } from './ui/collapsible-wrapper';
 import { getToolDisplayInfo } from './tool-icon';
 import { Spinner } from './ui/spinner';
@@ -470,6 +470,26 @@ const PurePreviewMessage = ({
               // Handle any other tool calls (including web automation tools)
               if (type.startsWith('tool-') && !['tool-getWeather', 'tool-createDocument', 'tool-updateDocument', 'tool-requestSuggestions', 'tool-gapAnalysis'].includes(type)) {
                 const { toolCallId, state } = part as any;
+
+                if (state === 'stopped') {
+                  const { input } = part as any;
+                  const { text: displayName } = getToolDisplayInfo(type, input);
+
+                  if (displayName === 'Updated working memory' || displayName === 'Executed JavaScript') {
+                    return;
+                  }
+
+                  // For stopped tools, show X icon and "(Stopped)" text
+                  return (
+                    <div key={toolCallId} className="flex items-center gap-2 p-3 border-0 rounded-md">
+                      <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground/60 flex items-center gap-2">
+                        <X size={12} className=" shrink-0" />
+                        {displayName}
+                        <span>(Stopped)</span>
+                      </div>
+                    </div>
+                  );
+                }
 
                 if (state === 'input-available') {
                   const { input } = part as any;

--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronDown, Layers } from 'lucide-react';
+import { ChevronDown, Layers, X } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
   Collapsible,
@@ -248,14 +248,22 @@ export function ToolCallGroup({
 
   // Single part → render as-is (no card wrapper)
   if (deduped.length === 1) {
-    return <SingleToolLine part={deduped[0]} />;
+    const singlePart = deduped[0];
+    return (
+      <SingleToolLine
+        part={singlePart}
+        isRunning={singlePart.state === 'input-available'}
+        isStopped={singlePart.state === 'stopped'}
+      />
+    );
   }
 
   // If the latest tool is still running, show it separately below the summary.
   // Otherwise all tools are done — include everything in the summary counts.
   const lastTool = deduped[deduped.length - 1];
   const isLastRunning = lastTool.state === 'input-available';
-  const summaryParts = isLastRunning ? deduped.slice(0, -1) : deduped;
+  const isLastStopped = lastTool.state === 'stopped';
+  const summaryParts = isLastRunning || isLastStopped ? deduped.slice(0, -1) : deduped;
 
   const summary = generateGroupSummary(summaryParts);
 
@@ -301,13 +309,14 @@ export function ToolCallGroup({
           </CollapsibleContent>
         </Collapsible>
 
-        {/* Current tool — only shown while still running */}
-        {isLastRunning && (
+        {/* Current tool — only shown while still running or stopped */}
+        {(isLastRunning || isLastStopped) && (
           <div className="mt-1">
             <SingleToolLine
               part={lastTool}
               compact
-              isRunning
+              isRunning={isLastRunning}
+              isStopped={isLastStopped}
             />
           </div>
         )}
@@ -335,10 +344,12 @@ function SingleToolLine({
   part,
   compact = false,
   isRunning = false,
+  isStopped = false,
 }: {
   part: MessagePart;
   compact?: boolean;
   isRunning?: boolean;
+  isStopped?: boolean;
 }) {
   const { text: displayName, icon: Icon } = getToolDisplayInfo(
     part.type,
@@ -351,13 +362,19 @@ function SingleToolLine({
         compact ? 'px-1 py-1.5' : 'p-3',
       )}
     >
-      <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
+      <div className={cn(
+        'text-[10px] leading-[150%] font-ibm-plex-mono flex items-center gap-2',
+        isStopped ? 'text-muted-foreground/60' : 'text-muted-foreground'
+      )}>
         {isRunning ? (
           <Spinner className="size-3 shrink-0 text-primary" />
+        ) : isStopped ? (
+          <X size={12} className="shrink-0" />
         ) : (
           Icon && <Icon size={12} className="text-gray-500 shrink-0" />
         )}
         {displayName}
+        {isStopped && <span>(Stopped)</span>}
       </div>
     </div>
   );

--- a/lib/ai/abort-registry.ts
+++ b/lib/ai/abort-registry.ts
@@ -1,0 +1,93 @@
+import { Redis } from '@upstash/redis';
+
+// Initialize Redis for distributed abort signal storage
+// This is critical for Cloud Run where multiple instances may handle requests
+const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+const REDIS_KEY_PREFIX = 'chat-abort:';
+const ABORT_TTL_SECONDS = 5 * 60; // 5 minutes
+
+// In-memory registry for local AbortControllers (per-instance)
+// When an abort signal is received via Redis pub/sub or polling, we use this to actually abort
+const globalForAbort = globalThis as typeof globalThis & {
+  abortControllers?: Map<string, AbortController>;
+};
+
+if (!globalForAbort.abortControllers) {
+  globalForAbort.abortControllers = new Map<string, AbortController>();
+}
+
+const localAbortControllers = globalForAbort.abortControllers;
+
+function getRedisKey(chatId: string): string {
+  return `${REDIS_KEY_PREFIX}${chatId}`;
+}
+
+/**
+ * Register a new AbortController for a chat.
+ * If there's an existing one, it will be aborted first.
+ * Returns the new AbortController's signal.
+ */
+export async function registerAbortController(chatId: string): Promise<AbortController> {
+  // First, signal any previous request to abort (distributed)
+  await signalAbort(chatId);
+
+  // Abort any local controller
+  const existingController = localAbortControllers.get(chatId);
+  if (existingController) {
+    existingController.abort();
+  }
+
+  // Create new controller
+  const controller = new AbortController();
+  localAbortControllers.set(chatId, controller);
+
+  // Mark this chat as active in Redis
+  await redis.set(getRedisKey(chatId), { active: true, timestamp: Date.now() }, { ex: ABORT_TTL_SECONDS });
+
+  return controller;
+}
+
+/**
+ * Signal that a chat should be aborted.
+ * This sets a flag in Redis that can be polled by other instances.
+ */
+export async function signalAbort(chatId: string): Promise<void> {
+  // Mark as aborted in Redis
+  await redis.set(getRedisKey(chatId), { aborted: true, timestamp: Date.now() }, { ex: ABORT_TTL_SECONDS });
+
+  // Abort local controller if exists
+  const controller = localAbortControllers.get(chatId);
+  if (controller) {
+    controller.abort();
+    localAbortControllers.delete(chatId);
+  }
+}
+
+/**
+ * Check if a chat has been signaled to abort.
+ * Used for polling in long-running operations.
+ */
+export async function isAborted(chatId: string): Promise<boolean> {
+  const data = await redis.get<{ aborted?: boolean }>(getRedisKey(chatId));
+  return data?.aborted === true;
+}
+
+/**
+ * Clean up the abort controller for a chat.
+ * Called when the request completes normally.
+ */
+export async function cleanupAbortController(chatId: string): Promise<void> {
+  localAbortControllers.delete(chatId);
+  await redis.del(getRedisKey(chatId));
+}
+
+/**
+ * Get the local AbortController for a chat (if running on this instance).
+ */
+export function getLocalAbortController(chatId: string): AbortController | undefined {
+  return localAbortControllers.get(chatId);
+}

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -18,6 +18,7 @@ import { isTestEnvironment } from '../constants';
 
 // Anthropic model for web automation - used directly with streamText when USE_AI_SDK_AGENT=true
 export const webAutomationModel = anthropic('claude-opus-4-5-20251101');
+export const localWebAutomationModel = google('gemini-2.5-flash');
 
 export const myProvider = isTestEnvironment
   ? customProvider({

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -1,10 +1,87 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
+import { execFile, type ChildProcess } from 'child_process';
 import { createKernelBrowser } from '@/lib/kernel/browser';
+import { isAborted } from '@/lib/ai/abort-registry';
 
-const execFileAsync = promisify(execFile);
+/**
+ * Execute a command with support for early termination via abort checking.
+ * This wraps execFile to allow killing the process if the chat is aborted.
+ * Supports both AbortSignal (immediate) and Redis-based polling (distributed).
+ */
+function execFileWithAbort(
+  command: string,
+  args: string[],
+  options: { timeout?: number; maxBuffer?: number },
+  chatId?: string,
+  abortSignal?: AbortSignal
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let childProcess: ChildProcess | null = null;
+    let abortCheckInterval: NodeJS.Timeout | null = null;
+    let isCleanedUp = false;
+
+    const cleanup = () => {
+      if (isCleanedUp) return;
+      isCleanedUp = true;
+      if (abortCheckInterval) {
+        clearInterval(abortCheckInterval);
+        abortCheckInterval = null;
+      }
+    };
+
+    const killProcess = (reason: string) => {
+      if (childProcess && !childProcess.killed) {
+        console.log(`[browser-tool] Killing process: ${reason}`);
+        childProcess.kill('SIGTERM');
+        // Force kill after 1 second if SIGTERM doesn't work
+        setTimeout(() => {
+          if (childProcess && !childProcess.killed) {
+            console.log(`[browser-tool] Force killing process with SIGKILL`);
+            childProcess.kill('SIGKILL');
+          }
+        }, 1000);
+        cleanup();
+        reject({ killed: true, message: 'Command aborted by user', stdout: '', stderr: '' });
+      }
+    };
+
+    // Handle immediate abort via AbortSignal
+    if (abortSignal) {
+      if (abortSignal.aborted) {
+        reject({ killed: true, message: 'Command aborted by user', stdout: '', stderr: '' });
+        return;
+      }
+      abortSignal.addEventListener('abort', () => {
+        killProcess('AbortSignal fired');
+      }, { once: true });
+    }
+
+    childProcess = execFile(command, args, options, (error, stdout, stderr) => {
+      cleanup();
+
+      if (error) {
+        reject({ ...error, stdout, stderr });
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+
+    // If we have a chatId, periodically check if we should abort (for distributed abort across instances)
+    if (chatId) {
+      abortCheckInterval = setInterval(async () => {
+        try {
+          const shouldAbort = await isAborted(chatId);
+          if (shouldAbort) {
+            killProcess(`Redis abort signal for chat ${chatId}`);
+          }
+        } catch (err) {
+          // Ignore errors from abort check
+        }
+      }, 500); // Check every 500ms
+    }
+  });
+}
 
 /**
  * Parse a command string into an array of arguments, respecting quoted strings.
@@ -49,10 +126,13 @@ function parseCommand(command: string): string[] {
  * The tool connects to a Kernel.sh managed browser instance and executes
  * commands using the agent-browser CLI.
  *
+ * @param sessionId - The browser session ID for Kernel
+ * @param chatId - Optional chat ID for abort signal checking
+ *
  * @see https://www.kernel.sh/docs/integrations/agent-browser
  * @see https://agent-browser.dev/commands
  */
-export const createBrowserTool = (sessionId: string) =>
+export const createBrowserTool = (sessionId: string, chatId?: string) =>
   tool({
     description: `Execute browser automation commands using agent-browser CLI connected to a remote Kernel browser.
 
@@ -106,8 +186,27 @@ eval is only acceptable for reading values (e.g. checking if an element exists).
     inputSchema: z.object({
       command: z.string().describe('The agent-browser command to execute'),
     }),
-    execute: async ({ command }: { command: string }) => {
+    execute: async ({ command }: { command: string }, { abortSignal }: { abortSignal?: AbortSignal } = {}) => {
       try {
+        // Check if already aborted before starting (via signal or Redis)
+        if (abortSignal?.aborted) {
+          return {
+            success: false,
+            output: null,
+            error: 'Operation was stopped by user',
+          };
+        }
+        if (chatId) {
+          const shouldAbort = await isAborted(chatId);
+          if (shouldAbort) {
+            return {
+              success: false,
+              output: null,
+              error: 'Operation was stopped by user',
+            };
+          }
+        }
+
         // Ensure we have a Kernel browser instance for this session
         // This creates a new browser or returns existing one
         const browser = await createKernelBrowser(sessionId);
@@ -115,16 +214,17 @@ eval is only acceptable for reading values (e.g. checking if an element exists).
 
         console.log('[browser-tool] Session:', sessionId);
         console.log('[browser-tool] CDP URL:', cdpUrl);
+        if (chatId) console.log('[browser-tool] ChatId (for abort):', chatId);
 
         // Use --cdp flag to connect agent-browser to Kernel's browser via CDP WebSocket
         // Use execFile (no shell) so URLs with #, &, ? etc. aren't mangled by the shell
         const args = ['agent-browser', '--cdp', cdpUrl, ...parseCommand(command)];
         console.log('[browser-tool] Executing: npx', args.join(' '));
 
-        const { stdout, stderr } = await execFileAsync('npx', args, {
+        const { stdout, stderr } = await execFileWithAbort('npx', args, {
           timeout: 120000, // 2 minute timeout per command
           maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large snapshots
-        });
+        }, chatId, abortSignal);
 
         console.log('[browser-tool] Success. stdout length:', stdout?.length);
         if (stderr) console.log('[browser-tool] stderr:', stderr);
@@ -151,8 +251,16 @@ eval is only acceptable for reading values (e.g. checking if an element exists).
           stdout: execError.stdout,
         });
 
-        // Handle timeout specifically
+        // Handle abort/timeout specifically
         if (execError.killed) {
+          // Check if this was an abort or a timeout
+          if (execError.message === 'Command aborted by user') {
+            return {
+              success: false,
+              output: null,
+              error: 'Operation was stopped by user',
+            };
+          }
           return {
             success: false,
             output: null,

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -34,14 +34,12 @@ function execFileWithAbort(
       }
     };
 
-    const killProcess = (reason: string) => {
+    const killProcess = () => {
       if (childProcess && !childProcess.killed) {
-        console.log(`[browser-tool] Killing process: ${reason}`);
         childProcess.kill('SIGTERM');
         // Force kill after 1 second if SIGTERM doesn't work
         setTimeout(() => {
           if (childProcess && !childProcess.killed) {
-            console.log(`[browser-tool] Force killing process with SIGKILL`);
             childProcess.kill('SIGKILL');
           }
         }, 1000);
@@ -57,7 +55,7 @@ function execFileWithAbort(
         return;
       }
       abortSignal.addEventListener('abort', () => {
-        killProcess('AbortSignal fired');
+        killProcess();
       }, { once: true });
     }
 
@@ -72,17 +70,18 @@ function execFileWithAbort(
     });
 
     // If we have a chatId, periodically check if we should abort (for distributed abort across instances)
+    // Use 100ms interval for faster detection of abort signals
     if (chatId) {
       abortCheckInterval = setInterval(async () => {
         try {
           const shouldAbort = await isAborted(chatId);
           if (shouldAbort) {
-            killProcess(`Redis abort signal for chat ${chatId}`);
+            killProcess();
           }
         } catch (err) {
           // Ignore errors from abort check
         }
-      }, 500); // Check every 500ms
+      }, 100);
     }
   });
 }
@@ -130,13 +129,14 @@ function parseCommand(command: string): string[] {
  * The tool connects to a Kernel.sh managed browser instance and executes
  * commands using the agent-browser CLI.
  *
- * @param sessionId - The chat/session ID for browser isolation
+ * @param sessionId - The browser session ID for Kernel isolation
  * @param userId - The user ID for ownership validation and security
+ * @param chatId - Optional chat ID for abort signal checking
  *
  * @see https://www.kernel.sh/docs/integrations/agent-browser
  * @see https://agent-browser.dev/commands
  */
-export const createBrowserTool = (sessionId: string, userId: string) =>
+export const createBrowserTool = (sessionId: string, userId: string, chatId?: string) =>
   tool({
     description: `Execute browser automation commands using agent-browser CLI connected to a remote Kernel browser.
 
@@ -190,24 +190,19 @@ eval is only acceptable for reading values (e.g. checking if an element exists).
     inputSchema: z.object({
       command: z.string().describe('The agent-browser command to execute'),
     }),
-    execute: async ({ command }: { command: string }, { abortSignal }: { abortSignal?: AbortSignal } = {}) => {
+    execute: async ({ command }: { command: string }, options: { abortSignal?: AbortSignal } = {}) => {
+      const { abortSignal } = options;
+
       try {
         // Check if already aborted before starting (via signal or Redis)
+        // Throw error instead of returning result to stop AI SDK from retrying
         if (abortSignal?.aborted) {
-          return {
-            success: false,
-            output: null,
-            error: 'Operation was stopped by user',
-          };
+          throw new Error('ABORT: Operation was stopped by user');
         }
         if (chatId) {
           const shouldAbort = await isAborted(chatId);
           if (shouldAbort) {
-            return {
-              success: false,
-              output: null,
-              error: 'Operation was stopped by user',
-            };
+            throw new Error('ABORT: Operation was stopped by user');
           }
         }
 
@@ -217,22 +212,25 @@ eval is only acceptable for reading values (e.g. checking if an element exists).
         await recordAgentActivity(sessionId, userId);
         const cdpUrl = browser.cdp_ws_url;
 
-        console.log('[browser-tool] Session:', sessionId);
-        console.log('[browser-tool] CDP URL:', cdpUrl);
-        if (chatId) console.log('[browser-tool] ChatId (for abort):', chatId);
+        // Check abort again after browser setup (might have taken time)
+        if (abortSignal?.aborted) {
+          throw new Error('ABORT: Operation was stopped by user');
+        }
+        if (chatId) {
+          const shouldAbort = await isAborted(chatId);
+          if (shouldAbort) {
+            throw new Error('ABORT: Operation was stopped by user');
+          }
+        }
 
         // Use --cdp flag to connect agent-browser to Kernel's browser via CDP WebSocket
         // Use execFile (no shell) so URLs with #, &, ? etc. aren't mangled by the shell
         const args = ['agent-browser', '--cdp', cdpUrl, ...parseCommand(command)];
-        console.log('[browser-tool] Executing: npx', args.join(' '));
 
         const { stdout, stderr } = await execFileWithAbort('npx', args, {
           timeout: 120000, // 2 minute timeout per command
           maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large snapshots
         }, chatId, abortSignal);
-
-        console.log('[browser-tool] Success. stdout length:', stdout?.length);
-        if (stderr) console.log('[browser-tool] stderr:', stderr);
 
         return {
           success: true,
@@ -242,6 +240,11 @@ eval is only acceptable for reading values (e.g. checking if an element exists).
           error: null,
         };
       } catch (error: unknown) {
+        // Re-throw ABORT errors to stop the AI SDK from retrying
+        if (error instanceof Error && error.message.startsWith('ABORT:')) {
+          throw error;
+        }
+
         const execError = error as {
           killed?: boolean;
           stdout?: string;
@@ -249,22 +252,12 @@ eval is only acceptable for reading values (e.g. checking if an element exists).
           message?: string;
         };
 
-        console.error('[browser-tool] Error:', {
-          killed: execError.killed,
-          message: execError.message,
-          stderr: execError.stderr,
-          stdout: execError.stdout,
-        });
-
         // Handle abort/timeout specifically
         if (execError.killed) {
           // Check if this was an abort or a timeout
           if (execError.message === 'Command aborted by user') {
-            return {
-              success: false,
-              output: null,
-              error: 'Operation was stopped by user',
-            };
+            // Re-throw to stop AI SDK
+            throw new Error('ABORT: Operation was stopped by user');
           }
           return {
             success: false,


### PR DESCRIPTION
Fix: Stop action now properly stops browser tool calls and updates UI                                                                                             
                                                                                                                                                                  
 ## Problem                                                                                                                                                           
   
  **When clicking the stop button during web automation:**                                                                                                              
  - The spinner continued showing instead of an X icon                                                                                                            
  - Browser actions continued running in the background

 ## Solution

  **UI Changes:**
  - chat.tsx: Stop function now marks running tools as stopped state
  - tool-call-group.tsx: Added stopped state handling with X icon and "(Stopped)" text
  - message.tsx: Added stopped state handling for non-grouped tools

  **Browser Tool Changes:**
  - browser.ts: Enhanced abort handling with:
    - Native AbortSignal support for immediate cancellation
    - SIGKILL fallback after 1s if SIGTERM doesn't work
    - Both immediate (AbortSignal) and distributed (Redis polling) abort mechanisms

## Files Changed

  - `components/chat.tsx`
  - `components/tool-call-group.tsx`
  - `components/message.tsx`
  - `lib/ai/tools/browser.ts`

## Testing

  - Click stop during active browser automation
  - Verify spinner changes to X icon with "(Stopped)" text
  - Verify browser commands actually stop executing