### PR TITLE
fix: fix for glitches in the kernel browser

### DIFF
--- a/artifacts/browser/client-kernel.tsx
+++ b/artifacts/browser/client-kernel.tsx
@@ -438,14 +438,18 @@ export function KernelBrowserClient({
                   <BrowserLoadingState />
                 ) : (
                   <div className="h-full flex items-center justify-center">
-                    <iframe
-                      key={liveViewUrl}
-                      src={iframeUrl || undefined}
-                      className="max-w-full max-h-full border-0 bg-white rounded-lg shadow-lg"
+                    <div
+                      className="relative w-full max-h-full"
                       style={{ aspectRatio: '4 / 3' }}
-                      allow="clipboard-read; clipboard-write"
-                      title="Browser View"
-                    />
+                    >
+                      <iframe
+                        key={liveViewUrl}
+                        src={iframeUrl || undefined}
+                        className="absolute inset-0 w-full h-full border-0 bg-white rounded-lg shadow-lg"
+                        allow="clipboard-read; clipboard-write"
+                        title="Browser View"
+                      />
+                    </div>
                   </div>
                 )}
               </div>
@@ -490,17 +494,21 @@ export function KernelBrowserClient({
         </div>
       )}
 
-      {/* Browser iframe - matches client.tsx layout: flex-1 relative m-4 with centered content */}
+      {/* Browser iframe - wrapper div handles aspect ratio, iframe fills wrapper */}
       <div className="flex-1 relative m-4 overflow-hidden min-h-0">
         <div className="absolute inset-0 flex items-center justify-center">
-          <iframe
-            key={liveViewUrl}
-            src={iframeUrl || undefined}
-            className="max-w-full max-h-full border-0 bg-white rounded-lg"
+          <div
+            className="relative w-full max-h-full"
             style={{ aspectRatio: '16 / 9' }}
-            allow="clipboard-read; clipboard-write"
-            title="Browser View"
-          />
+          >
+            <iframe
+              key={liveViewUrl}
+              src={iframeUrl || undefined}
+              className="absolute inset-0 w-full h-full border-0 bg-white rounded-lg"
+              allow="clipboard-read; clipboard-write"
+              title="Browser View"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/artifacts/browser/client-kernel.tsx
+++ b/artifacts/browser/client-kernel.tsx
@@ -407,7 +407,7 @@ export function KernelBrowserClient({
 
               {/* Control mode indicator */}
               {isConnected && (
-                <div className="flex items-center justify-between py-2 px-4 bg-muted/20">
+                <div className="flex-shrink-0 flex items-center justify-between py-2 px-4 bg-muted/20">
                   <AgentStatusIndicator
                     chatStatus={chatStatus}
                     controlMode={controlMode}
@@ -431,23 +431,21 @@ export function KernelBrowserClient({
               )}
 
               {/* Browser content */}
-              <div className="flex-1 overflow-y-scroll p-4">
+              <div className="flex-1 overflow-hidden min-h-0 p-4">
                 {error ? (
                   <BrowserErrorState onRetry={initBrowser} />
                 ) : !isConnected ? (
                   <BrowserLoadingState />
                 ) : (
-                  <div className="flex items-center justify-center">
-                    <div className="relative w-full max-w-[768px] bg-white rounded-lg shadow-lg">
-                      <iframe
-                        key={liveViewUrl}
-                        src={iframeUrl || undefined}
-                        className="w-full border-0 bg-white rounded-lg"
-                        style={{ aspectRatio: '4 / 3' }}
-                        allow="clipboard-read; clipboard-write"
-                        title="Browser View"
-                      />
-                    </div>
+                  <div className="h-full flex items-center justify-center">
+                    <iframe
+                      key={liveViewUrl}
+                      src={iframeUrl || undefined}
+                      className="max-w-full max-h-full border-0 bg-white rounded-lg shadow-lg"
+                      style={{ aspectRatio: '4 / 3' }}
+                      allow="clipboard-read; clipboard-write"
+                      title="Browser View"
+                    />
                   </div>
                 )}
               </div>
@@ -463,7 +461,7 @@ export function KernelBrowserClient({
     <div className="h-full flex flex-col">
       {/* Control mode indicator and buttons */}
       {isConnected && (
-        <div className="flex items-center justify-between py-2 bg-muted/20">
+        <div className="flex-shrink-0 flex items-center justify-between py-2 bg-muted/20">
           <AgentStatusIndicator
             chatStatus={chatStatus}
             controlMode={controlMode}
@@ -493,12 +491,12 @@ export function KernelBrowserClient({
       )}
 
       {/* Browser iframe - matches client.tsx layout: flex-1 relative m-4 with centered content */}
-      <div className="flex-1 relative m-4">
+      <div className="flex-1 relative m-4 overflow-hidden min-h-0">
         <div className="absolute inset-0 flex items-center justify-center">
           <iframe
             key={liveViewUrl}
             src={iframeUrl || undefined}
-            className="w-full border-0 bg-white rounded-lg"
+            className="max-w-full max-h-full border-0 bg-white rounded-lg"
             style={{ aspectRatio: '16 / 9' }}
             allow="clipboard-read; clipboard-write"
             title="Browser View"

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -805,7 +805,7 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
               
               {/* Control mode indicator */}
               {metadata.isConnected && (
-                <div className="flex items-center justify-between py-2 px-4 bg-muted/20">
+                <div className="flex-shrink-0 flex items-center justify-between py-2 px-4 bg-muted/20">
                   <AgentStatusIndicator
                     chatStatus={chatStatus}
                     controlMode={metadata.controlMode}
@@ -831,8 +831,8 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
                   </Button>
                 </div>
               )}
-              {/* Browser content with scroll */}
-              <div className="flex-1 overflow-y-scroll p-4">
+              {/* Browser content */}
+              <div className="flex-1 overflow-hidden min-h-0 p-4">
                 {metadata.error ? (
                   <BrowserErrorState onRetry={connectToBrowserStream} />
                 ) : !metadata.isConnected ? (
@@ -886,7 +886,7 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
       <div className="h-full flex flex-col">
         {/* Control mode indicator */}
         {metadata.isConnected && (
-          <div className="flex items-center justify-between py-2 bg-muted/20">
+          <div className="flex-shrink-0 flex items-center justify-between py-2 bg-muted/20">
             <AgentStatusIndicator
               chatStatus={chatStatus}
               controlMode={metadata.controlMode}
@@ -908,7 +908,7 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
           </div>
         )}
         {/* Main browser display area */}
-        <div className="flex-1 relative m-4">
+        <div className="flex-1 relative m-4 overflow-hidden min-h-0">
           {renderBrowserContent()}
           </div>
         </div>


### PR DESCRIPTION
## Summary                                                                                                                                                           
                                                                                                                                                                    
  - Fix browser iframe/canvas not responding to height changes in browser viewing mode                                                                              
  - Prevent layout thrashing when resizing (rapidly switching between pixel values)                                                                               
  - Ensure control bar buttons remain visible and don't get covered by browser content

### Changes

  `client-kernel.tsx:`
  - Changed iframe from w-full to max-w-full max-h-full to properly constrain based on both width and height while respecting aspect ratio
  - Added flex-shrink-0 to control bar to prevent compression
  - Added overflow-hidden min-h-0 to browser container to prevent overflow and stabilize flex layout

  `client.tsx:`
  - Added flex-shrink-0 to control bars (mobile and desktop)
  - Changed mobile content container to overflow-hidden min-h-0
  - Added overflow-hidden min-h-0 to desktop browser display area

### Test plan

  - Resize browser panel height and verify iframe scales proportionally
  - Verify no black bars appear around browser content
  - Verify "Take control" button remains visible during resize
  - Verify no layout thrashing (rapid size flickering) occurs
  - Test on mobile view in browser sheet