### PR TITLE
chore: vertex ai model change

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -25,7 +25,7 @@ import { updateDocument } from '@/lib/ai/tools/update-document';
 import { requestSuggestions } from '@/lib/ai/tools/request-suggestions';
 import { getWeather } from '@/lib/ai/tools/get-weather';
 import { isProductionEnvironment } from '@/lib/constants';
-import { myProvider, webAutomationModel } from '@/lib/ai/providers';
+import { myProvider, vertexModel, webAutomationModel } from '@/lib/ai/providers';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
 import { postRequestBodySchema, type PostRequestBody } from './schema';
 import { geolocation } from '@vercel/functions';
@@ -176,7 +176,8 @@ export async function POST(request: Request) {
       const stream = createUIMessageStream({
         execute: async ({ writer: dataStream }) => {
           const result = streamText({
-            model: webAutomationModel,
+            // model: webAutomationModel,
+            model: vertexModel,
             system: webAutomationSystemPrompt,
             messages: await convertToModelMessages(uiMessages),
             tools: {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -19,8 +19,8 @@ import { isTestEnvironment } from '../constants';
 
 // Anthropic model for web automation - used directly with streamText when USE_AI_SDK_AGENT=true
 export const webAutomationModel = anthropic('claude-opus-4-5-20251101');
-// Vertex AI model
-export const vertexModel = vertex('gemini-2.0-flash');
+// Claude Sonnet 4.5 via Vertex AI
+export const vertexModel = vertex('claude-sonnet-4-5@20250514');
 
 export const myProvider = isTestEnvironment
   ? customProvider({

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -6,6 +6,7 @@ import {
 import { xai } from '@ai-sdk/xai';
 import { openai } from '@ai-sdk/openai';
 import { google } from '@ai-sdk/google';
+import { vertex } from '@ai-sdk/google-vertex';
 import { anthropic } from '@ai-sdk/anthropic';
 import { gateway } from '@ai-sdk/gateway';
 import {
@@ -18,6 +19,8 @@ import { isTestEnvironment } from '../constants';
 
 // Anthropic model for web automation - used directly with streamText when USE_AI_SDK_AGENT=true
 export const webAutomationModel = anthropic('claude-opus-4-5-20251101');
+// Vertex AI model
+export const vertexModel = vertex('gemini-2.0-flash');
 
 export const myProvider = isTestEnvironment
   ? customProvider({


### PR DESCRIPTION
This pull request updates the chat API to introduce support for Google's Vertex AI as a provider, specifically using the Claude Sonnet 4.5 model. The main change is switching the model used for web automation from Anthropic's Claude Opus to Claude Sonnet 4.5 via Vertex AI, and adding the necessary provider integration.

**Provider Integration Updates:**

* Added the Vertex AI provider import (`vertex`) to `lib/ai/providers.ts` and defined a new `vertexModel` using Claude Sonnet 4.5. [[1]](diffhunk://#diff-db03cd0ad5ff417e9fd6e922e1003333aa8f3eaec0cddebb7194275809e49612R9) [[2]](diffhunk://#diff-db03cd0ad5ff417e9fd6e922e1003333aa8f3eaec0cddebb7194275809e49612R22-R23)

**Chat API Model Selection:**

* Updated the chat API route to use the new `vertexModel` (Claude Sonnet 4.5 via Vertex AI) instead of the previous `webAutomationModel` (Anthropic Claude Opus) for web automation tasks. [[1]](diffhunk://#diff-dee1550b5ed5afa23c207445438b6542ca172911418ae471e2e285f01ada6469L28-R28) [[2]](diffhunk://#diff-dee1550b5ed5afa23c207445438b6542ca172911418ae471e2e285f01ada6469L179-R180)