### PR TITLE
fix: add in disconnect and idle timeout

### DIFF
--- a/app/api/kernel-browser/route.ts
+++ b/app/api/kernel-browser/route.ts
@@ -4,6 +4,7 @@ import {
   deleteBrowser,
   refreshSession,
 } from '@/lib/kernel/browser';
+import { stopWorker } from '@/lib/kernel/command-worker';
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -40,6 +41,9 @@ export async function POST(request: Request) {
     }
 
     if (action === 'delete') {
+      // Stop the command worker first so it doesn't keep executing commands
+      // on a browser that's about to be destroyed, racing with the stream deletion.
+      stopWorker(userId, sessionId);
       await deleteBrowser(sessionId, userId);
       return Response.json({ success: true });
     }

--- a/artifacts/browser/client-kernel.tsx
+++ b/artifacts/browser/client-kernel.tsx
@@ -32,6 +32,14 @@ interface BrowserStatusEvent {
   timestamp: string;
 }
 
+// =============================================================================
+// Idle timeout: disconnect after 5 minutes of no user interaction.
+// The agent idle timeout (server-side, 5 min) covers agent inactivity.
+// This covers user inactivity (e.g., user walks away from computer).
+// =============================================================================
+const USER_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const IDLE_CHECK_INTERVAL_MS = 30_000; // Check every 30 seconds
+
 interface KernelBrowserClientProps {
   sessionId: string;
   controlMode: 'agent' | 'user';
@@ -86,6 +94,10 @@ export function KernelBrowserClient({
   // Keep sessionId in a ref so the beforeunload handler always has the latest value
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
+
+  // Keep chatStatus in a ref so idle timeout can check without re-running effect
+  const chatStatusRef = useRef(chatStatus);
+  chatStatusRef.current = chatStatus;
 
   // =========================================================================
   // Heartbeat — simple TTL refresh + URL change detection
@@ -313,13 +325,102 @@ export function KernelBrowserClient({
     };
   }, []);
 
-  // Cleanup heartbeat and SSE on unmount
+  // Cleanup on unmount: stop heartbeat, SSE, and delete browser session.
+  // This handles SPA navigation (e.g., switching chats). Full page navigation
+  // is handled by the beforeunload sendBeacon above.
   useEffect(() => {
     return () => {
       stopHeartbeat();
       stopEventSource();
+
+      if (isConnectedRef.current) {
+        fetch('/api/kernel-browser', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'delete',
+            sessionId: sessionIdRef.current,
+          }),
+        }).catch(() => {
+          // Best-effort cleanup
+        });
+      }
     };
   }, [stopHeartbeat, stopEventSource]);
+
+  // =========================================================================
+  // User idle timeout — disconnect after prolonged user inactivity.
+  // Tracks mouse, keyboard, scroll, touch, and visibility events.
+  // Pauses while the agent is actively streaming (user may be watching).
+  // =========================================================================
+  useEffect(() => {
+    if (!isConnected) return;
+
+    let lastUserActivity = Date.now();
+
+    const onActivity = () => {
+      lastUserActivity = Date.now();
+    };
+
+    const activityEvents = [
+      'mousemove',
+      'mousedown',
+      'keydown',
+      'scroll',
+      'touchstart',
+    ];
+    activityEvents.forEach((event) => {
+      document.addEventListener(event, onActivity, { passive: true });
+    });
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        onActivity();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    const idleCheckInterval = setInterval(() => {
+      // Don't time out while the agent is actively working
+      const status = chatStatusRef.current;
+      if (status === 'streaming' || status === 'submitted') {
+        lastUserActivity = Date.now();
+        return;
+      }
+
+      if (Date.now() - lastUserActivity > USER_IDLE_TIMEOUT_MS) {
+        clearInterval(idleCheckInterval);
+        console.log(
+          '[Kernel] User idle timeout — disconnecting browser session',
+        );
+
+        fetch('/api/kernel-browser', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'delete',
+            sessionId: sessionIdRef.current,
+          }),
+        }).catch(() => {});
+
+        setSessionExpired(true);
+        setLiveViewUrl(null);
+        setIsConnected(false);
+        onConnectionChangeRef.current?.(false);
+        stopHeartbeat();
+        stopEventSource();
+        toast.info('Browser session closed due to inactivity');
+      }
+    }, IDLE_CHECK_INTERVAL_MS);
+
+    return () => {
+      clearInterval(idleCheckInterval);
+      activityEvents.forEach((event) => {
+        document.removeEventListener(event, onActivity);
+      });
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [isConnected, stopHeartbeat, stopEventSource]);
 
   // Track previous chatStatus to detect when the chat stops.
   // When chatStatus transitions from 'streaming'/'submitted' → 'ready'/'error',


### PR DESCRIPTION
## Changes made to client/artifacts/browser/client-kernel.tsx                                                                                                        
                                                                                                                                                                    
  1. Disconnect on navigate away (SPA navigation)                                                                                                                   
  - Lines 328-349: Modified the unmount cleanup effect to call the delete API when the component unmounts while still connected. Previously, unmount only stopped
  the heartbeat and SSE — the browser session was left orphaned.
  - This covers: switching chats, clicking "New Chat", browser back/forward — any SPA navigation that unmounts the component.
  - Full page navigation (refresh, closing tab) is still handled by the existing beforeunload + sendBeacon handler (line 284-304).

  2. Client-side idle timeout
  - Lines 40-41: Added USER_IDLE_TIMEOUT_MS (5 min) and IDLE_CHECK_INTERVAL_MS (30s) constants.
  - Lines 98-100: Added chatStatusRef to track chat status without triggering effect re-runs.
  - Lines 351-423: New useEffect that:
    - Listens for user activity (mousemove, mousedown, keydown, scroll, touchstart, visibility change)
    - Checks every 30 seconds if the user has been idle for >5 minutes
    - Pauses the timer while the agent is actively streaming (chatStatus === 'streaming' || 'submitted'), so users watching the agent work aren't timed out
    - When triggered: deletes the browser session via API, shows the BrowserTimeoutState with a retry button, and displays a toast notification