### PR TITLE
chore: switch model to sonnet

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -18,7 +18,7 @@ import {
 import { isTestEnvironment } from '../constants';
 
 // Anthropic model for web automation via Vertex AI
-export const webAutomationModel = vertexAnthropic('claude-opus-4-6');
+export const webAutomationModel = vertexAnthropic('claude-sonnet-4-5');
 
 export const myProvider = isTestEnvironment
   ? customProvider({


### PR DESCRIPTION
This pull request makes a small update to the AI provider configuration by switching the web automation model from `claude-opus-4-6` to `claude-sonnet-4-5`. This change likely aims to improve performance, cost, or compatibility.

- Changed the `webAutomationModel` export in `lib/ai/providers.ts` to use `claude-sonnet-4-5` instead of `claude-opus-4-6`.