### PR TITLE
fix: css fixes for design with skip logic to gap analysis

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -462,7 +462,7 @@ const PurePreviewMessage = ({
                     return;
                   }
                   // Only use CollapsibleWrapper for get-participant-with-household
-                  if (displayName === 'Retrieved participant data') {
+                  if (displayName === 'GetApricotRecord') {
                     return (
                       <CollapsibleWrapper key={toolCallId} displayName={displayName} input={input} icon={Icon} />
                     );
@@ -490,7 +490,7 @@ const PurePreviewMessage = ({
                   }
 
                   // Only use CollapsibleWrapper for get-participant-with-household
-                  if (displayName === 'Retrieved participant data') {
+                  if (displayName === 'GetApricotRecord') {
                     // Check for actual error value, not just presence of 'error' key
                     const hasParticipantError = output && 'error' in output && output.error;
                     return (

--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -9,6 +9,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { getToolDisplayInfo } from './tool-icon';
+import { Button } from './ui/button';
 import { Spinner } from './ui/spinner';
 import { cn } from '@/lib/utils';
 
@@ -260,7 +261,7 @@ export function ToolCallGroup({
   const summary = generateGroupSummary(summaryParts);
 
   return (
-    <Alert className="bg-accent/25 border-accent dark:bg-accent/10 p-3">
+    <Alert className="rounded-xl border-accent bg-background p-3">
       <AlertDescription>
         <Collapsible open={open} onOpenChange={setOpen}>
           {/* Summary line — always visible, clickable to expand */}
@@ -271,25 +272,28 @@ export function ToolCallGroup({
                 {summary.map(({ noun, count }) => (
                   <span
                     key={noun}
-                    className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground whitespace-nowrap border border-accent dark:border-accent/50 rounded px-1.5 py-0.5"
+                    className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground whitespace-nowrap border border-border rounded px-1.5 py-0.5"
                   >
                     {count} {count === 1 ? noun : noun + 's'}
                   </span>
                 ))}
               </div>
             </div>
-            <ChevronDown
-              size={14}
-              className={cn(
-                'text-muted-foreground transition-transform duration-200 shrink-0 mt-0.5',
-                open && 'rotate-180',
-              )}
-            />
+            <Button variant="ghost" size="sm" className="p-1 h-auto text-muted-foreground hover:text-primary hover:bg-accent">
+              <ChevronDown
+                size={14}
+                className={cn(
+                  'transition-transform duration-200',
+                  open && 'rotate-180',
+                )}
+              />
+              <span className="sr-only">Toggle details</span>
+            </Button>
           </CollapsibleTrigger>
 
           {/* Expanded: full sequential list */}
           <CollapsibleContent>
-            <div className="flex flex-col gap-0 mt-2 border-t border-accent pt-1">
+            <div className="flex flex-col gap-0 mt-2 border-t border-border pt-1">
               {(isLastRunning ? summaryParts : deduped).map((part) => (
                 <SingleToolLine
                   key={part.toolCallId}

--- a/components/ui/collapsible-wrapper.tsx
+++ b/components/ui/collapsible-wrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronDown, ChevronUp, CircleCheck } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import {
   Collapsible,
   CollapsibleContent,
@@ -29,7 +29,7 @@ export function CollapsibleWrapper({
 }: CollapsibleWrapperProps) {
   const [open, setOpen] = useState(false);
   
-  const baseClassName = isError ? "border-0 rounded-md" : "border-0 rounded-md";
+  const baseClassName = "rounded-xl border border-accent bg-background";
   const finalClassName = className ? `${baseClassName} ${className}` : baseClassName;
   
   return (
@@ -45,13 +45,13 @@ export function CollapsibleWrapper({
         </div>
         <CollapsibleTrigger asChild>
           <Button variant="ghost" size="sm" className="p-1 h-auto text-muted-foreground hover:text-primary hover:bg-accent">
-            {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            <ChevronDown className={`h-4 w-4 transition-transform duration-200 ${open ? 'rotate-180' : ''}`} />
             <span className="sr-only">Toggle details</span>
           </Button>
         </CollapsibleTrigger>
       </div>
       <CollapsibleContent className="px-3 pb-3">
-        <div className="border-t pt-3">
+        <div className="border-t border-border pt-3">
           {input && !isError && (
             <>
               <div className="text-xs text-muted-foreground mb-2">Input:</div>


### PR DESCRIPTION
## Summary                                                                                                                                                                       
                        
  - **Restyle card components to match Figma design**: Updated `gap-analysis-card`, `tool-call-group`, and `collapsible-wrapper` from the old accent-tinted backgrounds            
  (`bg-accent/25 border-accent dark:bg-accent/10`) to clean white cards with `rounded-xl border-accent bg-background` styling
  - **Add "Skip for now" to gap analysis card**: New secondary button alongside Submit that sends a skip message to the agent (`"Skipped ... for now. Please continue with the next
   step."`) and transitions to a compact dismissed state showing the question with a "SKIPPED" label                                                                               
  - **Unify chevron behavior**: Both `tool-call-group` and `collapsible-wrapper` now use the same ghost `Button`-wrapped `ChevronDown` with `rotate-180` animation on open and
  matching hover styles (`hover:text-primary hover:bg-accent`)

  ## Files changed

  | File | Changes |
  |------|---------|
  | `gap-analysis-card.tsx` | New card styling, `isSkipped` prop, `handleSkip()` with chat message, dismissed state, "Select all that apply" hint, Submit + Skip button row |
  | `tool-call-group.tsx` | Card restyled, chevron wrapped in ghost Button with rotate animation, inner borders updated to `border-border` |
  | `collapsible-wrapper.tsx` | Card restyled, `ChevronUp`/`ChevronDown` swap replaced with single rotating `ChevronDown`, inner border updated |
  | `message.tsx` | Updated `CollapsibleWrapper` display name check from `'Retrieved participant data'` to `'GetApricotRecord'` |

## Testing

<img width="852" height="663" alt="Screenshot 2026-02-11 at 11 14 42 AM" src="https://github.com/user-attachments/assets/2d0a3863-43d9-4b11-a516-03068e38130d" />

[Screen studio](https://screen.studio/share/DmwMe0uB)