### PR TITLE
chore: suggested actions removed from prod

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -32,6 +32,7 @@ import type { Attachment, ChatMessage } from '@/lib/types';
 import type { Session } from 'next-auth';
 import { useRouter } from 'next/navigation';
 import { Alert, AlertDescription } from './ui/alert';
+import { isProductionEnvironment } from '@/lib/constants';
 
 function PureMultimodalInput({
   chatId,
@@ -271,7 +272,7 @@ function PureMultimodalInput({
         attachments.length === 0 &&
         uploadQueue.length === 0 &&
         isLoggedIn &&
-        process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod' && (
+        !isProductionEnvironment && (
           <SuggestedActions
             sendMessage={sendMessage}
             chatId={chatId}

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -270,7 +270,8 @@ function PureMultimodalInput({
       {messages.length === 0 &&
         attachments.length === 0 &&
         uploadQueue.length === 0 &&
-        isLoggedIn && (
+        isLoggedIn &&
+        process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod' && (
           <SuggestedActions
             sendMessage={sendMessage}
             chatId={chatId}

--- a/lib/apricot-api.ts
+++ b/lib/apricot-api.ts
@@ -28,13 +28,14 @@ export type {
   FormFieldData,
   FormFieldsResponse,
 } from './models/apricot-models';
+import { isProductionEnvironment } from './constants';
 
 // ===== Configuration =====
 // Use 'api' for production only (ENVIRONMENT=prod), 'sandbox' for all other environments including dev
-const env = process.env.ENVIRONMENT === 'prod' ? 'api' : 'sandbox';
+const env = isProductionEnvironment ? 'api' : 'sandbox';
 
 // Log environment on module load for debugging
-console.log(`[Apricot API] Environment: "${env}" | ENVIRONMENT: "${process.env.ENVIRONMENT || 'undefined'}"`);
+console.log(`[Apricot API] Environment: "${env}" | ENVIRONMENT: "${isProductionEnvironment ? 'prod' : 'dev'}"`);
 console.log(`[Apricot API] Expected: prod (ENVIRONMENT=prod) → "api", all others → "sandbox"`);
 
 // API configuration from environment variables

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 import { generateDummyPassword } from './db/utils';
 
-export const isProductionEnvironment = process.env.NODE_ENV === 'production';
-export const isDevelopmentEnvironment = process.env.NODE_ENV === 'development';
+export const isProductionEnvironment = process.env.ENVIRONMENT === 'prod';
+export const isDevelopmentEnvironment = process.env.ENVIRONMENT === 'dev';
 export const isTestEnvironment = Boolean(
   process.env.PLAYWRIGHT_TEST_BASE_URL ||
     process.env.PLAYWRIGHT ||

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,6 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  env: {
-    NEXT_PUBLIC_ENVIRONMENT: process.env.ENVIRONMENT,
-  },
   // cacheComponents disabled to allow runtime env vars in API routes
   // See: https://github.com/vercel/next.js/discussions/84894
   cacheComponents: false,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_ENVIRONMENT: process.env.ENVIRONMENT,
+  },
   // cacheComponents disabled to allow runtime env vars in API routes
   // See: https://github.com/vercel/next.js/discussions/84894
   cacheComponents: false,


### PR DESCRIPTION
This pull request introduces an environment variable to control the visibility of suggested actions in the chat interface, ensuring that the feature is only available in non-production environments. The changes also update the Next.js configuration to expose the environment variable to the frontend.

Environment variable integration:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR4-R6): Added the `NEXT_PUBLIC_ENVIRONMENT` environment variable, sourced from `process.env.ENVIRONMENT`, to the Next.js configuration for runtime access in the frontend.

UI behavior change:

* [`components/multimodal-input.tsx`](diffhunk://#diff-9df7a8422a0b5bfedc8e2e6afcaec2d632fe43a9d784849702bb3f8d68fbb8e6L273-R274): Updated the conditional rendering logic for the `SuggestedActions` component to only show it when the user is logged in and the app is not running in the production environment, using the new environment variable.