### PR TITLE
fix: fix for the client side env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,11 @@ APRICOT_ORG_ID_PROD=****
 APRICOT_CLIENT_ID=****
 APRICOT_CLIENT_SECRET=****
 
+# Environment name (dev, prod, preview-*, etc.)
+# Used for client-side environment checks (e.g. hiding suggested actions in prod)
+ENVIRONMENT=dev
+NEXT_PUBLIC_ENVIRONMENT=dev
+
 # Feature flag for AI SDK agent vs Mastra
 USE_AI_SDK_AGENT=false
 NEXT_PUBLIC_USE_AI_SDK_AGENT=false

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,9 @@
 import { generateDummyPassword } from './db/utils';
 
-export const isProductionEnvironment = process.env.ENVIRONMENT === 'prod';
-export const isDevelopmentEnvironment = process.env.ENVIRONMENT === 'dev';
+// Use NEXT_PUBLIC_ prefix so these work in both server and client components
+const environment = process.env.NEXT_PUBLIC_ENVIRONMENT || process.env.ENVIRONMENT;
+export const isProductionEnvironment = environment === 'prod';
+export const isDevelopmentEnvironment = environment === 'dev';
 export const isTestEnvironment = Boolean(
   process.env.PLAYWRIGHT_TEST_BASE_URL ||
     process.env.PLAYWRIGHT ||


### PR DESCRIPTION
  ## Summary                                                                                                                                                              
  - **Enable AI SDK agent for all environments**: Removed the conditional check that restricted `USE_AI_SDK` to only dev and preview environments in the deploy workflow. 
  It is now unconditionally set to `"true"` for all environments including prod.                                                                                          
  - **Fix client-side environment detection**: `isProductionEnvironment` was always `false` in client components (like `multimodal-input.tsx`) because                    
  `process.env.ENVIRONMENT` is not available in Next.js client bundles. Added `NEXT_PUBLIC_ENVIRONMENT` so the check works on both server and client side.                
  - **Wire up `ENVIRONMENT` build arg**: Added `ENVIRONMENT` and `NEXT_PUBLIC_ENVIRONMENT` to `Dockerfile.ai-chatbot` and passed the environment value via `--build-arg`
  in the deploy workflow.

  ## Files changed
  - `.github/workflows/deploy.yml` — Removed `USE_AI_SDK` conditional (now always `"true"`), added `ENVIRONMENT` build arg to docker build
  - `Dockerfile.ai-chatbot` — Added `ENVIRONMENT` ARG and set `ENVIRONMENT` + `NEXT_PUBLIC_ENVIRONMENT` env vars
  - `client/lib/constants.ts` — Updated to check `NEXT_PUBLIC_ENVIRONMENT` first for client component compatibility
  - `client/.env.example` — Added `ENVIRONMENT` and `NEXT_PUBLIC_ENVIRONMENT` entries

  ## Test plan
  - [ ] Verify suggested actions are hidden in prod deployment
  - [ ] Verify suggested actions still appear in dev/preview environments
  - [x] Verify Apricot API calls use `api` subdomain in prod and `sandbox` in other environments
  - [x] Verify AI SDK agent is enabled in all environments (dev, preview, prod)