### PR TITLE
fix: fix for stop functionality for kernel stops when chat does

### DIFF
--- a/app/api/kernel-browser/route.ts
+++ b/app/api/kernel-browser/route.ts
@@ -4,6 +4,7 @@ import {
   deleteBrowser,
   getBrowser,
   stopBrowserOperations,
+  resumeBrowserOperations,
 } from '@/lib/kernel/browser';
 
 export async function POST(request: Request) {
@@ -60,6 +61,11 @@ export async function POST(request: Request) {
 
     if (action === 'stop') {
       await stopBrowserOperations(sessionId, userId);
+      return Response.json({ success: true });
+    }
+
+    if (action === 'resume') {
+      resumeBrowserOperations(sessionId, userId);
       return Response.json({ success: true });
     }
 

--- a/app/api/kernel-browser/route.ts
+++ b/app/api/kernel-browser/route.ts
@@ -3,6 +3,7 @@ import {
   getOrCreateBrowser,
   deleteBrowser,
   getBrowser,
+  stopBrowserOperations,
 } from '@/lib/kernel/browser';
 
 export async function POST(request: Request) {
@@ -54,6 +55,11 @@ export async function POST(request: Request) {
 
     if (action === 'delete') {
       await deleteBrowser(sessionId, userId);
+      return Response.json({ success: true });
+    }
+
+    if (action === 'stop') {
+      await stopBrowserOperations(sessionId, userId);
       return Response.json({ success: true });
     }
 

--- a/artifacts/browser/client-kernel.tsx
+++ b/artifacts/browser/client-kernel.tsx
@@ -255,6 +255,15 @@ export function KernelBrowserClient({
       // Exit fullscreen when giving back control to agent
       onFullscreenChange?.(false);
 
+      // Clear the server-side stopped flag so the browser tool can execute again
+      fetch('/api/kernel-browser', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'resume', sessionId }),
+      }).catch((err) => {
+        console.error('[Kernel] Failed to send resume signal:', err);
+      });
+
       // Tell the chat to send a message so the AI snapshots the page
       // and picks up any changes the user made while in control
       window.dispatchEvent(new CustomEvent('kernel-browser-resume'));

--- a/artifacts/browser/client-kernel.tsx
+++ b/artifacts/browser/client-kernel.tsx
@@ -254,6 +254,10 @@ export function KernelBrowserClient({
     } else {
       // Exit fullscreen when giving back control to agent
       onFullscreenChange?.(false);
+
+      // Tell the chat to send a message so the AI snapshots the page
+      // and picks up any changes the user made while in control
+      window.dispatchEvent(new CustomEvent('kernel-browser-resume'));
     }
 
     onControlModeChange(mode);

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -148,6 +148,20 @@ export function Chat({
     }
   };
 
+  // When the user gives back browser control, send a message so the AI
+  // takes a snapshot and picks up any changes the user made.
+  useEffect(() => {
+    const handleResume = () => {
+      sendMessage({
+        role: 'user' as const,
+        parts: [{ type: 'text', text: 'I\'ve finished making my changes to the page. Please take a snapshot to review what I updated and continue from where you left off.' }],
+      });
+    };
+
+    window.addEventListener('kernel-browser-resume', handleResume);
+    return () => window.removeEventListener('kernel-browser-resume', handleResume);
+  }, [sendMessage]);
+
   const [hasAppendedQuery, setHasAppendedQuery] = useState(false);
 
   useEffect(() => {

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -124,6 +124,9 @@ export function Chat({
     // Always call the original stop to abort the stream
     originalStop();
 
+    // Signal the kernel browser to stop its operations
+    window.dispatchEvent(new CustomEvent('kernel-browser-stop'));
+
     // For web automation model using Mastra backend, also send stopChat action
     // When using AI SDK agent, the AbortController handles stopping
     if (initialChatModel === 'web-automation-model' && !useAiSdkAgent) {

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -95,6 +95,15 @@ evaluate is only acceptable for reading values (e.g. checking if an element exis
         // Ensure we have a Kernel browser instance (creates one if needed)
         const session = await getOrCreateBrowser(sessionId, userId);
 
+        // If the session was stopped by a previous stream but this is a fresh
+        // stream (abortSignal not aborted), clear the stale stopped flag so the
+        // agent can resume. The stopped flag only matters within the stream that
+        // triggered the stop — a new stream means the user asked to continue.
+        if (session.stopped && !abortSignal?.aborted) {
+          console.log('[browser-tool] Clearing stale stopped flag for new stream');
+          session.stopped = false;
+        }
+
         // Check session-level stopped flag (set by stopBrowserOperations)
         if (session.stopped) {
           console.log('[browser-tool] Skipping — session stopped by user');

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -95,15 +95,6 @@ evaluate is only acceptable for reading values (e.g. checking if an element exis
         // Ensure we have a Kernel browser instance (creates one if needed)
         const session = await getOrCreateBrowser(sessionId, userId);
 
-        // If the session was stopped by a previous stream but this is a fresh
-        // stream (abortSignal not aborted), clear the stale stopped flag so the
-        // agent can resume. The stopped flag only matters within the stream that
-        // triggered the stop — a new stream means the user asked to continue.
-        if (session.stopped && !abortSignal?.aborted) {
-          console.log('[browser-tool] Clearing stale stopped flag for new stream');
-          session.stopped = false;
-        }
-
         // Check session-level stopped flag (set by stopBrowserOperations)
         if (session.stopped) {
           console.log('[browser-tool] Skipping — session stopped by user');


### PR DESCRIPTION
## Stop functionality for kernel browser + stopped tool call UI                                                                                                         
                  
  ### Summary                                                                                                                                                             
  - When the stop button is clicked, the kernel browser now receives a stop signal via a `kernel-browser-stop` custom event, which cancels any in-flight `initBrowser`
  polling and sends a `stop` action to the server API to halt in-progress browser operations (`window.stop()`)                                                            
  - The `initBrowser` polling loop in `client-kernel.tsx` is now cancellable via `AbortController` — the signal is passed to `fetch()` calls and the delay between polling
   attempts, so stopping no longer waits up to 30 seconds
  - Added a new `stop` action to the `/api/kernel-browser` route backed by a `stopBrowserOperations()` function in `lib/kernel/browser.ts` that sends `window.stop()` via
  `executeCommand` to halt page navigation/loading
  - Tool calls that were stopped (either stuck in `input-available` after streaming ends, or returned a "stopped by user" error) now display a gray X icon with
  "(Stopped)" text instead of a perpetual spinner or red error state

  ### Files changed
  - **`components/chat.tsx`** — Dispatches `kernel-browser-stop` custom event in the `stop()` function
  - **`artifacts/browser/client-kernel.tsx`** — Added `AbortController` for cancellable polling, listens for `kernel-browser-stop` event to abort polling and send
  server-side stop
  - **`app/api/kernel-browser/route.ts`** — Added `stop` action handler
  - **`lib/kernel/browser.ts`** — Added `stopBrowserOperations()` function using `executeCommand` with `evaluate` action
  - **`components/tool-call-group.tsx`** — Added `isToolStopped()` helper, `isStopped` prop on `SingleToolLine`, gray X icon rendering for stopped tools
  - **`components/message.tsx`** — Passes `isLoading` to `ToolCallGroup`, uses `isToolStopped()` for individual tool call rendering with gray X icon

  ### Test plan
  - [ ] Click stop while browser is initializing (polling) — polling should cancel immediately
  - [ ] Click stop while AI is executing browser commands — browser should stop loading, tool call in message should show X icon with "(Stopped)"
  - [ ] Verify normal chat completion still shows tool icons correctly (no false "Stopped" state)
  - [ ] Verify grouped tool calls show X icon on the last stopped tool
  - [ ] Verify "Take control" button still calls stop and works as before