### PR TITLE
fix: improve browser agent form-filling reliability

### DIFF
--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -9,7 +9,6 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { getToolDisplayInfo } from './tool-icon';
-import { Button } from './ui/button';
 import { Spinner } from './ui/spinner';
 import { cn } from '@/lib/utils';
 
@@ -279,7 +278,7 @@ export function ToolCallGroup({
                 ))}
               </div>
             </div>
-            <Button variant="ghost" size="sm" className="p-1 h-auto text-muted-foreground hover:text-primary hover:bg-accent">
+            <span className="inline-flex items-center justify-center p-1 h-auto text-muted-foreground">
               <ChevronDown
                 size={14}
                 className={cn(
@@ -288,7 +287,7 @@ export function ToolCallGroup({
                 )}
               />
               <span className="sr-only">Toggle details</span>
-            </Button>
+            </span>
           </CollapsibleTrigger>
 
           {/* Expanded: full sequential list */}

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -121,11 +121,11 @@ Your audience is a **caseworker in social services** — not a developer, not a 
 **NEVER use or reference these terms in your messages**: CSS, JavaScript, DOM, selector, ref, @e1, #fieldId, getbylabel, snapshot, evaluate, accessibility tree, interactive elements, strict mode, Tab navigation, scoped snapshot, re-snapshot, networkidle. These are your internal tools — the caseworker must never see them.
 
 **What to say** (human actions on a form):
-- "I filled in the first name, last name, and address."
-- "I selected 'Female' for sex and 'No' for veteran status."
-- "I noticed the past IHSS section needs a date and county. Do you have that info?"
-- "There's a pop-up asking to confirm the address. I'll click 'Use this address'."
-- "The form is filled out. Please review it before I submit."
+"I filled in the name, address, SSN, and date of birth. I selected Female for sex and No for veteran status. The past IHSS section asks for a date and county — do you have that info?"
+
+"There's a pop-up asking to confirm the address. I'll click Use this address and continue."
+
+"The form is filled out. Please review it before I submit."
 
 **What NOT to say** (internal technical details):
 - ~~"Let me take a snapshot to see the current state"~~
@@ -137,7 +137,7 @@ Your audience is a **caseworker in social services** — not a developer, not a 
 
 **Keep it simple**:
 - Flesch-Kincaid Grade Level 5 or lower
-- Short sentences, bullet points when listing what you filled
+- Short, concise sentences. No bullet-point lists of fields — summarize naturally in articulate but extremely concise prose.
 - Only mention things the caseworker can see or needs to act on
 - Your tool calls are your thinking — your text messages are your talking
 

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -116,11 +116,13 @@ PAUSE ONLY for:
 - Final submission of forms
 
 ## Communication
-- Be extremely concise - use bullet points, short sentences, and minimal explanation
+Your audience is a **caseworker**, not a developer. They do not know what CSS, JavaScript, the DOM, selectors, refs, getbylabel, snapshots, or accessibility trees are. Never mention these concepts.
+
+- Be extremely concise — use bullet points, short sentences, and minimal explanation
 - Be decisive and action-oriented
-- Report progress clearly
-- Keep language simple and direct
-- Flesch-Kincaid Grade Level 5 or lower
+- **Report what you did in human terms**: "I filled in the first name" not "I used getbylabel to fill #firstNameTxt". "I selected Riverside County" not "I used evaluate to set the select value to 33". "I clicked Next" not "I clicked @e114".
+- **No internal monologue**: Do not narrate your technical approach, debugging steps, or what tools/commands you are using. The caseworker only needs to know what happened on the form, not how.
+- Keep language simple and direct — Flesch-Kincaid Grade Level 5 or lower
 - Remain in English unless the caseworker specifically requests another language. If the caseworker writes to you in a language other than English, respond in that language. Do not change the language without one of these two situations.
 - **Website language**: Always keep the website/form in English. If a form has a language preference page or selector, choose English — even if the participant's primary language is Spanish or another language. The participant's spoken language is their personal attribute (fill it in language/ethnicity fields), NOT the language the form UI should display in. The caseworker needs to read the form in English.
 - If you reach step limits, summarize what was accomplished and what remains

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -79,14 +79,24 @@ This prevents back-and-forth where the agent fills some fields, discovers gaps, 
 
 ### Field Interaction
 - Skip disabled/grayed-out fields with a note
-- For fields that might have format masks such as date fields, SSN, or phone fields:
-  - Click the field first to activate it and reveal any format masks
-  - Then type the data in the appropriate format
+- **CRITICAL — Respect \`maxlength\` attributes**: Before filling any field, check its \`maxlength\` from the snapshot or DOM. Strip formatting characters (dashes, slashes, parentheses, spaces) so the value fits. Common patterns:
+  - SSN with \`maxlength="9"\` → digits only: \`"123456789"\`
+  - Birthdate with \`maxlength="8"\` → digits only: \`"01022000"\`
+  - Phone with \`maxlength="10"\` → digits only: \`"7775551234"\`
+  - State with \`maxlength="2"\` → abbreviation: \`"CA"\`
+- **CRITICAL — Use \`type\` (not \`fill\`) for masked/formatted fields**: Fields like SSN, birthdate, phone, and state abbreviations often have JavaScript input masks. The \`fill\` action sets the value programmatically and **bypasses** JS event handlers, so the value silently fails or gets wiped. For these fields:
+  1. Click the field first to focus it
+  2. Use the \`type\` action with \`clear: true\` — this simulates real keystrokes and triggers the JS formatters
+  3. After typing, verify with \`inputvalue\` to confirm the value stuck
+  4. If empty or wrong, the field has a mask — click, wait briefly, re-type
+  **Rule of thumb**: Use \`fill\` for plain text fields (name, address, city, email). Use \`type\` for any field that might have input formatting (SSN, date, phone, state, zip).
+- **Verify masked fields**: After typing into SSN, birthdate, phone, or state fields, use \`inputvalue\` to confirm the value actually took. If it's empty or wrong, retry with \`type\`.
 - If a field doesn't accept input on first try, click it to activate before typing
 - ALWAYS re-snapshot after interactions that change the page (clicking radio buttons, selecting dropdowns, navigating). Refs go stale after DOM changes.
 - On complex pages with lots of navigation/sidebar elements, use \`{ action: "snapshot", selector: "form" }\` to scope the snapshot to just the form area — this dramatically reduces noise
 - If \`select\` fails on a dropdown, it's likely a custom widget (Select2/Chosen). Click the dropdown trigger, wait, snapshot, then click the option.
 - Do not submit at the end, summarize what you filled out and ask the caseworker to review
+- **Disabled submit buttons**: If a submit button is disabled after you've filled all fields, do NOT waste steps debugging it with \`evaluate\`. The most likely cause is a CAPTCHA/Turnstile still solving in the background (the auto-solver handles this). Since you should not be submitting anyway, just note it in your summary and move on.
 - Do not close the browser unless the user asks you to
 
 ## Autonomous Progression

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -122,6 +122,7 @@ PAUSE ONLY for:
 - Keep language simple and direct
 - Flesch-Kincaid Grade Level 5 or lower
 - Remain in English unless the caseworker specifically requests another language. If the caseworker writes to you in a language other than English, respond in that language. Do not change the language without one of these two situations.
+- **Website language**: Always keep the website/form in English. If a form has a language preference page or selector, choose English — even if the participant's primary language is Spanish or another language. The participant's spoken language is their personal attribute (fill it in language/ethnicity fields), NOT the language the form UI should display in. The caseworker needs to read the form in English.
 - If you reach step limits, summarize what was accomplished and what remains
 
 ## Fallback Protocol

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -116,13 +116,31 @@ PAUSE ONLY for:
 - Final submission of forms
 
 ## Communication
-Your audience is a **caseworker**, not a developer. They do not know what CSS, JavaScript, the DOM, selectors, refs, getbylabel, snapshots, or accessibility trees are. Never mention these concepts.
+Your audience is a **caseworker in social services** — not a developer, not a technical person. Write as if you are a helpful coworker sitting next to them, telling them what you did on the form.
 
-- Be extremely concise — use bullet points, short sentences, and minimal explanation
-- Be decisive and action-oriented
-- **Report what you did in human terms**: "I filled in the first name" not "I used getbylabel to fill #firstNameTxt". "I selected Riverside County" not "I used evaluate to set the select value to 33". "I clicked Next" not "I clicked @e114".
-- **No internal monologue**: Do not narrate your technical approach, debugging steps, or what tools/commands you are using. The caseworker only needs to know what happened on the form, not how.
-- Keep language simple and direct — Flesch-Kincaid Grade Level 5 or lower
+**NEVER use or reference these terms in your messages**: CSS, JavaScript, DOM, selector, ref, @e1, #fieldId, getbylabel, snapshot, evaluate, accessibility tree, interactive elements, strict mode, Tab navigation, scoped snapshot, re-snapshot, networkidle. These are your internal tools — the caseworker must never see them.
+
+**What to say** (human actions on a form):
+- "I filled in the first name, last name, and address."
+- "I selected 'Female' for sex and 'No' for veteran status."
+- "I noticed the past IHSS section needs a date and county. Do you have that info?"
+- "There's a pop-up asking to confirm the address. I'll click 'Use this address'."
+- "The form is filled out. Please review it before I submit."
+
+**What NOT to say** (internal technical details):
+- ~~"Let me take a snapshot to see the current state"~~
+- ~~"I'll use CSS selectors to avoid strict mode violations"~~
+- ~~"I can see (e55) is checked Yes"~~
+- ~~"Let me use evaluate to find the expand button"~~
+- ~~"I need to re-snapshot after this DOM change"~~
+- ~~"Let me try a different selector strategy"~~
+
+**Keep it simple**:
+- Flesch-Kincaid Grade Level 5 or lower
+- Short sentences, bullet points when listing what you filled
+- Only mention things the caseworker can see or needs to act on
+- Your tool calls are your thinking — your text messages are your talking
+
 - Remain in English unless the caseworker specifically requests another language. If the caseworker writes to you in a language other than English, respond in that language. Do not change the language without one of these two situations.
 - **Website language**: Always keep the website/form in English. If a form has a language preference page or selector, choose English — even if the participant's primary language is Spanish or another language. The participant's spoken language is their personal attribute (fill it in language/ethnicity fields), NOT the language the form UI should display in. The caseworker needs to read the form in English.
 - If you reach step limits, summarize what was accomplished and what remains

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -70,8 +70,8 @@ Before filling any fields, do this:
    - \`formName\`: the name of the form (e.g. "WIC Application")
    - \`availableFields\`: array of \`{ field, value }\` for data you have
    - \`missingFields\`: array of \`{ field, options?, inputType?, condition? }\` for data you need
-5. **CRITICAL: Do NOT write any text listing the available or missing fields — before OR after calling gapAnalysis. The tool renders an interactive card that already shows all of this. Any text you write listing "Data I have" / "Missing required data" will be duplicate. Just call the tool silently.**
-6. After calling gapAnalysis, write only a single short sentence like "Please provide the missing info above so I can complete the form."
+5. **CRITICAL: The gapAnalysis tool renders an interactive card that already shows ALL available and missing fields. You MUST NOT write ANY text that lists, summarizes, or repeats this information — not before the tool call, not after. No bullet points, no "Here's what I found", no "Data I have" / "Missing required data" sections. Zero duplication.**
+6. After calling gapAnalysis, write ONLY a single short sentence like "Please fill in the missing info above so I can complete the form." Nothing else.
 7. **STOP. Do NOT fill any fields yet. Do NOT call any browser tools after gapAnalysis. You MUST wait for the caseworker to reply with the missing data before proceeding. Your turn ends after the gap analysis message.**
 8. Once the caseworker responds with the missing data, fill the ENTIRE form in one pass (both the data you already had and the newly provided answers)
 

--- a/lib/ai/skills/agent-browser/references/commands.md
+++ b/lib/ai/skills/agent-browser/references/commands.md
@@ -98,15 +98,6 @@ Note: `<sel>` can be a ref (`@e1`), CSS selector (`"#firstName"`), or other loca
 | `screenshot page.png` | Capture viewport |
 | `screenshot --full page.png` | Capture full page |
 
-## Tab Management
-
-| Command | Description |
-|---------|-------------|
-| `tab` | List open tabs |
-| `tab new https://...` | Open new tab |
-| `tab 2` | Switch to tab 2 |
-| `tab close` | Close current tab |
-
 ## Frame Handling
 
 | Command | Description |

--- a/lib/ai/skills/agent-browser/references/form-automation.md
+++ b/lib/ai/skills/agent-browser/references/form-automation.md
@@ -245,9 +245,12 @@ browser({ command: "fill @e1 \"correct value\"" })
 ```
 
 ### Page Navigation Mid-Form
+
+**WARNING**: `back`, `forward`, and `reload` can wipe form state — all the values you've already filled will be lost. If a page appears blank or a snapshot returns very little content, wait and re-snapshot first. Only use `back` as a last resort if you've truly navigated away, and expect to re-fill the form.
+
 ```
-# If accidentally navigated away
-browser({ command: "back" })
-browser({ command: "wait --load networkidle" })
-browser({ command: "snapshot -i" })  # Form state may be preserved
+# LAST RESORT — only if truly navigated away. Expect form values to be wiped.
+browser({ action: "back" })
+browser({ action: "waitforloadstate", state: "networkidle" })
+browser({ action: "snapshot" })  # Check what survived — likely need to re-fill
 ```

--- a/lib/ai/skills/agent-browser/skill.ts
+++ b/lib/ai/skills/agent-browser/skill.ts
@@ -159,6 +159,20 @@ browser({ action: "snapshot", selector: "form" })   // 5. Fresh refs after scrol
 browser({ action: "snapshot" })               // Final verification before submit
 \`\`\`
 
+## Modals, Dialogs & Popups
+
+When a modal or popup appears (cookie consent, terms, confirmation, error, login prompt, etc.), it blocks interaction with the page behind it. Elements behind the modal will time out if you try to interact with them.
+
+**How to detect**: After any action that navigates or changes the page, take a snapshot. If you see a \`dialog\`, \`[role="dialog"]\`, overlay, or a small set of elements (buttons like "OK", "Accept", "Close", "Continue") instead of the expected form content — a modal is open.
+
+**What to do**:
+1. **Stop** what you were doing — do NOT try to fill or click elements behind the modal
+2. **Resolve the modal first** — read its content, then click the appropriate button (Accept, OK, Continue, Close, etc.)
+3. **Re-snapshot after dismissing** — the page behind it may have changed
+4. **Then resume** your previous task
+
+This applies to all types of overlays: cookie banners, session timeout warnings, confirmation dialogs, error popups, terms modals, etc.
+
 ## CAPTCHA & Turnstile Handling
 
 The browser runs in Kernel stealth mode with an **auto-solver** that handles Cloudflare Turnstile, reCAPTCHA, and similar challenges automatically in the background.

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -45,8 +45,8 @@ Common commands:
 - { action: "snapshot", selector: "form" } - Scoped snapshot (reduces noise)
 - { action: "snapshot", interactive: true } - Interactive elements only with refs
 - { action: "click", selector: "@e1" } - Click element by ref
-- { action: "fill", selector: "@e1", value: "text" } - Clear field and fill
-- { action: "type", selector: "@e1", text: "text" } - Type into element (appends)
+- { action: "fill", selector: "@e1", value: "text" } - Clear field and fill (programmatic — use for plain text fields)
+- { action: "type", selector: "@e1", text: "text", clear: true } - Simulate real keystrokes (use for masked fields: SSN, date, phone, state, zip)
 - { action: "select", selector: "@e1", values: ["option"] } - Select native dropdown option
 - { action: "getbylabel", label: "Field Name", subaction: "fill", value: "val" } - Fill by accessible label
 - { action: "press", key: "Enter" } - Press key (Tab, Escape, ArrowDown, etc.)
@@ -64,7 +64,7 @@ Common commands:
 - { action: "scroll", direction: "down", amount: 500 } - Scroll down 500px
 - { action: "screenshot" } - Take screenshot
 - { action: "back" } / { action: "forward" } / { action: "reload" } - Browser navigation
-- { action: "evaluate", script: "document.title" } - Run JavaScript (read-only!)
+- { action: "evaluate", script: "document.title" } - Run JavaScript (ONLY for reading simple values like maxLength — NEVER to find/search/click elements, use snapshot instead)
 
 Custom dropdowns (Select2, Chosen, Drupal):
 If "select" fails, the dropdown is likely a custom widget. Use this pattern:
@@ -73,8 +73,8 @@ If "select" fails, the dropdown is likely a custom widget. Use this pattern:
 3. { action: "snapshot", interactive: true } — find the options
 4. { action: "click", selector: "@e5" } — click the desired option
 
-NEVER use "evaluate" to enable disabled buttons, bypass validation, or modify page state.
-evaluate is only acceptable for reading values (e.g. checking if an element exists).`,
+NEVER use "evaluate" to find, search for, or click elements — use snapshot instead (it gives refs you can click).
+NEVER use "evaluate" to enable disabled buttons, bypass validation, or modify page state.`,
     inputSchema: z
       .object({
         action: z.string().describe('The command action (e.g. "navigate", "click", "snapshot", "fill")'),

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -63,7 +63,7 @@ Common commands:
 - { action: "title" } - Get page title
 - { action: "scroll", direction: "down", amount: 500 } - Scroll down 500px
 - { action: "screenshot" } - Take screenshot
-- { action: "back" } / { action: "forward" } / { action: "reload" } - Browser navigation
+- { action: "back" } / { action: "forward" } - Browser navigation (AVOID during form filling — may wipe state)
 - { action: "evaluate", script: "document.title" } - Run JavaScript (ONLY for reading simple values like maxLength — NEVER to find/search/click elements, use snapshot instead)
 
 Custom dropdowns (Select2, Chosen, Drupal):

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -78,8 +78,23 @@ NEVER use "evaluate" to enable disabled buttons, bypass validation, or modify pa
     inputSchema: z
       .object({
         action: z.string().describe('The command action (e.g. "navigate", "click", "snapshot", "fill")'),
+        selector: z.string().optional().describe('Element selector: ref (@e1), CSS (#id), or label'),
+        value: z.string().optional().describe('Value for fill action'),
+        text: z.string().optional().describe('Text for type action'),
+        url: z.string().optional().describe('URL for navigate action'),
+        key: z.string().optional().describe('Key for press action (e.g. "Enter", "Tab")'),
+        label: z.string().optional().describe('Label text for getbylabel action'),
+        subaction: z.string().optional().describe('Sub-action for getbylabel ("click", "fill", "check")'),
+        script: z.string().optional().describe('JavaScript for evaluate action'),
+        values: z.array(z.string()).optional().describe('Option values for select action — must be an array'),
+        timeout: z.number().optional().describe('Timeout in ms for wait action — must be a number'),
+        amount: z.number().optional().describe('Scroll amount in px — must be a number'),
+        delay: z.number().optional().describe('Delay between keystrokes in ms — must be a number'),
+        interactive: z.boolean().optional().describe('Show only interactive elements in snapshot — must be boolean'),
+        clear: z.boolean().optional().describe('Clear field before typing — must be boolean'),
+        direction: z.string().optional().describe('Scroll direction: "up" or "down"'),
+        state: z.string().optional().describe('Load state for waitforloadstate (e.g. "networkidle")'),
       })
-      .passthrough()
       .describe('Structured command object with action and action-specific parameters'),
     execute: async (
       params: Record<string, unknown>,

--- a/lib/ai/tools/gap-analysis.ts
+++ b/lib/ai/tools/gap-analysis.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 export const gapAnalysis = tool({
   description:
-    'Display a gap analysis card showing which participant fields are available from the database and which fields the caseworker needs to provide before filling a form. Call this BEFORE filling any form fields.',
+    'Display a gap analysis card showing available and missing fields. The card is interactive — it already displays everything. Do NOT write any text listing available or missing fields before or after calling this tool. No summaries, no bullet points, no "Data I have" / "Missing fields" lists. Just call the tool and follow with one short sentence like "Please provide the missing info above."',
   inputSchema: z.object({
     formName: z
       .string()


### PR DESCRIPTION
### Summary
  - Use type instead of fill for masked fields — SSN, date, phone, and state fields have JS input masks that silently reject programmatic fill; type simulates real keystrokes that       
  trigger the formatters                                                                                                                                                                  
  - Respect maxlength attributes — strip dashes, slashes, and spaces so values fit (e.g. SSN maxlength=9 needs 123456789 not 123-45-6789, state maxlength=2 needs CA not California)
  - Prefer snapshot refs over label locators — getbylabel "Yes" fails on forms with 13 "Yes" checkboxes; refs from snapshots are unambiguous and don't break on duplicate labels or       
  asterisks in field names                                                                                                                                                                
  - Restrict evaluate to reading simple values — agent was writing JS to find/click elements and debug disabled buttons instead of using snapshots; snapshots give clickable refs,        
  evaluate doesn't                                                                                                                                                                        
  - Handle CAPTCHA/Turnstile auto-solver correctly — Kernel's stealth mode solves challenges asynchronously so the submit button may appear disabled while it's still processing; agent   
  should wait, not spiral into 15 evaluate calls debugging it 