### PR TITLE
fix: fix for the resume when stop in chat

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -103,6 +103,13 @@ export function Chat({
       mutate(unstable_serialize(getChatHistoryPaginationKey));
     },
     onError: (error) => {
+      // Suppress expected errors when user clicks Stop during a tool call —
+      // the AI SDK can't match the tool result after the stream is aborted.
+      if (error?.message?.includes('Tool result is missing')) {
+        console.log('Chat stopped during tool call (expected)');
+        return;
+      }
+
       console.error('Chat error:', error);
       if (error instanceof ChatSDKError) {
         toast({

--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -9,7 +9,6 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { getToolDisplayInfo } from './tool-icon';
-import { Button } from './ui/button';
 import { Spinner } from './ui/spinner';
 import { cn } from '@/lib/utils';
 
@@ -302,7 +301,7 @@ export function ToolCallGroup({
                 ))}
               </div>
             </div>
-            <Button variant="ghost" size="sm" className="p-1 h-auto text-muted-foreground hover:text-primary hover:bg-accent">
+            <div className="p-1 h-auto text-muted-foreground">
               <ChevronDown
                 size={14}
                 className={cn(
@@ -311,7 +310,7 @@ export function ToolCallGroup({
                 )}
               />
               <span className="sr-only">Toggle details</span>
-            </Button>
+            </div>
           </CollapsibleTrigger>
 
           {/* Expanded: full sequential list */}

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -95,9 +95,14 @@ evaluate is only acceptable for reading values (e.g. checking if an element exis
         // Ensure we have a Kernel browser instance (creates one if needed)
         const session = await getOrCreateBrowser(sessionId, userId);
 
-        // If session was previously stopped, auto-resume since the agent is
-        // actively trying to use the browser again (user sent a new message).
+        // If session was previously stopped, decide whether to resume or bail:
+        // - abortSignal aborted → this is a stale call from the stopped stream, bail out
+        // - abortSignal NOT aborted → new stream (user sent a new message), auto-resume
         if (session.stopped) {
+          if (abortSignal?.aborted) {
+            console.log('[browser-tool] Skipping — session stopped by user');
+            return { success: false, output: null, error: 'Browser command stopped by user' };
+          }
           console.log('[browser-tool] Auto-resuming previously stopped session');
           session.stopped = false;
         }

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -95,10 +95,11 @@ evaluate is only acceptable for reading values (e.g. checking if an element exis
         // Ensure we have a Kernel browser instance (creates one if needed)
         const session = await getOrCreateBrowser(sessionId, userId);
 
-        // Check session-level stopped flag (set by stopBrowserOperations)
+        // If session was previously stopped, auto-resume since the agent is
+        // actively trying to use the browser again (user sent a new message).
         if (session.stopped) {
-          console.log('[browser-tool] Skipping — session stopped by user');
-          return { success: false, output: null, error: 'Browser command stopped by user' };
+          console.log('[browser-tool] Auto-resuming previously stopped session');
+          session.stopped = false;
         }
 
         const command = {


### PR DESCRIPTION
## Summary                                                                                                                                                              
                                                                                                                                                                          
  - **Fix kernel browser not resuming after stop**: When the user clicks Stop and then sends a new message, the browser tool now auto-clears the `session.stopped` flag   
  instead of permanently blocking with "Browser command stopped by user". The `abortSignal` check still correctly prevents stale tool calls from the aborted stream.      
  - **Suppress expected error on stop during tool call**: Stopping mid-tool-call causes an `AI_MissingToolResultsError` because the stream is aborted before the tool
  result can be delivered. This is now caught in the `onError` handler and silently logged instead of showing an error toast.
  - **Fix nested button HTML warning**: Replaced `<Button>` inside `<CollapsibleTrigger>` in `ToolCallGroup` with a `<div>` to fix invalid `<button>` nesting.

  ## Test plan

  - [ ] Start a browser automation task, click Stop mid-tool-call, then send a follow-up message — the agent should be able to resume using the existing browser
  - [ ] Verify no error toast appears when stopping during a tool call
  - [ ] Verify no `<button> cannot contain a nested <button>` console warning on pages with tool call groups
  - [ ] Verify clicking Stop still immediately halts the current browser operation