### PR TITLE
Revert "fix: fix for stop functionality for kernel stops when chat does"

### DIFF
--- a/app/api/kernel-browser/route.ts
+++ b/app/api/kernel-browser/route.ts
@@ -3,8 +3,6 @@ import {
   getOrCreateBrowser,
   deleteBrowser,
   getBrowser,
-  stopBrowserOperations,
-  resumeBrowserOperations,
 } from '@/lib/kernel/browser';
 
 export async function POST(request: Request) {
@@ -56,16 +54,6 @@ export async function POST(request: Request) {
 
     if (action === 'delete') {
       await deleteBrowser(sessionId, userId);
-      return Response.json({ success: true });
-    }
-
-    if (action === 'stop') {
-      await stopBrowserOperations(sessionId, userId);
-      return Response.json({ success: true });
-    }
-
-    if (action === 'resume') {
-      resumeBrowserOperations(sessionId, userId);
       return Response.json({ success: true });
     }
 

--- a/artifacts/browser/client-kernel.tsx
+++ b/artifacts/browser/client-kernel.tsx
@@ -55,9 +55,6 @@ export function KernelBrowserClient({
   const initializedSessionRef = useRef<string | null>(null);
   const initInFlightRef = useRef(false);
 
-  // AbortController for cancelling initBrowser polling when stop is called
-  const abortControllerRef = useRef<AbortController | null>(null);
-
   const initBrowser = useCallback(async (force = false) => {
     // Skip if already initialized for this session (unless forced)
     if (!force && initializedSessionRef.current === sessionId && liveViewUrl) {
@@ -67,13 +64,6 @@ export function KernelBrowserClient({
     if (initInFlightRef.current) {
       return;
     }
-
-    // Cancel any previous polling and create a new AbortController
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
 
     try {
       initInFlightRef.current = true;
@@ -87,15 +77,10 @@ export function KernelBrowserClient({
       let attempts = 0;
 
       while (attempts < maxAttempts) {
-        if (abortController.signal.aborted) {
-          return; // Silently exit on abort
-        }
-
         const response = await fetch('/api/kernel-browser', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action, sessionId, isMobile }),
-          signal: abortController.signal,
         });
 
         if (response.ok) {
@@ -115,23 +100,12 @@ export function KernelBrowserClient({
 
         attempts++;
         if (attempts < maxAttempts) {
-          // Abort-aware delay between polling attempts
-          await new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(resolve, 1000);
-            abortController.signal.addEventListener('abort', () => {
-              clearTimeout(timer);
-              reject(new DOMException('Aborted', 'AbortError'));
-            }, { once: true });
-          });
+          await new Promise((r) => setTimeout(r, 1000));
         }
       }
 
       throw new Error('Browser session not available yet. Please try again.');
     } catch (err) {
-      // Silently ignore abort errors (user-initiated stop)
-      if (err instanceof DOMException && err.name === 'AbortError') {
-        return;
-      }
       const message = err instanceof Error ? err.message : 'Failed to connect';
       setError(message);
       setIsConnected(false);
@@ -175,33 +149,6 @@ export function KernelBrowserClient({
       cleanup();
     };
   }, []);
-
-  // Listen for stop events from the chat stop button
-  useEffect(() => {
-    const handleStop = () => {
-      console.log('[Kernel] Stop signal received, cancelling browser operations');
-
-      // Cancel any in-flight initBrowser polling
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-
-      // Send stop signal to the server to halt in-progress browser operations
-      fetch('/api/kernel-browser', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'stop', sessionId }),
-      }).catch((err) => {
-        console.error('[Kernel] Failed to send stop signal:', err);
-      });
-    };
-
-    window.addEventListener('kernel-browser-stop', handleStop);
-
-    return () => {
-      window.removeEventListener('kernel-browser-stop', handleStop);
-    };
-  }, [sessionId]);
 
   // Listen for control mode switch events from confirmation components
   useEffect(() => {
@@ -254,19 +201,6 @@ export function KernelBrowserClient({
     } else {
       // Exit fullscreen when giving back control to agent
       onFullscreenChange?.(false);
-
-      // Clear the server-side stopped flag so the browser tool can execute again
-      fetch('/api/kernel-browser', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'resume', sessionId }),
-      }).catch((err) => {
-        console.error('[Kernel] Failed to send resume signal:', err);
-      });
-
-      // Tell the chat to send a message so the AI snapshots the page
-      // and picks up any changes the user made while in control
-      window.dispatchEvent(new CustomEvent('kernel-browser-resume'));
     }
 
     onControlModeChange(mode);

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -124,9 +124,6 @@ export function Chat({
     // Always call the original stop to abort the stream
     originalStop();
 
-    // Signal the kernel browser to stop its operations
-    window.dispatchEvent(new CustomEvent('kernel-browser-stop'));
-
     // For web automation model using Mastra backend, also send stopChat action
     // When using AI SDK agent, the AbortController handles stopping
     if (initialChatModel === 'web-automation-model' && !useAiSdkAgent) {
@@ -147,20 +144,6 @@ export function Chat({
       }
     }
   };
-
-  // When the user gives back browser control, send a message so the AI
-  // takes a snapshot and picks up any changes the user made.
-  useEffect(() => {
-    const handleResume = () => {
-      sendMessage({
-        role: 'user' as const,
-        parts: [{ type: 'text', text: 'I\'ve finished making my changes to the page. Please take a snapshot to review what I updated and continue from where you left off.' }],
-      });
-    };
-
-    window.addEventListener('kernel-browser-resume', handleResume);
-    return () => window.removeEventListener('kernel-browser-resume', handleResume);
-  }, [sendMessage]);
 
   const [hasAppendedQuery, setHasAppendedQuery] = useState(false);
 

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -29,8 +29,7 @@ import { CollapsibleWrapper } from './ui/collapsible-wrapper';
 import { getToolDisplayInfo } from './tool-icon';
 import { Spinner } from './ui/spinner';
 import { UserActionConfirmation, GapAnalysisCard } from './ai-elements';
-import { groupMessageParts, ToolCallGroup, isToolStopped } from './tool-call-group';
-import { X } from 'lucide-react';
+import { groupMessageParts, ToolCallGroup } from './tool-call-group';
 
 // Responsive min-height calculation that accounts for side-chat-header height
 // This ensures the last message has enough space to scroll properly with the header
@@ -164,7 +163,6 @@ const PurePreviewMessage = ({
                     parts={processed.parts as any}
                     messageId={message.id}
                     startIndex={processed.startIndex}
-                    isLoading={isLoading}
                   />
                 );
               }
@@ -455,7 +453,6 @@ const PurePreviewMessage = ({
               // Handle any other tool calls (including web automation tools)
               if (type.startsWith('tool-') && !['tool-getWeather', 'tool-createDocument', 'tool-updateDocument', 'tool-requestSuggestions', 'tool-gapAnalysis'].includes(type)) {
                 const { toolCallId, state } = part as any;
-                const stopped = isToolStopped(part as any, isLoading);
 
                 if (state === 'input-available') {
                   const { input } = part as any;
@@ -475,13 +472,10 @@ const PurePreviewMessage = ({
                   return (
                     <div key={toolCallId} className="flex items-center gap-2 p-3 border-0 rounded-md">
                       <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
-                        {stopped ? (
-                          <X size={12} className="text-gray-500 shrink-0" />
-                        ) : Icon ? (
+                        {Icon && (
                           <Icon size={12} className="text-gray-500 shrink-0" />
-                        ) : null}
+                        )}
                         {displayName}
-                        {stopped && ' (Stopped)'}
                       </div>
                     </div>
                   );
@@ -516,14 +510,12 @@ const PurePreviewMessage = ({
                   const hasError = output && 'error' in output && output.error;
                   return (
                     <div key={toolCallId} className="flex items-center gap-2 p-3 border-0 rounded-md">
-                      <div className={cn('text-[10px] leading-[150%] font-ibm-plex-mono flex items-center gap-2', !stopped && hasError ? 'text-red-600' : 'text-muted-foreground')}>
-                        {stopped ? (
-                          <X size={12} className="text-gray-500 shrink-0" />
-                        ) : Icon ? (
+                      <div className={`text-[10px] leading-[150%] font-ibm-plex-mono flex items-center gap-2 ${hasError ? 'text-red-600' : 'text-muted-foreground'}`}>
+                        {Icon && (
                           <Icon size={12} className="text-gray-500 shrink-0" />
-                        ) : null}
+                        )}
                         {displayName}
-                        {stopped ? ' (Stopped)' : hasError ? ' (Error)' : ''}
+                        {hasError && ' (Error)'}
                       </div>
                     </div>
                   );

--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronDown, Layers, X } from 'lucide-react';
+import { ChevronDown, Layers } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
   Collapsible,
@@ -228,40 +228,18 @@ export function generateGroupSummary(parts: MessagePart[]): { noun: string; coun
   return Object.entries(counts).map(([noun, count]) => ({ noun, count }));
 }
 
-// --- Stopped detection ---
-
-/** A tool call is "stopped" if the user clicked stop while it was running
- *  (state stuck at input-available with isLoading=false), or if its output
- *  explicitly contains a "stopped by user" error. */
-export function isToolStopped(part: MessagePart, isLoading: boolean): boolean {
-  // Tool was mid-execution when the stream was aborted
-  if (part.state === 'input-available' && !isLoading) return true;
-  // Tool completed but with a "stopped" error from the server
-  if (
-    part.state === 'output-available' &&
-    part.output?.error &&
-    typeof part.output.error === 'string' &&
-    part.output.error.toLowerCase().includes('stopped by user')
-  ) {
-    return true;
-  }
-  return false;
-}
-
 // --- Component ---
 
 interface ToolCallGroupProps {
   parts: MessagePart[];
   messageId: string;
   startIndex: number;
-  isLoading: boolean;
 }
 
 export function ToolCallGroup({
   parts,
   messageId,
   startIndex,
-  isLoading,
 }: ToolCallGroupProps) {
   const [open, setOpen] = useState(false);
 
@@ -276,8 +254,7 @@ export function ToolCallGroup({
   // If the latest tool is still running, show it separately below the summary.
   // Otherwise all tools are done — include everything in the summary counts.
   const lastTool = deduped[deduped.length - 1];
-  const isLastRunning = lastTool.state === 'input-available' && isLoading;
-  const isLastStopped = isToolStopped(lastTool, isLoading);
+  const isLastRunning = lastTool.state === 'input-available';
   const summaryParts = isLastRunning ? deduped.slice(0, -1) : deduped;
 
   const summary = generateGroupSummary(summaryParts);
@@ -321,21 +298,19 @@ export function ToolCallGroup({
                   key={part.toolCallId}
                   part={part}
                   compact
-                  isStopped={isToolStopped(part, isLoading)}
                 />
               ))}
             </div>
           </CollapsibleContent>
         </Collapsible>
 
-        {/* Current tool — only shown while still running or stopped */}
-        {(isLastRunning || isLastStopped) && (
+        {/* Current tool — only shown while still running */}
+        {isLastRunning && (
           <div className="mt-1">
             <SingleToolLine
               part={lastTool}
               compact
-              isRunning={isLastRunning}
-              isStopped={isLastStopped}
+              isRunning
             />
           </div>
         )}
@@ -363,12 +338,10 @@ function SingleToolLine({
   part,
   compact = false,
   isRunning = false,
-  isStopped = false,
 }: {
   part: MessagePart;
   compact?: boolean;
   isRunning?: boolean;
-  isStopped?: boolean;
 }) {
   const { text: displayName, icon: Icon } = getToolDisplayInfo(
     part.type,
@@ -384,13 +357,10 @@ function SingleToolLine({
       <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
         {isRunning ? (
           <Spinner className="size-3 shrink-0 text-primary" />
-        ) : isStopped ? (
-          <X size={12} className="text-gray-500 shrink-0" />
         ) : (
           Icon && <Icon size={12} className="text-gray-500 shrink-0" />
         )}
         {displayName}
-        {isStopped && ' (Stopped)'}
       </div>
     </div>
   );

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -101,20 +101,8 @@ NEVER use "evaluate" to enable disabled buttons, bypass validation, or modify pa
       { abortSignal }: ToolExecutionOptions,
     ) => {
       try {
-        // Bail out immediately if already aborted (e.g. between queued tool calls)
-        if (abortSignal?.aborted) {
-          console.log('[browser-tool] Skipping — already aborted');
-          return { success: false, output: null, error: 'Browser command stopped by user' };
-        }
-
         // Ensure we have a Kernel browser instance (creates one if needed)
         const session = await getOrCreateBrowser(sessionId, userId);
-
-        // Check session-level stopped flag (set by stopBrowserOperations)
-        if (session.stopped) {
-          console.log('[browser-tool] Skipping — session stopped by user');
-          return { success: false, output: null, error: 'Browser command stopped by user' };
-        }
 
         const command = {
           id: nanoid(),


### PR DESCRIPTION
## Summary
- Reverts PR #141 which added stop functionality for the kernel browser and stopped tool call UI
- This reverts merge commit 27516bd

## Original PR changes being reverted
- `kernel-browser-stop` custom event dispatch and handling
- `AbortController` for cancellable polling in `client-kernel.tsx`
- `stop` action in `/api/kernel-browser` route
- `stopBrowserOperations()` function in `lib/kernel/browser.ts`
- Stopped tool call UI (gray X icon with "(Stopped)" text)

## Test plan
- [ ] Verify the app builds and runs without errors
- [ ] Verify browser tool calls work as expected without the stop functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)