### PR TITLE
feat: add Posthog person_profiles with NextJS useSession data

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import { Toaster } from 'sonner';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono, IBM_Plex_Mono, Source_Serif_4, Inter, Roboto } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
-import { PostHogProvider } from './providers';
+import { PostHogProvider, PostHogIdentify } from './providers';
 
 import './globals.css';
 import { SessionProvider } from 'next-auth/react';
@@ -110,7 +110,10 @@ export default async function RootLayout({
             disableTransitionOnChange
           >
             <Toaster position="top-center" />
-            <SessionProvider>{children}</SessionProvider>
+            <SessionProvider>
+              <PostHogIdentify />
+              {children}
+            </SessionProvider>
           </ThemeProvider>
         </PostHogProvider>
       </body>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import { usePathname, useSearchParams } from "next/navigation"
 import { useEffect, Suspense } from "react"
 import PostHogLib from 'posthog-js'
 import { PostHogProvider as PHProvider, usePostHog } from 'posthog-js/react'
+import { useSession } from 'next-auth/react'
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
@@ -23,6 +24,24 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       {children}
     </PHProvider>
   )
+}
+
+export function PostHogIdentify() {
+  const posthog = usePostHog()
+  const { data: session, status } = useSession()
+
+  useEffect(() => {
+    if (status === 'authenticated' && session?.user && posthog) {
+      posthog.identify(session.user.id, {
+        email: session.user.email,
+        name: session.user.name,
+      })
+    } else if (status === 'unauthenticated' && posthog) {
+      posthog.reset()
+    }
+  }, [status, session, posthog])
+
+  return null
 }
 
 function PostHogPageView() {


### PR DESCRIPTION
## Summary                                                                                                                                                                       
                                                                                                                                                                                   
  - Adds `PostHogIdentify` component that links signed-in users to PostHog person profiles                                                                                         
  - Uses `useSession()` from next-auth and `usePostHog()` from posthog-js/react                                                                                                    
  - When `status === 'authenticated'`: calls `posthog.identify(userId, { email, name })` — this creates a person profile in PostHog (since we use `person_profiles: 'identified_only'`) and links any prior anonymous events to this user
  - When `status === 'unauthenticated'`: calls `posthog.reset()` to clear the identified state on sign-out, so the next user on the same browser doesn't get merged into the previous person
  - `<PostHogIdentify />` is placed inside `SessionProvider` (so it can access the session) and inside `PostHogProvider` (so it can access the posthog client)
  - Covers all auth providers (Google, Microsoft Entra ID, credentials, guest) since they all produce the same session shape with `user.id`, `user.email`, and `user.name`

  ## References

  - [PostHog Person Properties Docs](https://posthog.com/docs/product-analytics/person-properties) — `posthog.identify(distinct_id, { email, name })` API
  - [PostHog Identify Demo](https://github.com/PostHog/posthog-identify-demo) — reference implementation pattern