### PR TITLE
feat: timeout modal window - mock ui

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ const ibmPlexMono = IBM_Plex_Mono({
 
 const sourceSerifPro = Source_Serif_4({
   subsets: ['latin'],
-  weight: ['400', '700'],
+  weight: ['300', '400', '600', '700'],
   display: 'swap',
   variable: '--font-source-serif',
 });

--- a/components/session-timeout-modal.tsx
+++ b/components/session-timeout-modal.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTime(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+// ---------------------------------------------------------------------------
+// SessionTimeoutModal
+// ---------------------------------------------------------------------------
+
+interface SessionTimeoutModalProps {
+  /** Whether the dialog is visible. */
+  open: boolean;
+  /** Called when the dialog open state changes. */
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Initial countdown duration **in seconds**.
+   * The timer starts counting down from this value when the dialog opens.
+   */
+  countdownSeconds: number;
+  /** Called when the user clicks "End session" or the countdown reaches 0. */
+  onEndSession: () => void;
+  /** Called when the user clicks "Continue session". */
+  onContinueSession: () => void;
+}
+
+export function SessionTimeoutModal({
+  open,
+  onOpenChange,
+  countdownSeconds,
+  onEndSession,
+  onContinueSession,
+}: SessionTimeoutModalProps) {
+  const [remaining, setRemaining] = useState(countdownSeconds);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Reset and start timer whenever the dialog opens.
+  useEffect(() => {
+    if (!open) {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      setRemaining(countdownSeconds);
+      return;
+    }
+
+    setRemaining(countdownSeconds);
+
+    intervalRef.current = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          clearInterval(intervalRef.current!);
+          onEndSession();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const handleEndSession = () => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    onOpenChange(false);
+    onEndSession();
+  };
+
+  const handleContinueSession = () => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    onOpenChange(false);
+    onContinueSession();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-[480px] bg-card rounded-[6px] border border-border p-0 gap-0"
+      >
+        <DialogHeader className="px-6 pt-6 pb-4">
+          <DialogTitle className="font-sans text-[16px] font-bold leading-[24px] text-card-foreground text-left">
+            Your session is ending soon
+          </DialogTitle>
+
+          <p
+            className="font-sans text-[56px] font-light leading-[64px] text-card-foreground text-left mt-1"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {formatTime(remaining)}
+          </p>
+        </DialogHeader>
+
+        <div className="h-px bg-border mx-6" />
+
+        <DialogDescription className="px-6 pt-4 pb-2 font-sans text-[14px] font-normal leading-[22px] text-foreground text-left">
+          To keep the system running smoothly, sessions end after inactivity.
+          Select <strong className="font-bold text-foreground">Continue session</strong> to keep
+          working.
+        </DialogDescription>
+
+        <DialogFooter className="px-6 pb-6 pt-3 flex-row justify-end gap-3">
+          <Button
+            variant="outline"
+            onClick={handleEndSession}
+            className="border border-border bg-card text-card-foreground text-[14px] font-medium leading-[24px] px-5 py-2 rounded-[6px] hover:bg-secondary/80 transition-colors"
+          >
+            End session
+          </Button>
+          <Button
+            onClick={handleContinueSession}
+            className="bg-primary text-primary-foreground text-[14px] font-medium leading-[24px] px-5 py-2 rounded-[6px] hover:bg-primary/90 transition-colors border-0"
+          >
+            Continue session
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SessionTimeoutModalDemo  –  test harness with a 5-minute countdown
+// TODO: remove this before production.
+// ---------------------------------------------------------------------------
+
+export function SessionTimeoutModalDemo() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Button
+        onClick={() => setOpen(true)}
+        variant="outline"
+        className="text-[14px] font-medium"
+      >
+        Test timeout modal (5 min)
+      </Button>
+
+      <SessionTimeoutModal
+        open={open}
+        onOpenChange={setOpen}
+        countdownSeconds={300}
+        onEndSession={() => {
+          setOpen(false);
+          // Replace with your real end-session logic.
+          console.log('Session ended');
+        }}
+        onContinueSession={() => {
+          setOpen(false);
+          // Replace with your real continue-session logic.
+          console.log('Session continued');
+        }}
+      />
+    </div>
+  );
+}

--- a/components/session-timeout-modal.tsx
+++ b/components/session-timeout-modal.tsx
@@ -97,7 +97,7 @@ export function SessionTimeoutModal({
         className="max-w-[480px] bg-card rounded-[6px] border border-border p-0 gap-0"
       >
         <DialogHeader className="px-6 pt-6 pb-0">
-          <DialogTitle className="font-source-serif text-[20px] font-semibold leading-[28px] text-card-foreground text-left break-words">
+          <DialogTitle className="font-source-serif font-semibold leading-[28px] text-card-foreground text-left break-words">
             Your session is ending soon
           </DialogTitle>
         </DialogHeader>

--- a/components/session-timeout-modal.tsx
+++ b/components/session-timeout-modal.tsx
@@ -96,23 +96,23 @@ export function SessionTimeoutModal({
         showCloseButton={false}
         className="max-w-[480px] bg-card rounded-[6px] border border-border p-0 gap-0"
       >
-        <DialogHeader className="px-6 pt-6 pb-4">
-          <DialogTitle className="font-sans text-[16px] font-bold leading-[24px] text-card-foreground text-left">
+        <DialogHeader className="px-6 pt-6 pb-0">
+          <DialogTitle className="font-source-serif text-[20px] font-semibold leading-[28px] text-card-foreground text-left break-words">
             Your session is ending soon
           </DialogTitle>
-
-          <p
-            className="font-sans text-[56px] font-light leading-[64px] text-card-foreground text-left mt-1"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {formatTime(remaining)}
-          </p>
         </DialogHeader>
+
+        <p
+          className="font-source-serif text-[64px] font-light leading-[64px] text-card-foreground text-left px-6 pt-6 pb-6"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {formatTime(remaining)}
+        </p>
 
         <div className="h-px bg-border mx-6" />
 
-        <DialogDescription className="px-6 pt-4 pb-2 font-sans text-[14px] font-normal leading-[22px] text-foreground text-left">
+        <DialogDescription className="px-6 pt-4 pb-2 font-inter text-[14px] font-normal leading-[22px] text-foreground text-left">
           To keep the system running smoothly, sessions end after inactivity.
           Select <strong className="font-bold text-foreground">Continue session</strong> to keep
           working.

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean;
+  }
+>(({ className, children, showCloseButton = true, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="size-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
+    {...props}
+  />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};


### PR DESCRIPTION
## Summary                                                                                                                                                              
                                                                                                                                                                        
  - Added a reusable `SessionTimeoutModal` component built on `@radix-ui/react-dialog` (via a new shadcn-style `Dialog` UI primitive) styled with the project's existing  
  Tailwind CSS theme variables                                                                                                                                            
  - Added a `SessionTimeoutModalDemo` test harness component with a 5-minute countdown trigger button (marked with a TODO for removal before production)                  
<img width="1071" height="623" alt="Screenshot 2026-02-18 at 4 34 47 PM" src="https://github.com/user-attachments/assets/9135787e-fbe0-419b-a337-2e4098b488c5" />
                                                                                                                                                                          
  ## Changes                                                                                                                                                              
                                                                                                                                                                          
  ### New files                                                                                                                                                           
  - **`components/ui/dialog.tsx`** — Shadcn-style Dialog primitive wrapping `@radix-ui/react-dialog`. Exports `Dialog`, `DialogTrigger`, `DialogContent`, `DialogHeader`,
  `DialogFooter`, `DialogTitle`, `DialogDescription`, and `DialogClose`.
  - **`components/session-timeout-modal.tsx`** — Session timeout modal with:
    - Configurable countdown duration via `countdownSeconds` prop
    - Live countdown timer display (large format, e.g. `4:59`)
    - Auto-triggers `onEndSession` when the countdown reaches zero
    - "End session" and "Continue session" action buttons
    - `aria-live` region on the timer for accessibility
    - `SessionTimeoutModalDemo` export for local testing (5-minute countdown)

  ## Props — `SessionTimeoutModal`

  | Prop | Type | Description |
  |---|---|---|
  | `open` | `boolean` | Controls dialog visibility |
  | `onOpenChange` | `(open: boolean) => void` | Dialog open state callback |
  | `countdownSeconds` | `number` | Initial countdown duration in seconds |
  | `onEndSession` | `() => void` | Called on "End session" click or timeout |
  | `onContinueSession` | `() => void` | Called on "Continue session" click |

  ## Test plan

  - [ ] Render `<SessionTimeoutModalDemo />` on any page and confirm the modal opens on button click
  - [ ] Verify the countdown ticks down correctly from 5:00
  - [ ] Confirm "Continue session" closes the modal and stops the timer
  - [ ] Confirm "End session" closes the modal and stops the timer
  - [ ] Let the timer expire and confirm `onEndSession` fires automatically at `0:00`
  - [ ] Verify modal reopens with a fresh countdown each time it is triggered