### PR TITLE
fix: remove duplicate control mode toasts and improve send button UX

### DIFF
--- a/artifacts/browser/client-kernel.tsx
+++ b/artifacts/browser/client-kernel.tsx
@@ -219,7 +219,6 @@ export function KernelBrowserClient({
     }
 
     onControlModeChange(mode);
-    toast.success(`Control switched to ${mode} mode`);
   };
 
   const disconnectBrowser = async () => {

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -181,7 +181,6 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
                   controlMode: newMode,
                   isFocused: newMode === 'agent' ? false : prev.isFocused, // Reset focus when switching to agent mode
                 }));
-                toast.success(`Control switched to ${newMode} mode`);
                 break;
                 
               case 'error':

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -337,9 +337,9 @@ function PureMultimodalInput({
 
               if (!isLoggedIn) {
                 router.push('/login');
-              } else if (status !== 'ready') {
-                toast.error('Please wait for the model to finish its response!');
-              } else {
+              } else if (status === 'error') {
+                toast.error('Something went wrong. Please try again.');
+              } else if (status === 'ready') {
                 submitForm();
               }
             }
@@ -445,17 +445,16 @@ function PureSendButton({
   status: UseChatHelpers<ChatMessage>['status'];
   isLoggedIn: boolean;
 }) {
-  const hasInput = input.length > 0 && uploadQueue.length === 0;
-  const isDisabled = !isLoggedIn || input.length === 0 || uploadQueue.length > 0;
-  const shouldShowWaitCursor = hasInput && isLoggedIn && (status === 'submitted' || status === 'streaming');
+  const isWorking = status === 'submitted' || status === 'streaming';
+  const isDisabled = !isLoggedIn || input.length === 0 || uploadQueue.length > 0 || isWorking;
 
   const button = (
     <Button
       data-testid="send-button"
-      className={`bg-primary hover:bg-primary/90 disabled:bg-muted disabled:hover:bg-muted rounded-[100px] px-3 py-1.5 flex items-center gap-1 text-primary-foreground disabled:text-muted-foreground text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${shouldShowWaitCursor ? 'cursor-wait' : ''}`}
+      className="bg-primary hover:bg-primary/90 disabled:bg-muted disabled:hover:bg-muted rounded-[100px] px-3 py-1.5 flex items-center gap-1 text-primary-foreground disabled:text-muted-foreground text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       onClick={(event) => {
         event.preventDefault();
-        if (isLoggedIn) {
+        if (isLoggedIn && status === 'ready') {
           submitForm();
         }
       }}
@@ -473,6 +472,17 @@ function PureSendButton({
           <span tabIndex={0}>{button}</span>
         </TooltipTrigger>
         <TooltipContent>Log in to submit</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (isWorking) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span tabIndex={0}>{button}</span>
+        </TooltipTrigger>
+        <TooltipContent>AI is still working</TooltipContent>
       </Tooltip>
     );
   }


### PR DESCRIPTION
## Summary
- Remove redundant `toast.success` on control mode switch from `client.tsx` and `client-kernel.tsx`
- Disable send button while AI is streaming/submitted instead of using `cursor-wait`
- Show "AI is still working" tooltip on disabled send button during active responses
- Handle `status === 'error'` case separately with a clearer error message in submit handler

## Test plan
- [ ] Switch browser control modes and verify no duplicate toasts appear
- [ ] Send a message and confirm the send button is disabled while the AI responds
- [ ] Hover over the disabled send button during a response to see "AI is still working" tooltip
- [ ] Trigger an error state and confirm the updated error message appears

