### PR TITLE
fix: added prompt changes and skip for now language change

### DIFF
--- a/components/ai-elements/gap-analysis-card.tsx
+++ b/components/ai-elements/gap-analysis-card.tsx
@@ -83,7 +83,7 @@ export function GapAnalysisCard({
       parts: [
         {
           type: 'text',
-          text: `Skipped "${name}" for now. Please continue with the next step.`,
+          text: 'Skipped adding more data for now. Please continue with filling in with the data you already have.',
         },
       ],
     });

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -5,7 +5,9 @@ import { agentBrowserSkill } from '../skills/agent-browser/skill';
  * Adapted from the Mastra web-automation-agent for use with AI SDK and agent-browser.
  */
 export const webAutomationSystemPrompt = `
-You are an expert web automation specialist who intelligently does web searches, navigates websites, queries database information, and performs multi-step web automation tasks on behalf of caseworkers applying for benefits for families seeking public support.
+You are an expert web automation specialist who intelligently does web searches, navigates websites, queries database information, and performs multi-step web automation tasks to help caseworkers apply for benefits for families seeking public support.
+
+**IMPORTANT — Applicant identity**: The caseworker is sitting WITH the participant and filling out the participant's OWN application. When a form asks "Are you applying for yourself?", "Who is this application for?", or any similar question — always answer as the PARTICIPANT applying for themselves. Select "Yes" / "Self" / "For myself". NEVER select "on behalf of someone else", "authorized representative", or "third party". The applicant IS the participant.
 
 ## Core Approach
 1. AUTONOMOUS: Take decisive action without asking for permission, except for the last submission step.


### PR DESCRIPTION
This pull request makes minor but important updates to user messaging and prompt instructions to improve clarity and accuracy in the application process. The changes help ensure users understand the data entry process and clarify how the AI handles applicant identity in web automation.

Improvements to user messaging:

* Updated the `GapAnalysisCard` message to clarify that users should continue filling in with the data they already have, instead of simply skipping a step. (`components/ai-elements/gap-analysis-card.tsx`)

Enhancements to AI prompt instructions:

* Revised the `webAutomationSystemPrompt` to clearly state that the caseworker is sitting with the participant and filling out the participant's own application, ensuring the AI always answers identity-related questions as "self" and never as a third party. (`lib/ai/prompts/web-automation.ts`)