### PR TITLE
fix: browser back button to close chat

### DIFF
--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -16,6 +16,7 @@ import { BrowserLoadingState, BrowserErrorState, BrowserTimeoutState } from './b
 import { closeArtifact, useArtifact } from '@/hooks/use-artifact';
 import { KernelBrowserClient } from './client-kernel';
 import { useRouter } from 'next/navigation';
+import { ExitWarningModal } from '@/components/exit-warning-modal';
 
 // Feature flag for AI SDK agent vs Mastra (client-side)
 const useAiSdkAgent = process.env.NEXT_PUBLIC_USE_AI_SDK_AGENT === 'true';
@@ -100,6 +101,10 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
     const isMobile = useIsMobile();
     const { setArtifact } = useArtifact();
     const router = useRouter();
+    const [showBackModal, setShowBackModal] = useState(false);
+    // Keep a ref to the latest metadata so the popstate handler never has a stale closure
+    const metadataRef = useRef(metadata);
+    metadataRef.current = metadata;
     const wsRef = useRef<WebSocket | null>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const frameCountRef = useRef(0);
@@ -628,15 +633,25 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
       window.history.pushState({ browserArtifact: true }, '');
 
       const handlePopState = (event: PopStateEvent) => {
-        if (event.state?.browserArtifact) {
+        if (!event.state?.browserArtifact) return;
+
+        if (metadataRef.current?.isConnected) {
+          // Block Next.js from handling this navigation by stopping propagation
+          // in the capture phase (our listener fires before Next.js's bubble listener)
+          event.stopImmediatePropagation();
+          // Re-push the guard entry so cancel leaves the user on this page
+          window.history.pushState({ browserArtifact: true }, '');
+          setShowBackModal(true);
+        } else {
           closeArtifact(setArtifact);
           router.push('/home');
         }
       };
 
-      window.addEventListener('popstate', handlePopState);
+      // Capture phase fires before Next.js's popstate listener
+      window.addEventListener('popstate', handlePopState, { capture: true });
       return () => {
-        window.removeEventListener('popstate', handlePopState);
+        window.removeEventListener('popstate', handlePopState, { capture: true });
       };
     }, [setArtifact, router]);
 
@@ -648,6 +663,7 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
     // This uses an iframe with Kernel's live-view instead of WebSocket streaming
     if (useAiSdkAgent && metadata?.sessionId) {
       return (
+        <>
         <KernelBrowserClient
           sessionId={metadata.sessionId}
           controlMode={metadata.controlMode}
@@ -676,6 +692,16 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
           }}
           sendMessage={sendMessage}
         />
+        <ExitWarningModal
+          open={showBackModal}
+          onOpenChange={setShowBackModal}
+          onLeaveSession={() => {
+            setShowBackModal(false);
+            closeArtifact(setArtifact);
+            router.push('/home');
+          }}
+        />
+      </>
       );
     }
 
@@ -941,6 +967,15 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
         <div className="flex-1 relative m-4 overflow-hidden min-h-0">
           {renderBrowserContent()}
           </div>
+        <ExitWarningModal
+          open={showBackModal}
+          onOpenChange={setShowBackModal}
+          onLeaveSession={() => {
+            setShowBackModal(false);
+            closeArtifact(setArtifact);
+            router.push('/home');
+          }}
+        />
         </div>
     );
   },

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -630,10 +630,6 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
     // When the browser artifact opens, push a history entry so the browser
     // back button pops our state instead of navigating away from the chat page.
     useEffect(() => {
-      // Push a guard entry onto the history stack. When the user presses back
-      // from this entry, popstate fires with the *destination* state (the previous
-      // entry) — NOT our guard state — so we track "are we at the guard?" with a
-      // local flag rather than checking event.state.
       window.history.pushState({ browserArtifact: true }, '');
       const guardActive = { current: true };
 

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -630,27 +630,33 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
     // When the browser artifact opens, push a history entry so the browser
     // back button pops our state instead of navigating away from the chat page.
     useEffect(() => {
+      // Push a guard entry onto the history stack. When the user presses back
+      // from this entry, popstate fires with the *destination* state (the previous
+      // entry) — NOT our guard state — so we track "are we at the guard?" with a
+      // local flag rather than checking event.state.
       window.history.pushState({ browserArtifact: true }, '');
+      const guardActive = { current: true };
 
       const handlePopState = (event: PopStateEvent) => {
-        if (!event.state?.browserArtifact) return;
+        if (!guardActive.current) return;
 
         if (metadataRef.current?.isConnected) {
-          // Block Next.js from handling this navigation by stopping propagation
-          // in the capture phase (our listener fires before Next.js's bubble listener)
+          // Capture phase + stopImmediatePropagation prevents Next.js's bubble
+          // phase listener from handling the navigation while the modal is open.
           event.stopImmediatePropagation();
-          // Re-push the guard entry so cancel leaves the user on this page
+          // Restore the guard so cancel keeps the user on this page
           window.history.pushState({ browserArtifact: true }, '');
           setShowBackModal(true);
         } else {
+          guardActive.current = false;
           closeArtifact(setArtifact);
           router.push('/home');
         }
       };
 
-      // Capture phase fires before Next.js's popstate listener
       window.addEventListener('popstate', handlePopState, { capture: true });
       return () => {
+        guardActive.current = false;
         window.removeEventListener('popstate', handlePopState, { capture: true });
       };
     }, [setArtifact, router]);

--- a/artifacts/browser/client.tsx
+++ b/artifacts/browser/client.tsx
@@ -13,7 +13,9 @@ import {
 } from '@/components/ui/sheet';
 import { AgentStatusIndicator } from '@/components/agent-status-indicator';
 import { BrowserLoadingState, BrowserErrorState, BrowserTimeoutState } from './browser-states';
+import { closeArtifact, useArtifact } from '@/hooks/use-artifact';
 import { KernelBrowserClient } from './client-kernel';
+import { useRouter } from 'next/navigation';
 
 // Feature flag for AI SDK agent vs Mastra (client-side)
 const useAiSdkAgent = process.env.NEXT_PUBLIC_USE_AI_SDK_AGENT === 'true';
@@ -96,6 +98,8 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
     // =====================================================
     const [lastFrame, setLastFrame] = useState<string | null>(null);
     const isMobile = useIsMobile();
+    const { setArtifact } = useArtifact();
+    const router = useRouter();
     const wsRef = useRef<WebSocket | null>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const frameCountRef = useRef(0);
@@ -617,6 +621,24 @@ export const browserArtifact = new Artifact<'browser', BrowserArtifactMetadata>(
         // Chrome stays alive - agent or "Close Browser" button controls its lifecycle
       };
     }, []);
+
+    // When the browser artifact opens, push a history entry so the browser
+    // back button pops our state instead of navigating away from the chat page.
+    useEffect(() => {
+      window.history.pushState({ browserArtifact: true }, '');
+
+      const handlePopState = (event: PopStateEvent) => {
+        if (event.state?.browserArtifact) {
+          closeArtifact(setArtifact);
+          router.push('/home');
+        }
+      };
+
+      window.addEventListener('popstate', handlePopState);
+      return () => {
+        window.removeEventListener('popstate', handlePopState);
+      };
+    }, [setArtifact, router]);
 
     if (!metadata) {
       return <BrowserLoadingState />;


### PR DESCRIPTION
The main goal is to ensure that pressing the browser's back button while the browser artifact is open will close the artifact and navigate the user back to the home page, instead of leaving the chat context unexpectedly.

## Changes

* Added in artifact close and router navigate to the browser back button 
* Fixes the back button on browser page so it will close the chat window