### PR TITLE
feat: browser navigation guardrails and tab/dialog support

### DIFF
--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -102,26 +102,11 @@ Before filling any fields, do this:
 This prevents back-and-forth where the agent fills some fields, discovers gaps, asks, fills more, discovers more gaps, asks again.
 
 ### Field Interaction
-- **ALWAYS use snapshot refs** (@e1, @e2, etc.) to target fields. Do NOT use \`getbylabel\` as your first choice — it fails on forms with repeated sections (home/mailing/facility address, applicant/household member). Take a snapshot, read the refs, use them.
+Follow the Browser Automation skill rules above for selectors, masked fields, fill vs type, maxlength, and snapshot discipline.
+
+Additional form-specific rules:
 - Skip disabled/grayed-out fields with a note
-- **CRITICAL — Respect \`maxlength\` attributes**: Before filling any field, check its \`maxlength\` from the snapshot or DOM. Strip formatting characters (dashes, slashes, parentheses, spaces) so the value fits. Common patterns:
-  - SSN with \`maxlength="9"\` → digits only: \`"123456789"\`
-  - Birthdate with \`maxlength="8"\` → digits only: \`"01022000"\`
-  - Phone with \`maxlength="10"\` → digits only: \`"7775551234"\`
-  - State with \`maxlength="2"\` → abbreviation: \`"CA"\`
-- **CRITICAL — Use \`type\` (not \`fill\`) for masked/formatted fields**: Fields like SSN, birthdate, phone, and state abbreviations often have JavaScript input masks. The \`fill\` action sets the value programmatically and **bypasses** JS event handlers, so the value silently fails or gets wiped. For these fields:
-  1. Click the field first to focus it
-  2. Use the \`type\` action with \`clear: true\` — this simulates real keystrokes and triggers the JS formatters
-  3. After typing, verify with \`inputvalue\` to confirm the value stuck
-  4. If empty or wrong, the field has a mask — click, wait briefly, re-type
-  **Rule of thumb**: Use \`fill\` for plain text fields (name, address, city, email). Use \`type\` for any field that might have input formatting (SSN, date, phone, state, zip).
-- **Verify masked fields**: After typing into SSN, birthdate, phone, or state fields, use \`inputvalue\` to confirm the value actually took. If it's empty or wrong, retry with \`type\`.
-- If a field doesn't accept input on first try, click it to activate before typing
-- ALWAYS re-snapshot after interactions that change the page (clicking radio buttons, selecting dropdowns, navigating). Refs go stale after DOM changes.
-- On complex pages with lots of navigation/sidebar elements, use \`{ action: "snapshot", selector: "form" }\` to scope the snapshot to just the form area — this dramatically reduces noise
-- If \`select\` fails on a dropdown, it's likely a custom widget (Select2/Chosen). Click the dropdown trigger, wait, snapshot, then click the option.
 - Do not submit at the end. Call the \`formSummary\` tool to show the caseworker a card of everything that was filled in (categorized as: from database / from caseworker / inferred by agent). Then write one short sentence asking them to review and submit.
-- **Disabled submit buttons**: If a submit button is disabled after you've filled all fields, do NOT waste steps debugging it with \`evaluate\`. The most likely cause is a CAPTCHA/Turnstile still solving in the background (the auto-solver handles this). Since you should not be submitting anyway, just note it in your summary and move on.
 - Do not close the browser unless the user asks you to
 
 ## Autonomous Progression

--- a/lib/ai/skills/agent-browser/references/commands.md
+++ b/lib/ai/skills/agent-browser/references/commands.md
@@ -6,74 +6,95 @@ Complete reference for all agent-browser commands. Load this when you need detai
 
 | Command | Description |
 |---------|-------------|
-| `open <url>` | Navigate to URL (aliases: goto, navigate) |
+| `open <url>` | Navigate to URL (aliases: goto, navigate). Auto-prepends https:// if no protocol given |
 | `back` | Go back in history |
 | `forward` | Go forward in history |
 | `reload` | Refresh current page |
-| `close` | Close browser |
+| `close` | Close browser (aliases: quit, exit) |
+| `connect <port>` | Connect to browser via CDP port |
 
 ## Snapshot
 
 | Command | Description |
 |---------|-------------|
 | `snapshot` | Full accessibility tree with labels |
-| `snapshot -i` | Interactive elements only (with refs) |
+| `snapshot -i` | Interactive elements only (with refs) — recommended |
+| `snapshot -i -C` | Include cursor-interactive elements (divs with onclick, cursor:pointer) |
 | `snapshot -c` | Compact output |
+| `snapshot -d 3` | Limit depth to 3 |
 | `snapshot -s "#main"` | Scope to CSS selector |
-
-## Label Locators (RECOMMENDED for forms)
-
-| Command | Description |
-|---------|-------------|
-| `find label "First Name" fill "John"` | Fill field by its label |
-| `find label "Yes" click` | Click labeled checkbox/radio |
-| `find label "State" select "California"` | Select dropdown by label |
-| `find label "Email" type "test@test.com"` | Type into labeled field |
 
 ## Interaction (by ref or CSS selector)
 
 | Command | Description |
 |---------|-------------|
 | `click <sel>` | Click element |
+| `click <sel> --new-tab` | Click and open in new tab |
 | `dblclick <sel>` | Double-click element |
-| `fill <sel> "text"` | Clear field and fill |
-| `type <sel> "text"` | Type into element (appends) |
+| `focus <sel>` | Focus element |
+| `fill <sel> "text"` | Clear field and fill (plain text only: name, address, city, email) |
+| `type <sel> "text"` | Type into element without clearing (use for masked/formatted fields) |
 | `press Enter` | Press key (Tab, Escape, ArrowDown, Control+a) |
+| `keyboard type "text"` | Type with real keystrokes at current focus (no selector) |
+| `keyboard inserttext "text"` | Insert text without key events (no selector) |
+| `keydown <key>` | Hold key down |
+| `keyup <key>` | Release key |
 | `hover <sel>` | Hover over element |
-| `select <sel> "value"` | Select dropdown option |
+| `select <sel> "value"` | Select dropdown option (native `<select>` only) |
+| `select <sel> "a" "b"` | Select multiple options |
 | `check <sel>` | Check checkbox |
 | `uncheck <sel>` | Uncheck checkbox |
 | `upload <sel> "/path/to/file"` | Upload file |
 | `drag <sel1> <sel2>` | Drag from sel1 to sel2 |
+| `scrollintoview <sel>` | Scroll element into view (alias: scrollinto) |
 
 Note: `<sel>` can be a ref (`@e1`), CSS selector (`"#firstName"`), or other locator.
+
+## Semantic Locators (alternative to refs)
+
+| Command | Description |
+|---------|-------------|
+| `find role <role> <action> --name "Name"` | By ARIA role (e.g., `find role button click --name "Submit"`) |
+| `find text "Sign In" click` | By text content |
+| `find text "Sign In" click --exact` | By exact text match |
+| `find label "Email" fill "user@test.com"` | By label |
+| `find placeholder "Search" type "query"` | By placeholder |
+| `find alt "Logo" click` | By alt text |
+| `find title "Close" click` | By title attribute |
+| `find testid "submit-btn" click` | By data-testid |
+| `find first ".item" click` | First match |
+| `find last ".item" click` | Last match |
+| `find nth 2 "a" hover` | Nth match |
+
+Actions: `click`, `fill`, `type`, `hover`, `focus`, `check`, `uncheck`, `text`
 
 ## Information Retrieval
 
 | Command | Description |
 |---------|-------------|
-| `get text @e1` | Get text content |
-| `get value @e1` | Get input field value |
-| `get html @e1` | Get innerHTML |
-| `get attr @e1 href` | Get attribute value |
+| `get text <sel>` | Get text content |
+| `get value <sel>` | Get input field value |
+| `get html <sel>` | Get innerHTML |
+| `get attr <sel> <attr>` | Get attribute value |
 | `get url` | Get current URL |
 | `get title` | Get page title |
-| `get count @e1` | Count matching elements |
-| `get box @e1` | Get bounding box |
+| `get count <sel>` | Count matching elements |
+| `get box <sel>` | Get bounding box |
+| `get styles <sel>` | Get computed styles (font, color, bg, etc.) |
 
 ## State Checks
 
 | Command | Description |
 |---------|-------------|
-| `is visible @e1` | Check visibility |
-| `is enabled @e1` | Check if enabled |
-| `is checked @e1` | Check checkbox state |
+| `is visible <sel>` | Check visibility |
+| `is enabled <sel>` | Check if enabled |
+| `is checked <sel>` | Check checkbox state |
 
 ## Waiting
 
 | Command | Description |
 |---------|-------------|
-| `wait @e1` | Wait for element in DOM |
+| `wait <sel>` | Wait for element in DOM |
 | `wait 2000` | Wait milliseconds |
 | `wait --text "Welcome"` | Wait for text on page |
 | `wait --url "**/dashboard"` | Wait for URL pattern |
@@ -81,29 +102,83 @@ Note: `<sel>` can be a ref (`@e1`), CSS selector (`"#firstName"`), or other loca
 | `wait --fn "document.readyState === 'complete'"` | Wait for JS condition |
 | `wait --download` | Wait for download |
 
+Load states: `load`, `domcontentloaded`, `networkidle`
+
 ## Scrolling
 
 | Command | Description |
 |---------|-------------|
-| `scroll down 500` | Scroll down pixels |
+| `scroll down 500` | Scroll down pixels (default: down 300px) |
 | `scroll up 300` | Scroll up pixels |
 | `scroll left 200` | Scroll left |
 | `scroll right 200` | Scroll right |
-| `scrollintoview @e1` | Scroll element into view |
+| `scroll down 500 --selector "div.content"` | Scroll within a specific container |
+| `scrollintoview <sel>` | Scroll element into view |
 
-## Screenshots
+## Tabs and Windows
 
 | Command | Description |
 |---------|-------------|
-| `screenshot page.png` | Capture viewport |
+| `tab` | List all open tabs |
+| `tab new [url]` | Open new tab (optionally with URL) |
+| `tab <index>` | Switch to tab by index (e.g., `tab 2`) |
+| `tab close` | Close current tab |
+| `tab close <index>` | Close tab by index |
+| `window new` | Open new window |
+
+## Screenshots and PDF
+
+| Command | Description |
+|---------|-------------|
+| `screenshot` | Save to temporary directory |
+| `screenshot page.png` | Capture viewport to path |
 | `screenshot --full page.png` | Capture full page |
+| `screenshot --annotate` | Annotated screenshot with numbered element labels |
+| `pdf output.pdf` | Save page as PDF |
 
 ## Frame Handling
 
 | Command | Description |
 |---------|-------------|
-| `frame @e1` | Switch to iframe |
+| `frame <sel>` | Switch to iframe (e.g., `frame "#iframe"`) |
 | `frame main` | Return to main frame |
+
+## Dialogs
+
+| Command | Description |
+|---------|-------------|
+| `dialog accept [text]` | Accept dialog (optionally with prompt text) |
+| `dialog dismiss` | Dismiss dialog |
+
+## Mouse Control
+
+| Command | Description |
+|---------|-------------|
+| `mouse move <x> <y>` | Move mouse to coordinates |
+| `mouse down [button]` | Press mouse button (left/right/middle) |
+| `mouse up [button]` | Release mouse button |
+| `mouse wheel <dy> [dx]` | Scroll wheel |
+
+## JavaScript Evaluation
+
+| Command | Description |
+|---------|-------------|
+| `eval "document.title"` | Simple expressions only |
+| `eval -b "<base64>"` | Any JavaScript (base64 encoded) — avoids shell escaping issues |
+| `eval --stdin` | Read script from stdin |
+
+Use `-b`/`--base64` or `--stdin` for reliable execution with nested quotes or special characters.
+
+## Network
+
+| Command | Description |
+|---------|-------------|
+| `network route <url>` | Intercept requests |
+| `network route <url> --abort` | Block requests |
+| `network route <url> --body '{}'` | Mock response |
+| `network unroute [url]` | Remove routes |
+| `network requests` | View tracked requests |
+| `network requests --filter api` | Filter requests |
 
 ## Storage & Cookies
 
@@ -115,10 +190,66 @@ Note: `<sel>` can be a ref (`@e1`), CSS selector (`"#firstName"`), or other loca
 | `storage local` | List localStorage |
 | `storage local key` | Get localStorage value |
 | `storage local set key value` | Set localStorage |
+| `storage local clear` | Clear all localStorage |
 
 ## Session State
 
 | Command | Description |
 |---------|-------------|
-| `state save session.json` | Save browser state |
+| `state save session.json` | Save cookies, storage, auth state |
 | `state load session.json` | Load browser state |
+
+## Browser Settings
+
+| Command | Description |
+|---------|-------------|
+| `set viewport <w> <h> [scale]` | Set viewport size (scale for retina, e.g., 2) |
+| `set device "iPhone 14"` | Emulate device (viewport + user agent) |
+| `set geo <lat> <lon>` | Set geolocation |
+| `set offline on` | Toggle offline mode |
+| `set headers '<json>'` | Extra HTTP headers |
+| `set credentials <user> <pass>` | HTTP basic auth |
+| `set media dark` | Emulate color scheme (dark/light) |
+| `set media light reduced-motion` | Light mode + reduced motion |
+
+## Video Recording
+
+| Command | Description |
+|---------|-------------|
+| `record start ./demo.webm` | Start recording |
+| `record stop` | Stop and save video |
+| `record restart ./take2.webm` | Stop current + start new |
+
+## Debugging
+
+| Command | Description |
+|---------|-------------|
+| `--headed open <url>` | Show browser window |
+| `console` | View console messages |
+| `console --clear` | Clear console |
+| `errors` | View page errors |
+| `errors --clear` | Clear errors |
+| `highlight <sel>` | Highlight element |
+| `trace start` | Start recording trace |
+| `trace stop trace.zip` | Stop and save trace |
+
+## Diff (Compare Page States)
+
+| Command | Description |
+|---------|-------------|
+| `diff snapshot` | Compare current vs last snapshot |
+| `diff snapshot --baseline before.txt` | Compare current vs saved file |
+| `diff screenshot --baseline before.png` | Visual pixel diff |
+| `diff url <url1> <url2>` | Compare two pages |
+
+## Global Options
+
+| Option | Description |
+|---------|-------------|
+| `--session <name>` | Isolated browser session |
+| `--json` | JSON output for parsing |
+| `--headed` | Show browser window (not headless) |
+| `--cdp <port>` | Connect via Chrome DevTools Protocol |
+| `-p <provider>` | Cloud browser provider (--provider) |
+| `--proxy <url>` | Use proxy server |
+| `--ignore-https-errors` | Ignore SSL certificate errors |

--- a/lib/ai/skills/agent-browser/references/snapshot-refs.md
+++ b/lib/ai/skills/agent-browser/references/snapshot-refs.md
@@ -1,29 +1,29 @@
 # Snapshot and Refs Guide
 
-Understanding when to use snapshots vs label locators.
+Understanding snapshot modes, ref lifecycle, and selector strategy.
 
-## When to Use What
+## Selector Priority
 
-### Use `find label` (PREFERRED for forms)
-When the form has visible labels next to fields:
-```
-browser({ command: "find label \"First Name\" fill \"John\"" })
-browser({ command: "find label \"Email\" fill \"john@example.com\"" })
-```
-No snapshot needed - uses accessibility tree directly.
+### 1. Refs (@e3) or CSS IDs (#id) — PREFERRED
+After every snapshot you get refs. If the snapshot also shows `[id="..."]`, you can use `#id` directly — CSS IDs are stable across DOM changes.
 
-### Use Snapshot + Refs
-When you need to see the page structure or labels aren't working:
 ```
-browser({ command: "snapshot -i" })
-# Output: textbox [ref=@e1], button [ref=@e2]
-browser({ command: "fill @e1 \"John\"" })
+browser({ action: "snapshot", selector: "form" })
+// Output: textbox "First Name" [ref=@e3] [id="firstNameTxt"]
+
+// Either works:
+browser({ action: "fill", selector: "@e3", value: "John" })
+browser({ action: "fill", selector: "#firstNameTxt", value: "John" })
 ```
 
-### Use CSS Selectors
-When IDs are visible and labels/refs don't work:
+### 2. Label Locators — LAST RESORT
+Use `getbylabel` ONLY when the label is globally unique AND the element has no ID. NEVER use for common labels like "Yes", "No", "First Name", "State" — these appear multiple times on benefit forms and cause strict-mode violations.
+
+**NEVER include asterisks or colons** in labels.
+
 ```
-browser({ command: "fill \"#firstName\" \"John\"" })
+// Only when label is truly unique and no IDs available:
+browser({ action: "getbylabel", label: "Social Security Number", subaction: "fill", value: "123456789" })
 ```
 
 ## Ref Format
@@ -36,15 +36,15 @@ browser({ command: "fill \"#firstName\" \"John\"" })
 ```
 
 Each ref includes:
-- `@eN` - The reference ID
-- `[type attributes]` - Element type and key attributes
-- `"text"` - Visible text content
+- `@eN` — The reference ID
+- `[type attributes]` — Element type and key attributes
+- `"text"` — Visible text content
 
 ## The Golden Rule
 
 **Refs are invalidated when the page changes.**
 
-You MUST re-snapshot after:
+Re-snapshot after:
 - Page navigation (`open`, clicking links)
 - Form submission
 - Dropdown/modal opening
@@ -54,7 +54,7 @@ You MUST re-snapshot after:
 ## Snapshot Modes
 
 ### `snapshot` (Full Tree)
-Shows page structure with labels - useful for understanding the form:
+Shows page structure with labels — useful for understanding the form:
 ```
 heading "Welcome to Our Site"
   paragraph "Please fill out the form below"
@@ -75,7 +75,7 @@ button "Submit" [ref=@e4]
 ### `snapshot -s "#formId"` (Scoped)
 For large pages, scope to a specific container:
 ```
-browser({ command: "snapshot -i -s \"#registrationForm\"" })
+browser({ action: "snapshot", selector: "#registrationForm" })
 ```
 
 ## Troubleshooting
@@ -90,15 +90,12 @@ browser({ command: "snapshot -i -s \"#registrationForm\"" })
 
 ### Too many elements in snapshot
 **Cause**: Page is large/complex
-**Fix**: Use `-s` to scope to a container
-
-### Ref is ambiguous
-**Cause**: Multiple similar elements
-**Fix**: Use CSS selector if IDs are visible, or use `find first @e1` / `find nth 2 @e1`
+**Fix**: Use `selector` to scope to a container (`form`, `main`, `#content`)
 
 ## Best Practices
 
-1. **Snapshot → Interact → Snapshot** - Always follow this cycle
-2. **Use `-i` for forms** - Cleaner output, less noise
-3. **Check refs before critical actions** - Re-snapshot before submitting
-4. **Don't cache refs** - Always use refs from the most recent snapshot
+1. **Snapshot → Interact → Snapshot** — Always follow this cycle
+2. **Scope on complex pages** — Use `selector: "form"` to reduce noise
+3. **Check refs before critical actions** — Re-snapshot before submitting
+4. **Don't cache refs** — Always use refs from the most recent snapshot
+5. **Prefer CSS IDs when available** — More stable than refs across DOM changes

--- a/lib/ai/skills/agent-browser/skill.ts
+++ b/lib/ai/skills/agent-browser/skill.ts
@@ -142,9 +142,11 @@ Multiple modals can appear in sequence (e.g. address validation → county selec
 **Workflow:**
 1. Snapshot the page
 2. If minimal content → modal is present. Snapshot with: \`selector: "[role=dialog]"\`, or \`.ReactModal__Overlay\`, or \`.modal\`, or \`[aria-modal=true]\`
-3. Use refs from that snapshot to interact (fill dropdowns, click buttons)
+3. Use refs from that snapshot to interact — if there's a native \`<select>\`/combobox, use \`select\`; if it's a custom dropdown (button that opens a listbox), click to open → snapshot again → click the option
 4. After dismissing, go back to step 1 — another modal may have appeared
 5. When the full page is visible again, resume normal workflow
+
+**County/location selection modals** (common on benefits sites): These often appear after address entry. The modal contains a dropdown (native or custom) and a Continue button. Scope your snapshot to \`[role=dialog]\`, select the county, click Continue. Do NOT use \`evaluate\` to dismiss these — use the refs.
 
 ### Google Translate Bar
 

--- a/lib/ai/skills/agent-browser/skill.ts
+++ b/lib/ai/skills/agent-browser/skill.ts
@@ -16,6 +16,7 @@ export const agentBrowserSkill = `
 5. **Use \`fill\` ONLY for plain text fields** — name, address, city, email. Nothing with formatting.
 6. **NEVER mention technical terms in your text messages.** No refs, selectors, snapshot, DOM, field IDs, evaluate, CSS, getbylabel, strict mode, interactive elements, or any code-related terms. Your audience is a caseworker. Describe actions in human terms only: "Filling in the personal information" — NOT "I have all the refs" or "Using CSS selectors".
 7. **Call multiple tools in parallel when they are independent.** After a snapshot gives you refs, you can fill/type multiple fields simultaneously in one response. You can also fetch database records while navigating the browser. Do NOT parallelize actions that depend on each other (e.g., snapshot then use refs from that snapshot).
+8. **\`evaluate\` is for workarounds, not form filling.** Use it to remove overlays (Google Translate bar), enable a stuck submit button after CAPTCHA solves, or read field attributes. NEVER use it to find, click, fill, or check elements — use the proper actions instead. For disabled submit buttons, follow the CAPTCHA section step by step before using evaluate.
 
 ## Snapshot Strategy (CRITICAL)
 
@@ -170,7 +171,9 @@ The browser runs in Kernel stealth mode with an **auto-solver** that handles Clo
 3. If a submit button is disabled and you've filled all required fields, wait for the CAPTCHA to resolve: \`{ action: "wait", timeout: 5000 }\` then re-check
 4. If still disabled after waiting, take a snapshot to check for missing required fields — the issue is likely unfilled fields, not the CAPTCHA
 5. **Verification checklist** — if submit is still disabled after the 5-second wait, take a snapshot and confirm ALL of the following: (a) all required fields are filled, (b) the CAPTCHA/Turnstile widget visually shows solved/success (green checkmark, "Success", etc.), (c) no error messages are displayed on the page
-6. **Captcha-stuck-button fix** — if ALL three conditions above are confirmed (fields filled + captcha solved + no errors) and the submit button is STILL disabled, the captcha solver succeeded but the form's JS failed to re-enable the button. Use \`evaluate\` to remove the disabled attribute: \`{ action: "evaluate", script: "const btn = document.querySelector('#btnSubmit, [type=\\"submit\\"]:disabled, button[type=\\"submit\\"]:disabled'); if (btn) btn.removeAttribute('disabled');" }\`. Do NOT click submit after this — proceed with \`formSummary\` as normal so the caseworker can review and submit manually.
+6. **Captcha-stuck-button fix** — if ALL three conditions above are confirmed (fields filled + captcha solved + no errors) and the submit button is STILL disabled, the captcha solver succeeded but the form's JS failed to re-enable the button. Use **exactly this script and nothing else**:
+   \`{ action: "evaluate", script: "const btn = document.querySelector('#btnSubmit, [type=\\"submit\\"]:disabled, button[type=\\"submit\\"]:disabled'); if (btn) btn.removeAttribute('disabled');" }\`
+   Do NOT invent your own JavaScript. Do NOT set JS variables like \`isCaptchaChecked\`, \`isExpanded\`, or any other page state. Do NOT click submit after this — proceed with \`formSummary\` as normal so the caseworker can review and submit manually.
 
 ## Form Completion Summary
 

--- a/lib/ai/skills/agent-browser/skill.ts
+++ b/lib/ai/skills/agent-browser/skill.ts
@@ -1,7 +1,7 @@
 /**
  * Agent-browser skill - Core workflow for browser automation.
  *
- * This is the main skill loaded into context. Keep it concise (<200 lines).
+ * This is the main skill loaded into context. Keep it concise.
  * Detailed references are in ./references/ and loaded on demand.
  */
 export const agentBrowserSkill = `
@@ -79,42 +79,16 @@ browser({ action: "type", selector: ":focus", text: "Doe" })
 
 ## Custom Dropdowns (Select2, Chosen, Drupal)
 
-The \`select\` action ONLY works on native \`<select>\` elements. Many CMS forms (Drupal, WordPress) use Select2 or Chosen widgets that render custom HTML. Signs you're dealing with a custom dropdown:
-- \`select\` command fails or does nothing
-- Snapshot shows a \`<span>\` or \`<div>\` with class like "select2" instead of a \`<select>\`
-- The dropdown trigger looks like a styled container, not a native select
-
-**Pattern for custom dropdowns:**
-\`\`\`
-// 1. Click the dropdown trigger (the visible styled element, NOT a hidden <select>)
-browser({ action: "click", selector: "@e5" })
-// 2. Wait for options to render
-browser({ action: "wait", timeout: 300 })
-// 3. Snapshot to find the options (scope to dropdown panel if possible)
-browser({ action: "snapshot", interactive: true })
-// 4. Click the desired option
-browser({ action: "click", selector: "@e12" })
-// 5. Re-snapshot to confirm selection and get fresh refs
-browser({ action: "snapshot", selector: "form" })
-\`\`\`
-
-**If the dropdown has a search box** (common in Select2):
-\`\`\`
-browser({ action: "click", selector: "@e5" })          // Open dropdown
-browser({ action: "wait", timeout: 300 })
-browser({ action: "type", selector: ":focus", text: "California" })  // Type into search
-browser({ action: "wait", timeout: 300 })
-browser({ action: "snapshot", interactive: true })         // Find filtered options
-browser({ action: "click", selector: "@e12" })          // Click matching option
-\`\`\`
+If \`select\` fails, the dropdown is a custom widget. Click the trigger → wait → snapshot → click the option → re-snapshot. See \`references/form-automation.md\` for detailed patterns including Select2 search boxes.
 
 ## Essential Commands
 
 ### Navigation & Snapshot
-- \`{ action: "navigate", url: "<url>" }\` - Go to URL
+- \`{ action: "navigate", url: "<url>" }\` - Go to URL (already waits for load)
 - \`{ action: "snapshot" }\` - Full accessibility tree (ALWAYS first)
 - \`{ action: "snapshot", selector: "form" }\` - Scoped snapshot (complex pages)
 - \`{ action: "snapshot", interactive: true }\` - Interactive elements with refs only
+- \`{ action: "url" }\` - Get current URL (use to verify you're still on the right domain)
 - \`{ action: "back" }\` / \`{ action: "forward" }\` - Browser navigation (AVOID during form filling — may wipe state)
 
 ### Interaction
@@ -128,10 +102,19 @@ browser({ action: "click", selector: "@e12" })          // Click matching option
 - \`{ action: "scrollintoview", selector: "@e1" }\` - Scroll element into view
 
 ### Information & Waiting
-- \`{ action: "gettext", selector: "<sel>" }\` / \`{ action: "inputvalue", selector: "<sel>" }\` / \`{ action: "url" }\`
+- \`{ action: "gettext", selector: "<sel>" }\` / \`{ action: "inputvalue", selector: "<sel>" }\`
 - \`{ action: "wait", selector: "<sel>" }\` / \`{ action: "wait", timeout: 2000 }\` — use sparingly, only when waiting for async content
 - \`{ action: "waitforloadstate", state: "networkidle" }\` — RARELY needed. Navigate already waits for load. Only use after full-page navigations via link clicks, never after fills/types/clicks on form elements
 - \`{ action: "scroll", direction: "down", amount: 500 }\` / \`{ action: "scroll", direction: "up", amount: 300 }\`
+
+### Tabs & Dialogs
+- \`{ action: "tab_list" }\` - List open tabs
+- \`{ action: "tab_new", url: "<url>" }\` - Open new tab (optionally with URL)
+- \`{ action: "tab_switch", index: 2 }\` - Switch to tab by index
+- \`{ action: "tab_close" }\` - Close current tab
+- \`{ action: "dialog", response: "accept" }\` / \`{ action: "dialog", response: "dismiss" }\` - Handle browser dialogs
+- \`{ action: "frame", selector: "#iframe" }\` - Switch to iframe
+- \`{ action: "mainframe" }\` - Return to main frame
 
 ## Masked/Formatted Fields (CRITICAL)
 
@@ -148,57 +131,6 @@ Many form fields (SSN, birthdate, phone, state, zip) have JavaScript input masks
 - State \`maxlength="2"\` → \`"CA"\`
 
 **Always verify**: After typing into masked fields, use \`inputvalue\` to confirm the value stuck. If empty/wrong, click the field, wait, and re-type.
-
-## Form Workflow Example (with proper snapshot discipline)
-
-\`\`\`
-browser({ action: "navigate", url: "https://example.com/application" })
-browser({ action: "snapshot" })              // 1. Full snapshot first (navigate already waits for load)
-
-// Complex page? Scope to the form area
-browser({ action: "snapshot", selector: "form" })   // 2. Reduces 200+ elements to just form fields
-// Snapshot shows refs: textbox "First Name" [ref=@e3], textbox "Last Name" [ref=@e4],
-//   textbox "Email" [ref=@e5], radio "Yes" [ref=@e7], textbox "SSN" [ref=@e10],
-//   textbox "Birthdate" [ref=@e11], textbox "Phone" [ref=@e12]
-
-// *** PARALLEL: Fill all plain text fields in ONE response (they are independent) ***
-browser({ action: "fill", selector: "@e3", value: "John" })
-browser({ action: "fill", selector: "@e4", value: "Doe" })
-browser({ action: "fill", selector: "@e5", value: "john@example.com" })
-
-// *** PARALLEL: Handle masked fields — each field's click+type+verify is independent ***
-// Field 1: SSN
-browser({ action: "click", selector: "@e10" })
-browser({ action: "type", selector: "@e10", text: "123456789", clear: true })
-// Field 2: Birthdate
-browser({ action: "click", selector: "@e11" })
-browser({ action: "type", selector: "@e11", text: "01022000", clear: true })
-// Field 3: Phone
-browser({ action: "click", selector: "@e12" })
-browser({ action: "type", selector: "@e12", text: "7775551234", clear: true })
-
-// *** PARALLEL: Verify all masked fields at once ***
-browser({ action: "inputvalue", selector: "@e10" })  // Verify SSN
-browser({ action: "inputvalue", selector: "@e11" })  // Verify birthdate
-browser({ action: "inputvalue", selector: "@e12" })  // Verify phone
-
-// Radio button — click ref, then re-snapshot (DOM may change with conditional fields)
-browser({ action: "click", selector: "@e7" })
-browser({ action: "snapshot", selector: "form" })   // 3. Re-snapshot: radio may reveal new fields
-
-// Custom dropdown (Select2) — NOT a native select
-browser({ action: "click", selector: "@e8" })              // Click dropdown trigger
-browser({ action: "wait", timeout: 300 })
-browser({ action: "snapshot", interactive: true })          // Find dropdown options
-browser({ action: "click", selector: "@e15" })             // Click desired option
-browser({ action: "snapshot", selector: "form" })          // 4. Re-snapshot after selection
-
-// Scroll to see more fields if form is long
-browser({ action: "scrollintoview", selector: "@e20" })
-browser({ action: "snapshot", selector: "form" })   // 5. Fresh refs after scroll
-
-browser({ action: "snapshot" })               // Final verification before submit
-\`\`\`
 
 ## Modals, Dialogs & Popups
 
@@ -237,7 +169,8 @@ The browser runs in Kernel stealth mode with an **auto-solver** that handles Clo
    - You can continue doing other independent work (gap analysis, database lookups) while waiting — the auto-solver runs in the background
 3. If a submit button is disabled and you've filled all required fields, wait for the CAPTCHA to resolve: \`{ action: "wait", timeout: 5000 }\` then re-check
 4. If still disabled after waiting, take a snapshot to check for missing required fields — the issue is likely unfilled fields, not the CAPTCHA
-5. Do NOT use \`evaluate\` to debug why the submit button is disabled — the most common causes are: (a) CAPTCHA still solving (wait), (b) required fields not filled (snapshot and check), (c) the form doesn't allow submission and the agent should stop anyway per instructions
+5. **Verification checklist** — if submit is still disabled after the 5-second wait, take a snapshot and confirm ALL of the following: (a) all required fields are filled, (b) the CAPTCHA/Turnstile widget visually shows solved/success (green checkmark, "Success", etc.), (c) no error messages are displayed on the page
+6. **Captcha-stuck-button fix** — if ALL three conditions above are confirmed (fields filled + captcha solved + no errors) and the submit button is STILL disabled, the captcha solver succeeded but the form's JS failed to re-enable the button. Use \`evaluate\` to remove the disabled attribute: \`{ action: "evaluate", script: "const btn = document.querySelector('#btnSubmit, [type=\\"submit\\"]:disabled, button[type=\\"submit\\"]:disabled'); if (btn) btn.removeAttribute('disabled');" }\`. Do NOT click submit after this — proceed with \`formSummary\` as normal so the caseworker can review and submit manually.
 
 ## Form Completion Summary
 
@@ -254,14 +187,19 @@ Do NOT write a bullet list, do NOT summarize fields in your text response — th
 
 ## Forbidden Actions
 
+### Navigation Boundaries
+Once you navigate to the target application, **stay on that domain.** NEVER click social media links (Facebook, Twitter/X, Instagram, YouTube, LinkedIn, TikTok), "Share"/"Follow" buttons, footer links to external sites, banner ads, or any link to a different domain. Focus ONLY on the form content area (\`main\`, \`form\`, \`#content\`). If you accidentally navigate away, immediately use \`{ action: "back" }\` to return, then re-snapshot.
+
+### Evaluate
+
 - NEVER use \`evaluate\` to find, search for, click, fill, select, or check elements. Always use the proper actions (\`snapshot\`, \`click\`, \`fill\`, \`type\`, \`select\`, \`check\`). If you need to find something, use a snapshot — it gives you refs you can interact with directly.
 - NEVER use \`evaluate\` as a fallback when snapshots return empty/minimal content. Empty snapshots mean a modal is blocking — find and dismiss the modal, then snapshots will work again. Do NOT switch to using \`evaluate\` for the rest of the session.
-- NEVER use \`evaluate\` to enable disabled buttons or bypass validation
+- NEVER use \`evaluate\` to enable disabled buttons or bypass validation — **except** for the captcha-stuck-button fix described in the CAPTCHA section above (all three conditions must be confirmed first)
 - NEVER use \`evaluate\` to modify form state or hidden fields
-- \`evaluate\` is acceptable for: reading simple values (e.g. checking a field's maxLength), and removing known third-party overlays that block clicks (e.g. Google Translate bar — see above)
+- \`evaluate\` is acceptable for: reading simple values (e.g. checking a field's maxLength), removing known third-party overlays that block clicks (e.g. Google Translate bar — see above), and removing the disabled attribute from submit buttons when the captcha solver succeeded but the form's JS failed to re-enable them (see CAPTCHA section)
 - If a button is disabled, fill the required fields — don't force-enable it
 - NEVER use \`reload\` while filling a form — reloading wipes all form state and you lose everything you filled. If a page appears blank or a snapshot returns very little content, wait a moment and re-snapshot. If still blank, it's likely a modal overlay or a page transition — do NOT reload.
-- NEVER use \`back\` during multi-page form filling unless recovering from an error — going back may also wipe form state on the current page
+- NEVER use \`back\` during multi-page form filling — going back wipes form state on the current page. The ONE exception: if you accidentally navigated off the target domain, use \`back\` to return immediately.
 
 ## Parameter Types
 

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -38,25 +38,9 @@ export const createBrowserTool = (sessionId: string, userId: string) =>
   tool({
     description: `Execute browser automation commands on a remote Kernel browser.
 
-Send structured JSON commands with an "action" field and action-specific parameters.
+Send structured JSON commands with an "action" field and action-specific parameters. See the Browser Automation skill for snapshot discipline, selector strategy, and workflow rules.
 
-SNAPSHOT DISCIPLINE (critical for reliable automation):
-- ALWAYS run { action: "snapshot" } as the FIRST command after navigating
-- On complex pages (Drupal, long forms), scope with { action: "snapshot", selector: "form" } or { action: "snapshot", selector: "main" }
-- Use { action: "snapshot", interactive: true } only when you specifically need just interactive element refs
-- ALWAYS re-snapshot after ANY action that changes the DOM (click, select, fill that triggers dynamic fields, navigation)
-- NEVER reuse refs from a previous snapshot after a DOM-changing action — they may be stale
-
-Core workflow:
-1. { action: "navigate", url: "<url>" } — navigate to the page (already waits for load — do NOT add waitforloadstate after this)
-2. { action: "snapshot" } — full page snapshot to understand structure
-3. { action: "snapshot", selector: "form" } — scope to form on complex pages
-4. Interact using refs (@e1, @e2) or label locators
-5. Re-snapshot after every DOM-changing interaction
-
-IMPORTANT: Do NOT use "waitforloadstate" after clicks, fills, types, or other in-page interactions — it wastes a tool call. Navigate already waits for page load internally.
-
-Common commands:
+Commands:
 - { action: "navigate", url: "<url>" } - Navigate to URL
 - { action: "snapshot" } - Full accessibility tree (ALWAYS do this first)
 - { action: "snapshot", selector: "form" } - Scoped snapshot (reduces noise)
@@ -81,17 +65,12 @@ Common commands:
 - { action: "scroll", direction: "down", amount: 500 } - Scroll down 500px
 - { action: "screenshot" } - Take screenshot
 - { action: "back" } / { action: "forward" } - Browser navigation (AVOID during form filling — may wipe state)
-- { action: "evaluate", script: "document.title" } - Run JavaScript (ONLY for reading simple values like maxLength — NEVER to find/search/click elements, use snapshot instead)
+- { action: "evaluate", script: "document.title" } - Run JavaScript (ONLY for reading simple values — NEVER to find/click elements)
+- { action: "tab_list" } / { action: "tab_switch", index: N } / { action: "tab_new" } / { action: "tab_close" } - Tab management
+- { action: "dialog", response: "accept" } / { action: "dialog", response: "dismiss" } - Handle browser dialogs
+- { action: "frame", selector: "#iframe" } / { action: "mainframe" } - Switch between frames
 
-Custom dropdowns (Select2, Chosen, Drupal):
-If "select" fails, the dropdown is likely a custom widget. Use this pattern:
-1. { action: "click", selector: "@e1" } — click the dropdown trigger
-2. { action: "wait", timeout: 300 } — let options render
-3. { action: "snapshot", interactive: true } — find the options
-4. { action: "click", selector: "@e5" } — click the desired option
-
-NEVER use "evaluate" to find, search for, or click elements — use snapshot instead (it gives refs you can click).
-NEVER use "evaluate" to enable disabled buttons, bypass validation, or modify page state.`,
+NEVER navigate away from the target application domain. Do NOT click social media links, share buttons, or external links.`,
     inputSchema: z
       .object({
         action: z.string().describe('The command action (e.g. "navigate", "click", "snapshot", "fill")'),
@@ -111,6 +90,9 @@ NEVER use "evaluate" to enable disabled buttons, bypass validation, or modify pa
         clear: z.boolean().optional().describe('Clear field before typing — must be boolean'),
         direction: z.string().optional().describe('Scroll direction: "up" or "down"'),
         state: z.string().optional().describe('Load state for waitforloadstate (e.g. "networkidle")'),
+        index: z.number().optional().describe('Tab index for tab_switch/tab_close'),
+        response: z.string().optional().describe('Dialog response: "accept" or "dismiss"'),
+        promptText: z.string().optional().describe('Text to enter in prompt dialog'),
       })
       .describe('Structured command object with action and action-specific parameters'),
     execute: async (


### PR DESCRIPTION
## Summary
- Add navigation boundary rules to prevent the browser agent from clicking social media links, share buttons, and external links during form filling (fixes Facebook navigation bug on BenefitsCal)
- Add tab management (`tab_list`, `tab_switch`, `tab_new`, `tab_close`), dialog handling, and frame switching commands to browser tool
  - Updated zod schema with `index`, `response`, `promptText` params
  - Added commands to skill.ts Essential Commands and browser.ts tool description

## Cleanup
- Align `commands.md` and `snapshot-refs.md` references with upstream agent-browser official docs
  - Added tabs, dialogs, mouse, network, settings, video, debugging sections to commands.md
  - Fixed snapshot-refs.md selector priority (was incorrectly recommending `find label` as preferred)
- Deduplicate field interaction rules from web-automation.ts (already covered by skill.ts)
  - Removed ~20 lines of duplicated masked field, maxlength, fill-vs-type instructions
  - Consolidated Navigation Boundaries into Forbidden Actions section
  - Moved Form Workflow Example and Custom Dropdowns detail to references (skill.ts 297→209 lines)