### PR TITLE
feat: adding in the shimmer for the tool group calls

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -44,6 +44,7 @@ import { apricotTools } from '@/lib/ai/tools/apricot';
 import { createBrowserTool } from '@/lib/ai/tools/browser';
 import { gapAnalysis } from '@/lib/ai/tools/gap-analysis';
 import { formSummary } from '@/lib/ai/tools/form-summary';
+import { actionLabel } from '@/lib/ai/tools/action-label';
 import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
@@ -235,6 +236,7 @@ export async function POST(request: Request) {
               ...apricotTools,
               gapAnalysis,
               formSummary,
+              actionLabel,
               browser: createBrowserTool(sessionId, session.user.id),
               loadSkill,
               readSkillFile,

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,9 @@
 @layer base {
     :root {
         --background: 0 0% 100%;
+        /* ai-elements Shimmer component aliases */
+        --color-background: hsl(var(--background));
+        --color-muted-foreground: hsl(var(--muted-foreground));
         --foreground: 48 20% 20%;
         --chat-background: 320 45% 94%;
         --card: 0 0% 100%;
@@ -61,6 +64,9 @@
     }
     .dark {
         --background: 60 6% 10%;
+        /* ai-elements Shimmer component aliases */
+        --color-background: hsl(var(--background));
+        --color-muted-foreground: hsl(var(--muted-foreground));
         --foreground: 46 10% 74%;
         --chat-background: 45 7% 11%;
         --card: 60 3% 15%;

--- a/components/ai-elements/shimmer.tsx
+++ b/components/ai-elements/shimmer.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { MotionProps } from "motion/react";
+import { motion } from "motion/react";
+import type { CSSProperties, ElementType, JSX } from "react";
+import { memo, useMemo } from "react";
+
+type MotionHTMLProps = MotionProps & Record<string, unknown>;
+
+// Cache motion components at module level to avoid creating during render
+const motionComponentCache = new Map<
+  keyof JSX.IntrinsicElements,
+  React.ComponentType<MotionHTMLProps>
+>();
+
+const getMotionComponent = (element: keyof JSX.IntrinsicElements) => {
+  let component = motionComponentCache.get(element);
+  if (!component) {
+    component = motion.create(element);
+    motionComponentCache.set(element, component);
+  }
+  return component;
+};
+
+export interface TextShimmerProps {
+  children: string;
+  as?: ElementType;
+  className?: string;
+  duration?: number;
+  spread?: number;
+}
+
+const ShimmerComponent = ({
+  children,
+  as: Component = "p",
+  className,
+  duration = 2,
+  spread = 2,
+}: TextShimmerProps) => {
+  const MotionComponent = getMotionComponent(
+    Component as keyof JSX.IntrinsicElements
+  );
+
+  const dynamicSpread = useMemo(
+    () => (children?.length ?? 0) * spread,
+    [children, spread]
+  );
+
+  return (
+    <MotionComponent
+      animate={{ backgroundPosition: "0% center" }}
+      className={cn(
+        "relative inline-block bg-[length:250%_100%,auto] bg-clip-text text-transparent",
+        "[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),var(--color-background),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]",
+        className
+      )}
+      initial={{ backgroundPosition: "100% center" }}
+      style={
+        {
+          "--spread": `${dynamicSpread}px`,
+          backgroundImage:
+            "var(--bg), linear-gradient(var(--color-muted-foreground), var(--color-muted-foreground))",
+        } as CSSProperties
+      }
+      transition={{
+        duration,
+        ease: "linear",
+        repeat: Number.POSITIVE_INFINITY,
+      }}
+    >
+      {children}
+    </MotionComponent>
+  );
+};
+
+export const Shimmer = memo(ShimmerComponent);

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -134,6 +134,11 @@ const PurePreviewMessage = ({
     [message.parts],
   );
 
+  const lastToolGroupIdx = useMemo(
+    () => processedParts.reduce((last, p, i) => (p.kind === 'tool-group' ? i : last), -1),
+    [processedParts],
+  );
+
   // Map each checkpoint to the processed-part index it should render after.
   // We use the stepNumber from the checkpoint event to find the Nth step-start
   // in the original parts, then map that part index to the processed-part index.
@@ -226,8 +231,7 @@ const PurePreviewMessage = ({
                   <div key={`message-${message.id}-group-${processed.startIndex}`}>
                     <ToolCallGroup
                       parts={processed.parts as any}
-                      messageId={message.id}
-                      startIndex={processed.startIndex}
+                      isStreaming={isLoading && processedIdx === lastToolGroupIdx}
                     />
                     {cpCards?.map((cp, i) => (
                       <CheckpointCard key={`checkpoint-${cp.stepNumber}-${i}`} summary={cp.summary} />

--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronDown, Layers } from 'lucide-react';
+import { CheckIcon, ChevronDown, Globe, Layers, Monitor, MousePointer, Pencil, Search } from 'lucide-react';
+
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
   Collapsible,
@@ -9,8 +10,8 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { getToolDisplayInfo } from './tool-icon';
-import { Spinner } from './ui/spinner';
 import { cn } from '@/lib/utils';
+import { Shimmer } from '@/components/ai-elements/shimmer';
 
 // --- Types ---
 
@@ -40,8 +41,14 @@ const EXCLUDED_TOOL_TYPES = new Set([
   'tool-formSummary',
 ]);
 
+// Tools included in groups but not shown in the expanded list (they're metadata, not actions)
+const LABEL_TOOL_TYPES = new Set([
+  'tool-actionLabel',
+]);
+
 // Tools that are hidden or have special rendering via CollapsibleWrapper
 const HIDDEN_DISPLAY_NAMES = new Set([
+  'Updated working memory',
   'Executed JavaScript',
   'Retrieved participant data',
 ]);
@@ -139,7 +146,13 @@ export function groupMessageParts(parts: MessagePart[]): ProcessedPart[] {
 
   function flushGroup() {
     if (currentGroupTools.length === 0) return;
-    if (currentGroupTools.length === 1) {
+    // If the only part is a label tool (no real actions), discard it
+    const actionParts = currentGroupTools.filter((p) => !LABEL_TOOL_TYPES.has(p.type));
+    if (actionParts.length === 0) {
+      currentGroupTools = [];
+      return;
+    }
+    if (currentGroupTools.length === 1 && !LABEL_TOOL_TYPES.has(currentGroupTools[0].type)) {
       result.push({
         kind: 'passthrough',
         part: currentGroupTools[0],
@@ -228,18 +241,43 @@ export function generateGroupSummary(parts: MessagePart[]): { noun: string; coun
   return Object.entries(counts).map(([noun, count]) => ({ noun, count }));
 }
 
+// --- Group title generation ---
+
+const GROUP_TITLE_MAP: Record<string, {
+  inProgress: string;
+  done: string;
+  icon: React.ComponentType<any>;
+}> = {
+  fill:     { inProgress: 'Filling in form',       done: 'Filled the form',      icon: Pencil },
+  navigate: { inProgress: 'Navigating to page',    done: 'Navigated to page',    icon: Globe },
+  interact: { inProgress: 'Interacting with page', done: 'Interacted with page', icon: MousePointer },
+  read:     { inProgress: 'Reading page',          done: 'Read page',            icon: Monitor },
+  search:   { inProgress: 'Searching',             done: 'Search complete',      icon: Search },
+  misc:     { inProgress: 'Working on page',       done: 'Completed actions',    icon: Layers },
+};
+
+function getGroupTitle(
+  parts: MessagePart[],
+  isProcessing: boolean,
+): { label: string; Icon: React.ComponentType<any> } {
+  const labelPart = parts.find((p) => p.type === 'tool-actionLabel');
+  const entry = GROUP_TITLE_MAP[labelPart?.input?.category] ?? GROUP_TITLE_MAP.misc;
+  return {
+    label: isProcessing ? entry.inProgress : entry.done,
+    Icon: isProcessing ? entry.icon : CheckIcon,
+  };
+}
+
 // --- Component ---
 
 interface ToolCallGroupProps {
   parts: MessagePart[];
-  messageId: string;
-  startIndex: number;
+  isStreaming?: boolean;
 }
 
 export function ToolCallGroup({
   parts,
-  messageId,
-  startIndex,
+  isStreaming = false,
 }: ToolCallGroupProps) {
   const [open, setOpen] = useState(false);
 
@@ -251,32 +289,34 @@ export function ToolCallGroup({
     return <SingleToolLine part={deduped[0]} />;
   }
 
-  // If the latest tool is still running, show it separately below the summary.
-  // Otherwise all tools are done — include everything in the summary counts.
-  const lastTool = deduped[deduped.length - 1];
-  const isLastRunning = lastTool.state === 'input-available';
-  const summaryParts = isLastRunning ? deduped.slice(0, -1) : deduped;
+  // Group is "in progress" while the parent signals the agent is still streaming this group.
+  const isInProgress = isStreaming;
+  const completedParts = deduped.filter((p) => p.state === 'output-available' && !LABEL_TOOL_TYPES.has(p.type));
+  const displayParts = (isInProgress ? completedParts : deduped).filter((p) => !LABEL_TOOL_TYPES.has(p.type));
 
-  const summary = generateGroupSummary(summaryParts);
+  const { label, Icon: TitleIcon } = getGroupTitle(deduped, isInProgress);
 
   return (
     <Alert className="rounded-xl border-accent bg-background p-3">
       <AlertDescription>
         <Collapsible open={open} onOpenChange={setOpen}>
           {/* Summary line — always visible, clickable to expand */}
-          <CollapsibleTrigger className="flex items-start justify-between w-full cursor-pointer gap-2">
-            <div className="flex items-start gap-2 min-w-0">
-              <Layers size={12} className="text-gray-500 shrink-0 mt-1" />
-              <div className="flex flex-wrap gap-x-1.5 gap-y-1">
-                {summary.map(({ noun, count }) => (
-                  <span
-                    key={noun}
-                    className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground whitespace-nowrap border border-border rounded px-1.5 py-0.5"
-                  >
-                    {count} {count === 1 ? noun : noun + 's'}
-                  </span>
-                ))}
-              </div>
+          <CollapsibleTrigger className="flex items-center justify-between w-full cursor-pointer gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <TitleIcon size={12} className="text-gray-500 shrink-0" />
+              {isInProgress ? (
+                <Shimmer
+                  as="span"
+                  className="text-[10px] leading-[150%] font-ibm-plex-mono"
+                  duration={1.5}
+                >
+                  {label}
+                </Shimmer>
+              ) : (
+                <span className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground">
+                  {label}
+                </span>
+              )}
             </div>
             <span className="inline-flex items-center justify-center p-1 h-auto text-muted-foreground">
               <ChevronDown
@@ -290,10 +330,10 @@ export function ToolCallGroup({
             </span>
           </CollapsibleTrigger>
 
-          {/* Expanded: full sequential list */}
+          {/* Expanded: show completed tools (or all when done) */}
           <CollapsibleContent>
             <div className="flex flex-col gap-0 mt-2 border-t border-border pt-1">
-              {(isLastRunning ? summaryParts : deduped).map((part) => (
+              {displayParts.map((part) => (
                 <SingleToolLine
                   key={part.toolCallId}
                   part={part}
@@ -303,17 +343,6 @@ export function ToolCallGroup({
             </div>
           </CollapsibleContent>
         </Collapsible>
-
-        {/* Current tool — only shown while still running */}
-        {isLastRunning && (
-          <div className="mt-1">
-            <SingleToolLine
-              part={lastTool}
-              compact
-              isRunning
-            />
-          </div>
-        )}
       </AlertDescription>
     </Alert>
   );
@@ -337,11 +366,9 @@ function deduplicateParts(parts: MessagePart[]): MessagePart[] {
 function SingleToolLine({
   part,
   compact = false,
-  isRunning = false,
 }: {
   part: MessagePart;
   compact?: boolean;
-  isRunning?: boolean;
 }) {
   const { text: displayName, icon: Icon } = getToolDisplayInfo(
     part.type,
@@ -355,11 +382,7 @@ function SingleToolLine({
       )}
     >
       <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
-        {isRunning ? (
-          <Spinner className="size-3 shrink-0 text-primary" />
-        ) : (
-          Icon && <Icon size={12} className="text-gray-500 shrink-0" />
-        )}
+        {Icon && <Icon size={12} className="text-gray-500 shrink-0" />}
         {displayName}
       </div>
     </div>

--- a/components/tool-icon.tsx
+++ b/components/tool-icon.tsx
@@ -11,6 +11,7 @@ import {
   FileText,
   Globe,
   Keyboard,
+  Layers,
   Maximize2,
   MessageCircle,
   MessageSquare,
@@ -84,6 +85,7 @@ const getToolIcon = (toolName: string) => {
     'search-participants-by-name': Search,
     'get-participant-with-household': Database,
     'gapAnalysis': FileText,
+    'actionLabel': Layers,
     'loadSkill': Download,
     'readSkillFile': FileText,
   };

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -97,6 +97,13 @@ When given tasks like "apply for WIC in Riverside County", use the following ste
 2. Navigate directly to the application website using the browser tool
 3. Begin form completion immediately, using the database tools to get the data needed to fill the form
 
+## Action Labeling
+
+Before starting each logical group of related browser actions, call the \`actionLabel\` tool once. The UI will display a standardized heading based on the icon you choose.
+
+- Call it ONCE per group, not before every individual action
+- Choose the \`category\` that best matches: \`fill\` (form filling), \`navigate\` (navigation/page load), \`interact\` (clicking/interacting), \`read\` (reading/snapshot), \`search\` (searching), \`misc\` (general)
+
 ## Form Field Protocol
 
 Before filling fields, run gap analysis first — compare what you have against what the form needs, then use the \`gapAnalysis\` tool. When done filling, use the \`formSummary\` tool. Load the \`caseworker-communication\` skill for the full gap analysis and form summary protocols.

--- a/lib/ai/tools/action-label.ts
+++ b/lib/ai/tools/action-label.ts
@@ -1,0 +1,13 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export const actionLabel = tool({
+  description:
+    'Label the upcoming group of browser actions with a human-readable title. Call this ONCE before starting a sequence of related browser actions so the UI can show a meaningful group heading. Do NOT call it before every individual action — only at the start of a logical group. Examples: "Filling in personal information", "Navigating to WIC portal", "Selecting household members", "Reviewing application before submission".',
+  inputSchema: z.object({
+    category: z
+      .enum(['fill', 'navigate', 'interact', 'read', 'search', 'misc'])
+      .describe('Type of action group, used to select the UI icon and label.'),
+  }),
+  execute: async (input) => input,
+});


### PR DESCRIPTION
## Summary

  ### Shimmer component for tool call groups
  Added the `Shimmer` component from `ai-elements` to animate the tool group heading while the agent is actively running. The heading animates while in-progress and resolves to
   a static label with a checkmark icon when done.

  ### `actionLabel` AI tool
  Introduced a new `actionLabel` tool the agent calls once before starting a logical group of browser actions. The agent provides a `category` (`fill`, `navigate`, `interact`,
  `read`, `search`, `misc`) which drives both the heading text and the icon shown in the UI — replacing the previous manual client-side categorization logic.

  **Category → UI mapping:**
  | Category | In Progress | Done | Icon |
  |---|---|---|---|
  | `fill` | Filling in form | Filled the form | Pencil |
  | `navigate` | Navigating to page | Navigated to page | Globe |
  | `interact` | Interacting with page | Interacted with page | MousePointer |
  | `read` | Reading page | Read page | Monitor |
  | `search` | Searching | Search complete | Search |
  | `misc` | Working on page | Completed actions | Layers |

  ### Tool call group redesign
  Replaced the previous pill-based summary (e.g. "3 clicks, 2 fills") with a single collapsible heading. While streaming, the heading shimmer-animates with the action-specific
  icon; once complete, it shows the done label with a checkmark. The `isStreaming` prop (passed from `message.tsx`) controls this state — only the last tool group in a message
  is considered in-progress.

  ### CSS variables
  Added `--color-background` and `--color-muted-foreground` aliases in `globals.css` (light and dark) required by the Shimmer component.