### PR TITLE
feat: tag Vertex AI traces with environment for BigQuery cost tracking

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -295,6 +295,9 @@ export async function POST(request: Request) {
             experimental_telemetry: {
               isEnabled: isProductionEnvironment,
               functionId: 'web-automation-agent',
+              metadata: {
+                environment: process.env.ENVIRONMENT ?? 'unknown',
+              },
             },
           });
 
@@ -352,6 +355,9 @@ export async function POST(request: Request) {
           experimental_telemetry: {
             isEnabled: isProductionEnvironment,
             functionId: 'stream-text',
+            metadata: {
+              environment: process.env.ENVIRONMENT ?? 'unknown',
+            },
           },
         });
 

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -7,7 +7,7 @@ import { xai } from '@ai-sdk/xai';
 import { openai } from '@ai-sdk/openai';
 import { google } from '@ai-sdk/google';
 import { gateway } from '@ai-sdk/gateway';
-import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
 import { createVertex } from '@ai-sdk/google-vertex';
 
 const vertex = createVertex({
@@ -21,6 +21,26 @@ import {
   titleModel,
 } from './models.test';
 import { isTestEnvironment } from '../constants';
+
+// Environment tag injected into every Vertex AI Anthropic request as
+// `metadata.user_id` so BigQuery request-response logs can be filtered
+// by environment (dev / prod / preview-pr-*).
+const environment = process.env.NEXT_PUBLIC_ENVIRONMENT || process.env.ENVIRONMENT || 'unknown';
+
+const vertexAnthropic = createVertexAnthropic({
+  fetch: async (url, init) => {
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        const body = JSON.parse(init.body);
+        body.metadata = { ...body.metadata, user_id: environment };
+        init = { ...init, body: JSON.stringify(body) };
+      } catch {
+        // non-JSON body, pass through
+      }
+    }
+    return fetch(url, init);
+  },
+});
 
 // Anthropic model for web automation via Vertex AI
 export const webAutomationModel = vertexAnthropic('claude-sonnet-4-6');


### PR DESCRIPTION
## Summary
- Injects `metadata.user_id` (set to `ENVIRONMENT` env var) into every Vertex AI Anthropic request via a custom `fetch` wrapper on `createVertexAnthropic`, so BigQuery request-response logs can be filtered by environment (dev/prod/preview-pr-*)
- Adds `environment` to `experimental_telemetry.metadata` on both `streamText` calls for OTel trace tagging
- Companion BigQuery view `vertex_ai_cost_by_environment` was created directly in the `nava-labs` project

## Context
When we upgraded from `claude-sonnet-4-5` to `claude-sonnet-4-6`, the per-model `setPublisherModelConfig` for BigQuery logging wasn't re-applied for the new model IDs. That's now fixed (separate infra change). This PR adds environment tagging so we can break down costs by dev/prod/preview.