### PR TITLE
feat: add @jfkfoundation.org to allowed email domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,6 @@ KERNEL_API_KEY=****
 # Only enabled for preview-pr-* deployments
 USE_GUEST_LOGIN=false
 NEXT_PUBLIC_USE_GUEST_LOGIN=false
+
+# Allowed email domains for OAuth sign-in (comma-separated)
+ALLOWED_EMAIL_DOMAINS=@example.com,@other.org

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -126,7 +126,10 @@ export const {
       // Handle OAuth sign-in with domain validation
       if (account?.provider === 'google' || account?.provider === 'microsoft-entra-id') {
         const email = user.email?.toLowerCase() || '';
-        const allowedDomains = ['@navapbc.com', '@rivco.org', '@navapbc.onmicrosoft.com', '@amplifi.org', '@jfkfoundation.org'];
+        const allowedDomains = (process.env.ALLOWED_EMAIL_DOMAINS || '')
+          .split(',')
+          .map(d => d.trim())
+          .filter(Boolean);
         const isAllowedDomain = allowedDomains.some(domain => email.endsWith(domain));
 
         if (!isAllowedDomain) {

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -126,7 +126,7 @@ export const {
       // Handle OAuth sign-in with domain validation
       if (account?.provider === 'google' || account?.provider === 'microsoft-entra-id') {
         const email = user.email?.toLowerCase() || '';
-        const allowedDomains = ['@navapbc.com', '@rivco.org', '@navapbc.onmicrosoft.com', '@amplifi.org'];
+        const allowedDomains = ['@navapbc.com', '@rivco.org', '@navapbc.onmicrosoft.com', '@amplifi.org', '@jfkfoundation.org'];
         const isAllowedDomain = allowedDomains.some(domain => email.endsWith(domain));
 
         if (!isAllowedDomain) {


### PR DESCRIPTION
## Summary
- Adds `@jfkfoundation.org` to the allowed email domains list in OAuth sign-in validation

## Test plan
- [ ] Verify users with `@jfkfoundation.org` emails can sign in
- [ ] Verify existing allowed domains still work
- [ ] Verify disallowed domains are still rejected