### PR TITLE
feat: add working memory to prevent hallucination during compaction

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -36,7 +36,7 @@ import { actionLabel } from '@/lib/ai/tools/action-label';
 import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
-import { createMessageCompressor, preCompactMessages } from '@/lib/ai/context-compression';
+import { createMessageCompressor } from '@/lib/ai/context-compression';
 
 export const maxDuration = 300; // 5 minutes for web automation tasks
 
@@ -164,34 +164,12 @@ export async function POST(request: Request) {
 
     const stream = createUIMessageStream({
       execute: async ({ writer: dataStream }) => {
-        // Pre-compact messages loaded from DB if they exceed the context
-        // window threshold. This handles the cross-request case where a
-        // previous request compacted mid-stream but saved raw messages.
         const initialModelMessages = await convertToModelMessages(uiMessages);
-        const { messages: preCompacted, compacted: wasPreCompacted, summary: preCompactSummary } =
-          await preCompactMessages(initialModelMessages, () => {
-            dataStream.write({
-              type: 'data-compacting',
-              data: { timestamp: Date.now() },
-              transient: true,
-            });
-          });
-
-        if (wasPreCompacted) {
-          dataStream.write({
-            type: 'data-checkpoint',
-            data: {
-              stepNumber: 0,
-              inputTokens: 0,
-              timestamp: Date.now(),
-              summary: preCompactSummary,
-            },
-            transient: true,
-          });
-        }
 
         // One compressor instance per request; its cache persists across all
         // prepareStep calls so generateText is not re-fired on every step.
+        // Compaction triggers on step 1+ using SDK-reported inputTokens
+        // (step 0 has no prior usage data, so it runs uncompacted).
         const compressStep = createMessageCompressor();
 
         const activeModel = resolvedModelOverride
@@ -201,7 +179,7 @@ export async function POST(request: Request) {
         const result = streamText({
           model: activeModel,
           system: getWebAutomationSystemPrompt(),
-          messages: preCompacted,
+          messages: initialModelMessages,
           tools: {
             ...apricotTools,
             gapAnalysis,

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -37,8 +37,6 @@ import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
 import { createMessageCompressor, preCompactMessages } from '@/lib/ai/context-compression';
-import { updateWorkingMemory } from '@/lib/ai/tools/working-memory';
-import { reconstructWorkingMemory, buildWorkingMemoryMessage } from '@/lib/ai/working-memory';
 
 export const maxDuration = 300; // 5 minutes for web automation tasks
 
@@ -170,16 +168,8 @@ export async function POST(request: Request) {
         // window threshold. This handles the cross-request case where a
         // previous request compacted mid-stream but saved raw messages.
         const initialModelMessages = await convertToModelMessages(uiMessages);
-
-        // Inject working memory as first message if available.
-        // This survives compaction so the model always has ground-truth participant data.
-        const workingMemory = reconstructWorkingMemory(uiMessages);
-        const messagesWithMemory = workingMemory
-          ? [buildWorkingMemoryMessage(workingMemory), ...initialModelMessages]
-          : initialModelMessages;
-
         const { messages: preCompacted, compacted: wasPreCompacted, summary: preCompactSummary } =
-          await preCompactMessages(messagesWithMemory, () => {
+          await preCompactMessages(initialModelMessages, () => {
             dataStream.write({
               type: 'data-compacting',
               data: { timestamp: Date.now() },
@@ -217,7 +207,6 @@ export async function POST(request: Request) {
             gapAnalysis,
             formSummary,
             actionLabel,
-            updateWorkingMemory,
             browser: createBrowserTool(sessionId, session.user.id),
             loadSkill,
             readSkillFile,

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -37,6 +37,8 @@ import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
 import { createMessageCompressor, preCompactMessages } from '@/lib/ai/context-compression';
+import { updateWorkingMemory } from '@/lib/ai/tools/working-memory';
+import { reconstructWorkingMemory, buildWorkingMemoryMessage } from '@/lib/ai/working-memory';
 
 export const maxDuration = 300; // 5 minutes for web automation tasks
 
@@ -168,8 +170,16 @@ export async function POST(request: Request) {
         // window threshold. This handles the cross-request case where a
         // previous request compacted mid-stream but saved raw messages.
         const initialModelMessages = await convertToModelMessages(uiMessages);
+
+        // Inject working memory as first message if available.
+        // This survives compaction so the model always has ground-truth participant data.
+        const workingMemory = reconstructWorkingMemory(uiMessages);
+        const messagesWithMemory = workingMemory
+          ? [buildWorkingMemoryMessage(workingMemory), ...initialModelMessages]
+          : initialModelMessages;
+
         const { messages: preCompacted, compacted: wasPreCompacted, summary: preCompactSummary } =
-          await preCompactMessages(initialModelMessages, () => {
+          await preCompactMessages(messagesWithMemory, () => {
             dataStream.write({
               type: 'data-compacting',
               data: { timestamp: Date.now() },
@@ -207,6 +217,7 @@ export async function POST(request: Request) {
             gapAnalysis,
             formSummary,
             actionLabel,
+            updateWorkingMemory,
             browser: createBrowserTool(sessionId, session.user.id),
             loadSkill,
             readSkillFile,

--- a/lib/ai/context-compression.ts
+++ b/lib/ai/context-compression.ts
@@ -1,5 +1,6 @@
 import { generateText, type ModelMessage } from 'ai';
 import { prepareStepModel } from '@/lib/ai/providers';
+import { WORKING_MEMORY_PREFIX } from '@/lib/ai/working-memory';
 
 const MODEL_CONTEXT_WINDOW = 200_000; // claude-sonnet-4-6
 const COMPACT_THRESHOLD_PCT = 0.75;
@@ -9,18 +10,43 @@ const SUMMARY_PREFIX = '[Session summary — earlier context compacted]';
 
 const COMPACTION_SYSTEM_PROMPT =
   'You are creating a session handoff document for a benefits form-filling agent. ' +
-  'Extract and preserve ALL of the following — be explicit and complete:\n' +
-  '- PARTICIPANT DATA: Every field-value pair from the database (Apricot record) and caseworker. Format as "Field: Value" lines.\n' +
+  'Participant field-value data is preserved separately in working memory — ' +
+  'do NOT list individual participant field values in the summary.\n\n' +
+  'Extract and preserve the following from the transcript:\n' +
   '- SESSION STATE: The current form name, URL, and which page/step we are on.\n' +
   '- COMPLETED FIELDS: Every field that has already been filled and its value.\n' +
   '- PENDING FIELDS: Every field still needing input.\n' +
   '- CASEWORKER INPUTS: Every answer or correction the caseworker provided.\n' +
   '- GAP ANALYSIS: Every field that has been identified as a gap and the reason why.\n' +
   '- GAP ANSWERS: Every answer or correction the caseworker provided to a gap analysis.\n' +
-  'Do NOT summarize participant data — list every field and value explicitly. ' +
+  '- KEY DECISIONS: Any decisions or clarifications made during the session.\n\n' +
+  'CRITICAL RULES:\n' +
+  '- Do NOT invent, infer, or fabricate any data that is not explicitly present in the transcript.\n' +
+  '- If a field value appears truncated or unclear, write [UNKNOWN] rather than guessing.\n' +
+  '- Do NOT include participant PII (names, DOB, SSN, address) — it is in working memory.\n' +
   'Do NOT include browser snapshot content or raw HTML.';
 
 const log = (...args: unknown[]) => console.log('[compressor]', ...args);
+
+/**
+ * Detect and extract a working memory message from the beginning of the
+ * message list. The working memory message is always the first message and
+ * starts with WORKING_MEMORY_PREFIX. It must be excluded from compaction
+ * so the model always has ground-truth participant data.
+ */
+function extractWorkingMemory(messages: ModelMessage[]): {
+  wmMessage: ModelMessage | null;
+  rest: ModelMessage[];
+} {
+  if (
+    messages.length > 0 &&
+    typeof messages[0].content === 'string' &&
+    messages[0].content.startsWith(WORKING_MEMORY_PREFIX)
+  ) {
+    return { wmMessage: messages[0], rest: messages.slice(1) };
+  }
+  return { wmMessage: null, rest: messages };
+}
 
 /**
  * Flatten a ModelMessage into a plain-text line for the transcript.
@@ -147,11 +173,14 @@ export async function preCompactMessages(
   messages: ModelMessage[],
   onCompacting?: () => void,
 ): Promise<{ messages: ModelMessage[]; compacted: boolean; summary?: string }> {
-  const estimatedTokens = estimateTokens(messages);
+  // Extract working memory — it must never be compacted
+  const { wmMessage, rest } = extractWorkingMemory(messages);
+
+  const estimatedTokens = estimateTokens(rest);
   const usedPct = estimatedTokens / MODEL_CONTEXT_WINDOW;
 
   log(
-    `pre-compact check — ${messages.length} msgs, ` +
+    `pre-compact check — ${rest.length} msgs (${wmMessage ? '+WM' : 'no WM'}), ` +
     `~${estimatedTokens} estimated tokens, ` +
     `${(usedPct * 100).toFixed(1)}% of ${MODEL_CONTEXT_WINDOW} context window`
   );
@@ -160,15 +189,18 @@ export async function preCompactMessages(
     return { messages, compacted: false };
   }
 
-  const result = await summarizeMessages(messages, 'pre-compact: ', onCompacting);
+  const result = await summarizeMessages(rest, 'pre-compact: ', onCompacting);
   if (!result) {
     return { messages, compacted: false };
   }
 
   const summaryMessage = buildSummaryMessage(result.summary);
-  log(`pre-compact done — returning ${1 + result.recentMessages.length} msgs`);
+  log(`pre-compact done — returning ${1 + result.recentMessages.length} msgs${wmMessage ? ' +WM' : ''}`);
+  const compactedMessages = wmMessage
+    ? [wmMessage, summaryMessage, ...result.recentMessages]
+    : [summaryMessage, ...result.recentMessages];
   return {
-    messages: [summaryMessage, ...result.recentMessages],
+    messages: compactedMessages,
     compacted: true,
     summary: result.summary,
   };
@@ -199,18 +231,25 @@ export function createMessageCompressor() {
     onCompacting?: () => void,
   ): Promise<{ messages: ModelMessage[]; compacted: boolean; summary?: string }> {
 
+    // --- Extract working memory — never compact it ---
+    const { wmMessage, rest: rawMessages } = extractWorkingMemory(stepMessages);
+
     // --- Re-apply prior compaction ---
     // The SDK gives us the full original messages every time. If we've
     // already compacted, strip the summarized prefix and prepend our summary.
-    let effectiveMessages = stepMessages;
+    let effectiveMessages = rawMessages;
     if (storedSummaryMessage && summarizedCount > 0) {
-      const newMessages = stepMessages.slice(summarizedCount);
+      const newMessages = rawMessages.slice(summarizedCount);
       effectiveMessages = [storedSummaryMessage, ...newMessages];
       log(
         `re-applied prior compaction — stripped ${summarizedCount} original msgs, ` +
         `${effectiveMessages.length} effective msgs (1 summary + ${newMessages.length} new)`
       );
     }
+
+    // Helper: prepend working memory back to final result
+    const withWm = (msgs: ModelMessage[]) =>
+      wmMessage ? [wmMessage, ...msgs] : msgs;
 
     const usedPct = (lastInputTokens ?? 0) / MODEL_CONTEXT_WINDOW;
 
@@ -223,24 +262,24 @@ export function createMessageCompressor() {
         `skip — stale inputTokens after compaction, ` +
         `${effectiveMessages.length} msgs, ${(usedPct * 100).toFixed(1)}% (stale)`
       );
-      return { messages: effectiveMessages, compacted: false };
+      return { messages: withWm(effectiveMessages), compacted: false };
     }
 
     log(
-      `step check — ${effectiveMessages.length} msgs (raw ${stepMessages.length}), ` +
+      `step check — ${effectiveMessages.length} msgs (raw ${stepMessages.length}${wmMessage ? ', +WM' : ''}), ` +
       `inputTokens=${lastInputTokens ?? 'n/a'}, ` +
       `${(usedPct * 100).toFixed(1)}% of ${MODEL_CONTEXT_WINDOW} context window, ` +
       `threshold=${(COMPACT_THRESHOLD_PCT * 100).toFixed(0)}%`
     );
 
     if (usedPct < COMPACT_THRESHOLD_PCT) {
-      return { messages: effectiveMessages, compacted: false };
+      return { messages: withWm(effectiveMessages), compacted: false };
     }
 
     const result = await summarizeMessages(effectiveMessages, '', onCompacting);
     if (!result) {
       justCompacted = true; // skip next stale check
-      return { messages: effectiveMessages, compacted: false };
+      return { messages: withWm(effectiveMessages), compacted: false };
     }
 
     const newSummaryMessage = buildSummaryMessage(result.summary);
@@ -262,10 +301,10 @@ export function createMessageCompressor() {
 
     log(
       `compaction persisted — summarizedCount=${summarizedCount}, ` +
-      `returning ${1 + result.recentMessages.length} msgs`
+      `returning ${1 + result.recentMessages.length} msgs${wmMessage ? ' +WM' : ''}`
     );
 
     justCompacted = true;
-    return { messages: [newSummaryMessage, ...result.recentMessages], compacted: true, summary: result.summary };
+    return { messages: withWm([newSummaryMessage, ...result.recentMessages]), compacted: true, summary: result.summary };
   };
 }

--- a/lib/ai/context-compression.ts
+++ b/lib/ai/context-compression.ts
@@ -1,6 +1,7 @@
 import { generateText, type ModelMessage } from 'ai';
 import { prepareStepModel } from '@/lib/ai/providers';
-import { WORKING_MEMORY_PREFIX } from '@/lib/ai/working-memory';
+import { WORKING_MEMORY_PREFIX, buildWorkingMemoryMessage } from '@/lib/ai/working-memory';
+import { updateWorkingMemory } from '@/lib/ai/tools/working-memory';
 
 const MODEL_CONTEXT_WINDOW = 200_000; // claude-sonnet-4-6
 const COMPACT_THRESHOLD_PCT = 0.75;
@@ -64,9 +65,8 @@ function flattenMessage(msg: ModelMessage): string {
       const r = part.result;
       if (r?.snapshot || r?.accessibility_tree || r?.screenshot) return '[browser output: pruned]';
     }
-    // Everything else: just stringify and truncate
     const s = typeof part === 'string' ? part : (part.text ?? JSON.stringify(part) ?? '');
-    return String(s).slice(0, 500);
+    return String(s);
   });
   return `[${role}]: ${parts.join('\n')}`;
 }
@@ -104,14 +104,23 @@ function estimateTokens(messages: ModelMessage[]): number {
 }
 
 /**
- * Shared summarization: split messages into old + recent, summarize old via Sonnet.
+ * Shared summarization: split messages into old + recent, then run two
+ * parallel Haiku calls on the same transcript:
+ *   1. Compaction summary (session state, actions, decisions)
+ *   2. Working memory extraction (structured participant data via tool call)
+ *
  * Returns null on failure (caller should fall back to original messages).
  */
 async function summarizeMessages(
   messages: ModelMessage[],
   logPrefix: string,
   onCompacting?: () => void,
-): Promise<{ summary: string; recentMessages: ModelMessage[]; splitAt: number } | null> {
+): Promise<{
+  summary: string;
+  workingMemory: Record<string, unknown> | null;
+  recentMessages: ModelMessage[];
+  splitAt: number;
+} | null> {
   if (messages.length <= KEEP_RECENT) {
     log(`${logPrefix}over threshold but only ${messages.length} msgs (≤ ${KEEP_RECENT}), skipping`);
     return null;
@@ -132,29 +141,57 @@ async function summarizeMessages(
   onCompacting?.();
 
   const t0 = Date.now();
-  let summary: string;
-  try {
-    const result = await generateText({
+
+  // Run compaction summary and working memory extraction in parallel on Haiku
+  const [compactionResult, wmResult] = await Promise.all([
+    // 1. Compaction summary
+    generateText({
       model: prepareStepModel,
       maxOutputTokens: 4096,
       system: COMPACTION_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: `Summarize this session transcript:\n\n${transcript}` }],
-    });
-    summary = result.text;
-    log(`${logPrefix}Sonnet finishReason: ${result.finishReason}`);
-  } catch (err) {
-    log(`${logPrefix}Sonnet ERROR:`, err);
-    return null;
-  }
+    }).catch((err) => {
+      log(`${logPrefix}compaction ERROR:`, err);
+      return null;
+    }),
+
+    // 2. Working memory extraction via tool call
+    generateText({
+      model: prepareStepModel,
+      maxOutputTokens: 4096,
+      tools: { updateWorkingMemory },
+      toolChoice: { type: 'tool', toolName: 'updateWorkingMemory' },
+      system:
+        'Extract all participant data from this transcript. ' +
+        'Include data from database records and caseworker answers. ' +
+        'Only include data explicitly present — never fabricate.',
+      messages: [{ role: 'user', content: transcript }],
+    }).catch((err) => {
+      log(`${logPrefix}working memory ERROR:`, err);
+      return null;
+    }),
+  ]);
+
   const elapsed = Date.now() - t0;
-  log(`${logPrefix}summary done in ${elapsed}ms — summary length: ${summary.length} chars`);
 
-  if (!summary.trim()) {
-    log(`${logPrefix}ABORT — empty summary`);
+  // Process compaction result
+  const summary = compactionResult?.text?.trim();
+  if (!summary) {
+    log(`${logPrefix}ABORT — empty or failed compaction summary`);
     return null;
   }
+  log(`${logPrefix}compaction done in ${elapsed}ms — summary: ${summary.length} chars`);
 
-  return { summary, recentMessages, splitAt };
+  // Process working memory result
+  let workingMemory: Record<string, unknown> | null = null;
+  if (wmResult?.toolResults?.length) {
+    workingMemory = wmResult.toolResults[0].output as Record<string, unknown>;
+    log(`${logPrefix}working memory extracted — ${Object.keys(workingMemory).length} keys`);
+  } else {
+    log(`${logPrefix}working memory extraction failed or empty — continuing without`);
+  }
+
+  return { summary, workingMemory, recentMessages, splitAt };
 }
 
 function buildSummaryMessage(summary: string): ModelMessage {
@@ -173,7 +210,7 @@ export async function preCompactMessages(
   messages: ModelMessage[],
   onCompacting?: () => void,
 ): Promise<{ messages: ModelMessage[]; compacted: boolean; summary?: string }> {
-  // Extract working memory — it must never be compacted
+  // Extract any existing working memory — it must never be compacted
   const { wmMessage, rest } = extractWorkingMemory(messages);
 
   const estimatedTokens = estimateTokens(rest);
@@ -195,9 +232,13 @@ export async function preCompactMessages(
   }
 
   const summaryMessage = buildSummaryMessage(result.summary);
-  log(`pre-compact done — returning ${1 + result.recentMessages.length} msgs${wmMessage ? ' +WM' : ''}`);
-  const compactedMessages = wmMessage
-    ? [wmMessage, summaryMessage, ...result.recentMessages]
+  // Use freshly extracted working memory, or fall back to existing one
+  const effectiveWm = result.workingMemory
+    ? buildWorkingMemoryMessage(result.workingMemory)
+    : wmMessage;
+  log(`pre-compact done — returning ${1 + result.recentMessages.length} msgs${effectiveWm ? ' +WM' : ''}`);
+  const compactedMessages = effectiveWm
+    ? [effectiveWm, summaryMessage, ...result.recentMessages]
     : [summaryMessage, ...result.recentMessages];
   return {
     messages: compactedMessages,
@@ -223,6 +264,7 @@ export function createMessageCompressor() {
 
   // Persisted compaction state — survives across prepareStep calls
   let storedSummaryMessage: ModelMessage | null = null;
+  let storedWmMessage: ModelMessage | null = null;
   let summarizedCount = 0; // how many original messages were folded into the summary
 
   return async function compress(
@@ -232,11 +274,10 @@ export function createMessageCompressor() {
   ): Promise<{ messages: ModelMessage[]; compacted: boolean; summary?: string }> {
 
     // --- Extract working memory — never compact it ---
-    const { wmMessage, rest: rawMessages } = extractWorkingMemory(stepMessages);
+    const { wmMessage: incomingWm, rest: rawMessages } = extractWorkingMemory(stepMessages);
+    let wm = storedWmMessage ?? incomingWm;
 
     // --- Re-apply prior compaction ---
-    // The SDK gives us the full original messages every time. If we've
-    // already compacted, strip the summarized prefix and prepend our summary.
     let effectiveMessages = rawMessages;
     if (storedSummaryMessage && summarizedCount > 0) {
       const newMessages = rawMessages.slice(summarizedCount);
@@ -247,64 +288,56 @@ export function createMessageCompressor() {
       );
     }
 
-    // Helper: prepend working memory back to final result
-    const withWm = (msgs: ModelMessage[]) =>
-      wmMessage ? [wmMessage, ...msgs] : msgs;
+    const prepend = (msgs: ModelMessage[]) =>
+      wm ? [wm, ...msgs] : msgs;
 
     const usedPct = (lastInputTokens ?? 0) / MODEL_CONTEXT_WINDOW;
 
-    // After compaction the next step's inputTokens is stale (measured before
-    // we replaced messages). Skip one threshold check so the model sees
-    // compacted context and reports accurate usage.
     if (justCompacted) {
       justCompacted = false;
       log(
         `skip — stale inputTokens after compaction, ` +
         `${effectiveMessages.length} msgs, ${(usedPct * 100).toFixed(1)}% (stale)`
       );
-      return { messages: withWm(effectiveMessages), compacted: false };
+      return { messages: prepend(effectiveMessages), compacted: false };
     }
 
     log(
-      `step check — ${effectiveMessages.length} msgs (raw ${stepMessages.length}${wmMessage ? ', +WM' : ''}), ` +
+      `step check — ${effectiveMessages.length} msgs (raw ${stepMessages.length}${wm ? ', +WM' : ''}), ` +
       `inputTokens=${lastInputTokens ?? 'n/a'}, ` +
       `${(usedPct * 100).toFixed(1)}% of ${MODEL_CONTEXT_WINDOW} context window, ` +
       `threshold=${(COMPACT_THRESHOLD_PCT * 100).toFixed(0)}%`
     );
 
     if (usedPct < COMPACT_THRESHOLD_PCT) {
-      return { messages: withWm(effectiveMessages), compacted: false };
+      return { messages: prepend(effectiveMessages), compacted: false };
     }
 
     const result = await summarizeMessages(effectiveMessages, '', onCompacting);
     if (!result) {
-      justCompacted = true; // skip next stale check
-      return { messages: withWm(effectiveMessages), compacted: false };
+      justCompacted = true;
+      return { messages: prepend(effectiveMessages), compacted: false };
     }
 
     const newSummaryMessage = buildSummaryMessage(result.summary);
 
-    // Persist compaction state so we can re-apply on next prepareStep call.
-    // summarizedCount tracks how many of the SDK's original messages are now
-    // folded into our summary.
     storedSummaryMessage = newSummaryMessage;
+    if (result.workingMemory) {
+      storedWmMessage = buildWorkingMemoryMessage(result.workingMemory);
+      wm = storedWmMessage;
+    }
     if (summarizedCount === 0) {
-      // First compaction: splitAt messages from the raw stepMessages
       summarizedCount = result.splitAt;
     } else {
-      // Re-compaction: the old portion of effectiveMessages had
-      // (splitAt) entries. The first one was our prior summary (not an
-      // original message), the rest are (splitAt - 1) originals that
-      // accumulated after the last compaction boundary.
       summarizedCount += result.splitAt - 1;
     }
 
     log(
       `compaction persisted — summarizedCount=${summarizedCount}, ` +
-      `returning ${1 + result.recentMessages.length} msgs${wmMessage ? ' +WM' : ''}`
+      `returning ${1 + result.recentMessages.length} msgs${wm ? ' +WM' : ''}`
     );
 
     justCompacted = true;
-    return { messages: withWm([newSummaryMessage, ...result.recentMessages]), compacted: true, summary: result.summary };
+    return { messages: prepend([newSummaryMessage, ...result.recentMessages]), compacted: true, summary: result.summary };
   };
 }

--- a/lib/ai/context-compression.ts
+++ b/lib/ai/context-compression.ts
@@ -1,4 +1,4 @@
-import { generateText, type ModelMessage } from 'ai';
+import { generateText, pruneMessages, type ModelMessage } from 'ai';
 import { prepareStepModel } from '@/lib/ai/providers';
 import { WORKING_MEMORY_PREFIX, buildWorkingMemoryMessage } from '@/lib/ai/working-memory';
 import { updateWorkingMemory } from '@/lib/ai/tools/working-memory';
@@ -60,47 +60,21 @@ function flattenMessage(msg: ModelMessage): string {
 
   const parts = (msg.content as any[]).map((part) => {
     if (!part) return '';
-    // Prune browser snapshots/screenshots — they're huge and useless in summaries
+    // Browser tool results: keep status, strip the heavy output payload
     if (part.type === 'tool-result' && part.toolName === 'browser') {
-      const r = part.result;
-      if (r?.snapshot || r?.accessibility_tree || r?.screenshot) return '[browser output: pruned]';
+      const r = part.result ?? part.output ?? {};
+      const status = (r as any)?.success ? 'success' : `error: ${(r as any)?.error ?? 'unknown'}`;
+      return `[browser result: ${status}]`;
+    }
+    // Browser tool calls: keep action + key param for context
+    if (part.type === 'tool-call' && part.toolName === 'browser') {
+      const a = part.args ?? {};
+      return `[browser: ${a.action ?? '?'}${a.selector ? ' ' + a.selector : a.url ? ' ' + a.url : ''}]`;
     }
     const s = typeof part === 'string' ? part : (part.text ?? JSON.stringify(part) ?? '');
     return String(s);
   });
   return `[${role}]: ${parts.join('\n')}`;
-}
-
-/**
- * Estimate token count from messages using a rough chars-per-token heuristic.
- * Claude averages ~3.5-4 chars per token; we use 3.5 to be conservative.
- * Skips browser snapshots (same as flattenMessage) to avoid massive JSON.stringify allocations.
- */
-function estimateTokens(messages: ModelMessage[]): number {
-  let totalChars = 0;
-  for (const msg of messages) {
-    if (typeof msg.content === 'string') {
-      totalChars += msg.content.length;
-    } else if (Array.isArray(msg.content)) {
-      for (const part of msg.content as any[]) {
-        if (!part) continue;
-        // Skip browser snapshots — same pruning as flattenMessage
-        if (part.type === 'tool-result' && part.toolName === 'browser') {
-          const r = part.result;
-          if (r?.snapshot || r?.accessibility_tree || r?.screenshot) {
-            totalChars += 50; // fixed budget for pruned output
-            continue;
-          }
-        }
-        if (typeof part === 'string') {
-          totalChars += part.length;
-        } else {
-          totalChars += (part.text?.length ?? JSON.stringify(part)?.length ?? 0);
-        }
-      }
-    }
-  }
-  return Math.ceil(totalChars / 3.5);
 }
 
 /**
@@ -199,55 +173,6 @@ function buildSummaryMessage(summary: string): ModelMessage {
 }
 
 /**
- * Pre-compact messages loaded from the database before passing to streamText.
- *
- * When a previous request compacted messages mid-stream, the raw messages
- * still get saved to the DB. On the next request, loading them all would
- * exceed the context window. This function runs the same summarization
- * up-front so the initial streamText call stays within limits.
- */
-export async function preCompactMessages(
-  messages: ModelMessage[],
-  onCompacting?: () => void,
-): Promise<{ messages: ModelMessage[]; compacted: boolean; summary?: string }> {
-  // Extract any existing working memory — it must never be compacted
-  const { wmMessage, rest } = extractWorkingMemory(messages);
-
-  const estimatedTokens = estimateTokens(rest);
-  const usedPct = estimatedTokens / MODEL_CONTEXT_WINDOW;
-
-  log(
-    `pre-compact check — ${rest.length} msgs (${wmMessage ? '+WM' : 'no WM'}), ` +
-    `~${estimatedTokens} estimated tokens, ` +
-    `${(usedPct * 100).toFixed(1)}% of ${MODEL_CONTEXT_WINDOW} context window`
-  );
-
-  if (usedPct < COMPACT_THRESHOLD_PCT) {
-    return { messages, compacted: false };
-  }
-
-  const result = await summarizeMessages(rest, 'pre-compact: ', onCompacting);
-  if (!result) {
-    return { messages, compacted: false };
-  }
-
-  const summaryMessage = buildSummaryMessage(result.summary);
-  // Use freshly extracted working memory, or fall back to existing one
-  const effectiveWm = result.workingMemory
-    ? buildWorkingMemoryMessage(result.workingMemory)
-    : wmMessage;
-  log(`pre-compact done — returning ${1 + result.recentMessages.length} msgs${effectiveWm ? ' +WM' : ''}`);
-  const compactedMessages = effectiveWm
-    ? [effectiveWm, summaryMessage, ...result.recentMessages]
-    : [summaryMessage, ...result.recentMessages];
-  return {
-    messages: compactedMessages,
-    compacted: true,
-    summary: result.summary,
-  };
-}
-
-/**
  * Returns a stateful compression function for a single streamText request.
  *
  * IMPORTANT: The AI SDK's prepareStep does NOT persist message overrides
@@ -291,7 +216,20 @@ export function createMessageCompressor() {
     const prepend = (msgs: ModelMessage[]) =>
       wm ? [wm, ...msgs] : msgs;
 
-    const usedPct = (lastInputTokens ?? 0) / MODEL_CONTEXT_WINDOW;
+    // Step 0: no prior inputTokens available. Prune browser tool content
+    // from older messages to avoid exceeding the main model's context window
+    // on cross-request reloads with large message histories.
+    if (lastInputTokens === undefined) {
+      const pruned = pruneMessages({
+        messages: effectiveMessages,
+        toolCalls: [{ type: 'before-last-2-messages', tools: ['browser'] }],
+        emptyMessages: 'remove',
+      });
+      log(`step 0 — pruned browser tools: ${effectiveMessages.length} → ${pruned.length} msgs`);
+      return { messages: prepend(pruned), compacted: false };
+    }
+
+    const usedPct = lastInputTokens / MODEL_CONTEXT_WINDOW;
 
     if (justCompacted) {
       justCompacted = false;

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -30,16 +30,6 @@ Age unknown: Check the database for date of birth. If still unknown, clarify wit
 3. GOAL-ORIENTED: Always work towards completing the stated objective
 4. TRANSPARENT: State what you did to the caseworker. Summarize wherever possible to reduce the amount of messages
 
-## Working Memory Protocol
-You have persistent working memory that survives context compaction. Use the \`updateWorkingMemory\` tool to store critical data:
-
-1. **After retrieving Apricot records**: Store ALL participant fields in \`participant\` and household members in \`household\`
-2. **When the caseworker answers gap analysis questions**: Add their answers to \`caseworkerInputs\`
-3. **On significant form progress**: Update \`formState\` with the current URL, step, completed/pending fields
-
-Each call REPLACES the full working memory. Always include ALL current data, not just changes.
-IMPORTANT: Always trust the working memory data over anything in conversation summaries or compacted context.
-
 ## Step Management Protocol
 - You have a limited number of steps (tool calls) available
 - Plan your approach carefully to maximize efficiency

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -30,6 +30,16 @@ Age unknown: Check the database for date of birth. If still unknown, clarify wit
 3. GOAL-ORIENTED: Always work towards completing the stated objective
 4. TRANSPARENT: State what you did to the caseworker. Summarize wherever possible to reduce the amount of messages
 
+## Working Memory Protocol
+You have persistent working memory that survives context compaction. Use the \`updateWorkingMemory\` tool to store critical data:
+
+1. **After retrieving Apricot records**: Store ALL participant fields in \`participant\` and household members in \`household\`
+2. **When the caseworker answers gap analysis questions**: Add their answers to \`caseworkerInputs\`
+3. **On significant form progress**: Update \`formState\` with the current URL, step, completed/pending fields
+
+Each call REPLACES the full working memory. Always include ALL current data, not just changes.
+IMPORTANT: Always trust the working memory data over anything in conversation summaries or compacted context.
+
 ## Step Management Protocol
 - You have a limited number of steps (tool calls) available
 - Plan your approach carefully to maximize efficiency

--- a/lib/ai/tools/working-memory.ts
+++ b/lib/ai/tools/working-memory.ts
@@ -1,0 +1,39 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export const updateWorkingMemory = tool({
+  description:
+    'Update the working memory with participant data, caseworker inputs, or form state. ' +
+    'Call this after retrieving Apricot records, when the caseworker provides gap analysis answers, ' +
+    'or when form state changes significantly. ' +
+    'Each call REPLACES the entire working memory — always include the COMPLETE current state.',
+  inputSchema: z.object({
+    participant: z
+      .record(z.unknown())
+      .optional()
+      .describe(
+        'All participant fields from Apricot database records (name, DOB, SSN, address, etc.)',
+      ),
+    household: z
+      .array(z.record(z.unknown()))
+      .optional()
+      .describe('Household members with their fields'),
+    caseworkerInputs: z
+      .record(z.unknown())
+      .optional()
+      .describe(
+        'Answers the caseworker provided during this session (gap analysis responses, corrections)',
+      ),
+    formState: z
+      .object({
+        formName: z.string().optional(),
+        currentUrl: z.string().optional(),
+        currentStep: z.string().optional(),
+        completedFields: z.record(z.string()).optional(),
+        pendingFields: z.array(z.string()).optional(),
+      })
+      .optional()
+      .describe('Current form-filling progress'),
+  }),
+  execute: async (input) => input,
+});

--- a/lib/ai/working-memory.ts
+++ b/lib/ai/working-memory.ts
@@ -1,0 +1,51 @@
+import type { ModelMessage } from 'ai';
+import type { ChatMessage } from '@/lib/types';
+
+export const WORKING_MEMORY_PREFIX =
+  '[WORKING MEMORY — Authoritative participant data for this session]';
+
+/**
+ * Reconstruct working memory from the message history by finding the last
+ * updateWorkingMemory tool invocation. Each call contains the full state
+ * (replace semantics), so only the most recent one matters.
+ */
+export function reconstructWorkingMemory(
+  messages: ChatMessage[],
+): Record<string, unknown> | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== 'assistant') continue;
+
+    for (let j = msg.parts.length - 1; j >= 0; j--) {
+      const part = msg.parts[j] as any;
+      if (
+        part.type === 'tool-updateWorkingMemory' &&
+        (part.state === 'output-available' ||
+          part.state === 'input-available')
+      ) {
+        return part.input ?? null;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build a synthetic user message containing the working memory JSON.
+ * This message is injected as the first message in the context and is
+ * excluded from compaction so the model always has ground-truth data.
+ */
+export function buildWorkingMemoryMessage(
+  memory: Record<string, unknown>,
+): ModelMessage {
+  return {
+    role: 'user' as const,
+    content:
+      `${WORKING_MEMORY_PREFIX}\n\n` +
+      `${JSON.stringify(memory, null, 2)}\n\n` +
+      'This is the authoritative participant data for this session. ' +
+      'Always prefer this data over anything in conversation history or compaction summaries. ' +
+      'Do NOT modify or re-interpret these values.',
+  };
+}

--- a/lib/ai/working-memory.ts
+++ b/lib/ai/working-memory.ts
@@ -1,35 +1,7 @@
 import type { ModelMessage } from 'ai';
-import type { ChatMessage } from '@/lib/types';
 
 export const WORKING_MEMORY_PREFIX =
   '[WORKING MEMORY — Authoritative participant data for this session]';
-
-/**
- * Reconstruct working memory from the message history by finding the last
- * updateWorkingMemory tool invocation. Each call contains the full state
- * (replace semantics), so only the most recent one matters.
- */
-export function reconstructWorkingMemory(
-  messages: ChatMessage[],
-): Record<string, unknown> | null {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role !== 'assistant') continue;
-
-    for (let j = msg.parts.length - 1; j >= 0; j--) {
-      const part = msg.parts[j] as any;
-      if (
-        part.type === 'tool-updateWorkingMemory' &&
-        (part.state === 'output-available' ||
-          part.state === 'input-available')
-      ) {
-        return part.input ?? null;
-      }
-    }
-  }
-
-  return null;
-}
 
 /**
  * Build a synthetic user message containing the working memory JSON.


### PR DESCRIPTION
## Summary
- Adds `updateWorkingMemory` tool so the agent persists participant data (name, DOB, SSN, household, caseworker inputs) in a structured JSON object
- Reconstructs working memory from message history on each request and injects as a synthetic first message
- Excludes working memory message from context compaction — ground-truth data is never summarized or truncated
- Updates compaction prompt with anti-hallucination rules: no PII in summaries, no fabrication, `[UNKNOWN]` for unclear values
- Adds Working Memory Protocol to system prompt

## Context
Agent was hallucinating participant names and DOB after context compaction (checkpoint 2 → 3). Root cause: `flattenMessage()` truncates tool results to 500 chars, and the compaction summarizer fabricates missing fields to fulfill "preserve ALL participant data."

## Test plan
- [ ] Start session: "Retrieve ID #339739 and apply for Benefits Cal"
- [ ] Verify agent calls `updateWorkingMemory` after Apricot record retrieval
- [ ] Answer gap analysis questions through the full session
- [ ] After compaction checkpoints, verify participant name/DOB remain correct
- [ ] Check server logs for `[compressor]` entries confirming WM excluded from compaction