### PR TITLE
feat: add Claude Opus 4.7 to model selector

### DIFF
--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -27,6 +27,7 @@ export const postRequestBodySchema = z.object({
   // Dev-only: overrides the actual LLM used without changing the routing logic.
   // Ignored in production environments.
   modelOverride: z.enum([
+    'claude-opus-4-7',
     'claude-sonnet-4-6',
     'claude-haiku-4-5',
     'gpt-5.4',

--- a/components/model-selector-button.tsx
+++ b/components/model-selector-button.tsx
@@ -37,6 +37,7 @@ const MODEL_GROUPS: Array<{ name: string; models: ModelOption[] }> = [
   {
     name: 'Anthropic',
     models: [
+      { id: 'claude-opus-4-7', name: 'Claude Opus 4.7', provider: 'anthropic' },
       { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'anthropic' },
       { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', provider: 'anthropic' },
     ],

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -41,6 +41,7 @@ export const myProvider = isTestEnvironment
         'gpt-5.4-pro': openai('gpt-5.4-pro'),
         'gpt-5.4-mini': openai('gpt-5.4-mini'),
         'gpt-5.4-nano': openai('gpt-5.4-nano'),
+        'claude-opus-4-7': vertexAnthropic('claude-opus-4-7'),
         'claude-sonnet-4-6': vertexAnthropic('claude-sonnet-4-6'),
         'claude-haiku-4-5': vertexAnthropic('claude-haiku-4-5'),
       },


### PR DESCRIPTION
## Summary
- Registers `claude-opus-4-7` via Vertex AI in `lib/ai/providers.ts`
- Adds `claude-opus-4-7` to the `modelOverride` enum in the chat API schema
- Exposes "Claude Opus 4.7" in the dev-only model selector alongside Sonnet 4.6 and Haiku 4.5

Opus 4.7 access has been enabled for `nava-labs` in Vertex AI Model Garden.

## Test plan
- [ ] In dev, select "Claude Opus 4.7" from the model selector and send a message — verify the request is routed to Vertex AI and returns a response
- [ ] Confirm production still hides the selector (no behavior change for end users)
- [ ] Confirm existing Sonnet 4.6 and Haiku 4.5 selections continue to work