### PR TITLE
fix: stop button halts multi-step tool loops

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -204,10 +204,7 @@ export async function POST(request: Request) {
           // passed as abortSignal. Mid-tool abort would leave a
           // tool-call with no matching tool-result, triggering
           // AI_MissingToolResultsError on the next turn.
-          stopWhen: [
-            stepCountIs(500),
-            () => chatAbort.signal.aborted || request.signal.aborted,
-          ],
+          stopWhen: [stepCountIs(500), () => chatAbort.signal.aborted],
           // Compress message history when token usage approaches the context
           // window limit (75% of 200K). First step has no prior usage data so
           // compression is skipped (correct — first step is always small).

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -63,12 +63,6 @@ export function getStreamContext() {
 }
 
 export async function POST(request: Request) {
-  const t0 = Date.now();
-  console.log('[abort-diag] request started, aborted=', request.signal.aborted);
-  request.signal.addEventListener('abort', () => {
-    console.log('[abort-diag] request.signal FIRED after', Date.now() - t0, 'ms');
-  });
-
   let requestBody: PostRequestBody;
 
   try {
@@ -206,13 +200,10 @@ export async function POST(request: Request) {
           // detection fires. Without this, streamText keeps running until
           // a write to the closed socket fails — which can be seconds of
           // extra tool calls after the user hits stop.
-          // Only check aborted at step boundaries — do NOT pass the
-          // signal to abortSignal. If we killed in-flight tool calls
-          // mid-execution, streamText would finalize the message with
-          // a tool-call part but no matching tool-result, and the next
-          // turn would throw AI_MissingToolResultsError. Letting the
-          // current tool call drain guarantees paired call+result
-          // before the loop exits.
+          // Abort is checked at step boundaries via stopWhen — not
+          // passed as abortSignal. Mid-tool abort would leave a
+          // tool-call with no matching tool-result, triggering
+          // AI_MissingToolResultsError on the next turn.
           stopWhen: [
             stepCountIs(500),
             () => chatAbort.signal.aborted || request.signal.aborted,
@@ -268,11 +259,6 @@ export async function POST(request: Request) {
         });
 
         dataStream.merge(result.toUIMessageStream());
-        // Do NOT eager-drain textStream here. An extra consumer decouples
-        // streamText from back-pressure, so when the client aborts the
-        // fetch, streamText keeps running (tool loop included) because
-        // this consumer is still pulling. The merged UI stream above is
-        // the only consumer we want.
       },
       generateId: generateUUID,
       onFinish: async ({ messages }) => {

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -206,11 +206,17 @@ export async function POST(request: Request) {
           // detection fires. Without this, streamText keeps running until
           // a write to the closed socket fails — which can be seconds of
           // extra tool calls after the user hits stop.
+          // Only check aborted at step boundaries — do NOT pass the
+          // signal to abortSignal. If we killed in-flight tool calls
+          // mid-execution, streamText would finalize the message with
+          // a tool-call part but no matching tool-result, and the next
+          // turn would throw AI_MissingToolResultsError. Letting the
+          // current tool call drain guarantees paired call+result
+          // before the loop exits.
           stopWhen: [
             stepCountIs(500),
             () => chatAbort.signal.aborted || request.signal.aborted,
           ],
-          abortSignal: chatAbort.signal,
           // Compress message history when token usage approaches the context
           // window limit (75% of 200K). First step has no prior usage data so
           // compression is skipped (correct — first step is always small).

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -62,6 +62,12 @@ export function getStreamContext() {
 }
 
 export async function POST(request: Request) {
+  const t0 = Date.now();
+  console.log('[abort-diag] request started, aborted=', request.signal.aborted);
+  request.signal.addEventListener('abort', () => {
+    console.log('[abort-diag] request.signal FIRED after', Date.now() - t0, 'ms');
+  });
+
   let requestBody: PostRequestBody;
 
   try {

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -1,5 +1,4 @@
 import {
-  consumeStream,
   convertToModelMessages,
   createUIMessageStream,
   JsonToSseTransformStream,
@@ -242,7 +241,11 @@ export async function POST(request: Request) {
         });
 
         dataStream.merge(result.toUIMessageStream());
-        consumeStream({ stream: result.textStream });
+        // Do NOT eager-drain textStream here. An extra consumer decouples
+        // streamText from back-pressure, so when the client aborts the
+        // fetch, streamText keeps running (tool loop included) because
+        // this consumer is still pulling. The merged UI stream above is
+        // the only consumer we want.
       },
       generateId: generateUUID,
       onFinish: async ({ messages }) => {

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -36,6 +36,7 @@ import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
 import { createMessageCompressor } from '@/lib/ai/context-compression';
+import { registerChatAbort, clearChatAbort } from '@/lib/chat-abort-registry';
 
 export const maxDuration = 300; // 5 minutes for web automation tasks
 
@@ -167,6 +168,12 @@ export async function POST(request: Request) {
     // sessionId includes both chatId and userId to ensure global uniqueness
     const sessionId = `${id}-${session.user.id}`;
 
+    // Register an AbortController the client can trigger via
+    // POST /api/chat/stop. Cloud Run HTTP/1.1 does not propagate client
+    // disconnects to request.signal, so this explicit channel is the
+    // only reliable way to abort an in-flight run from the browser.
+    const chatAbort = registerChatAbort(id);
+
     const stream = createUIMessageStream({
       execute: async ({ writer: dataStream }) => {
         const initialModelMessages = await convertToModelMessages(uiMessages);
@@ -199,8 +206,11 @@ export async function POST(request: Request) {
           // detection fires. Without this, streamText keeps running until
           // a write to the closed socket fails — which can be seconds of
           // extra tool calls after the user hits stop.
-          stopWhen: [stepCountIs(500), () => request.signal.aborted],
-          abortSignal: request.signal,
+          stopWhen: [
+            stepCountIs(500),
+            () => chatAbort.signal.aborted || request.signal.aborted,
+          ],
+          abortSignal: chatAbort.signal,
           // Compress message history when token usage approaches the context
           // window limit (75% of 200K). First step has no prior usage data so
           // compression is skipped (correct — first step is always small).
@@ -260,6 +270,7 @@ export async function POST(request: Request) {
       },
       generateId: generateUUID,
       onFinish: async ({ messages }) => {
+        clearChatAbort(id, chatAbort);
         await saveNewMessages(messages);
       },
       onError: () => {

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -194,7 +194,12 @@ export async function POST(request: Request) {
             loadSkill,
             readSkillFile,
           },
-          stopWhen: stepCountIs(500),
+          // request.signal.aborted is checked at each step boundary so the
+          // tool loop halts even before Node's write-failure-based abort
+          // detection fires. Without this, streamText keeps running until
+          // a write to the closed socket fails — which can be seconds of
+          // extra tool calls after the user hits stop.
+          stopWhen: [stepCountIs(500), () => request.signal.aborted],
           abortSignal: request.signal,
           // Compress message history when token usage approaches the context
           // window limit (75% of 200K). First step has no prior usage data so

--- a/app/(chat)/api/chat/stop/route.ts
+++ b/app/(chat)/api/chat/stop/route.ts
@@ -1,0 +1,40 @@
+import { auth } from '@/app/(auth)/auth';
+import { abortChat } from '@/lib/chat-abort-registry';
+import { getChatById } from '@/lib/db/queries';
+import { ChatSDKError } from '@/lib/errors';
+
+/**
+ * Explicit cancellation endpoint.
+ *
+ * Cloud Run over HTTP/1.1 does not propagate client disconnects, so
+ * pressing Stop on the client can't rely on `request.signal` firing in
+ * the in-flight POST /api/chat request. The client instead hits this
+ * endpoint with the chatId to abort the registered AbortController.
+ */
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return new ChatSDKError('unauthorized:chat').toResponse();
+  }
+
+  let body: { chatId?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new ChatSDKError('bad_request:api').toResponse();
+  }
+
+  const chatId = body.chatId;
+  if (!chatId) {
+    return new ChatSDKError('bad_request:api').toResponse();
+  }
+
+  const chat = await getChatById({ id: chatId });
+  if (chat && chat.userId !== session.user.id) {
+    return new ChatSDKError('forbidden:chat').toResponse();
+  }
+
+  const aborted = abortChat(chatId);
+  console.log(`[chat-stop] chatId=${chatId} aborted=${aborted}`);
+  return Response.json({ aborted });
+}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -184,6 +184,15 @@ export function Chat({
 
   const stop = async () => {
     stoppedRef.current = true;
+    // Explicit server-side cancel. Cloud Run over HTTP/1.1 does not
+    // propagate the fetch abort, so we POST to /api/chat/stop to trigger
+    // the server's AbortController directly. Fire-and-forget — errors
+    // here shouldn't block the local stop().
+    fetch('/api/chat/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chatId: id }),
+    }).catch((err) => console.error('[stop] server cancel failed', err));
     originalStop();
   };
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DefaultChatTransport } from 'ai';
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
 import { useChat } from '@ai-sdk/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
@@ -74,11 +74,17 @@ export function Chat({
   // Ref to always have the latest messages in the onData closure
   const messagesRef = useRef<ChatMessage[]>([]);
 
+  // When the user presses Stop, useChat aborts the in-flight fetch but
+  // auto-continues the tool loop on the next render (because the last
+  // assistant message ends with a completed tool call). We guard the
+  // auto-send with this flag so Stop actually halts the loop. Reset
+  // on the next user-initiated send.
+  const stoppedRef = useRef(false);
 
   const {
     messages,
     setMessages,
-    sendMessage,
+    sendMessage: rawSendMessage,
     status,
     stop: originalStop,
     regenerate,
@@ -88,6 +94,8 @@ export function Chat({
     messages: initialMessages,
     experimental_throttle: 100,
     generateId: generateUUID,
+    sendAutomaticallyWhen: ({ messages }) =>
+      !stoppedRef.current && lastAssistantMessageIsCompleteWithToolCalls({ messages }),
     transport: new DefaultChatTransport({
       api: '/api/chat',
       fetch: fetchWithErrorHandlers,
@@ -175,7 +183,13 @@ export function Chat({
   messagesRef.current = messages;
 
   const stop = async () => {
+    stoppedRef.current = true;
     originalStop();
+  };
+
+  const sendMessage: typeof rawSendMessage = (...args) => {
+    stoppedRef.current = false;
+    return rawSendMessage(...args);
   };
 
   const [hasAppendedQuery, setHasAppendedQuery] = useState(false);

--- a/lib/chat-abort-registry.ts
+++ b/lib/chat-abort-registry.ts
@@ -1,0 +1,37 @@
+/**
+ * Per-chat AbortController registry for explicit cancellation.
+ *
+ * We can't rely on `request.signal` firing when the client disconnects —
+ * on Cloud Run over HTTP/1.1 the LB doesn't propagate client disconnects,
+ * and even locally Node only detects disconnect lazily. A separate
+ * POST /api/chat/stop endpoint lets the client explicitly abort the
+ * in-flight streamText run by looking it up here.
+ *
+ * This map is per-process (no Redis). Session affinity keeps a given
+ * chat pinned to one Cloud Run instance, so this works in practice.
+ */
+const controllers = new Map<string, AbortController>();
+
+export function registerChatAbort(chatId: string): AbortController {
+  const existing = controllers.get(chatId);
+  if (existing) {
+    existing.abort(new Error('superseded by new request'));
+  }
+  const controller = new AbortController();
+  controllers.set(chatId, controller);
+  return controller;
+}
+
+export function abortChat(chatId: string): boolean {
+  const controller = controllers.get(chatId);
+  if (!controller) return false;
+  controller.abort(new Error('stopped by user'));
+  controllers.delete(chatId);
+  return true;
+}
+
+export function clearChatAbort(chatId: string, controller: AbortController): void {
+  if (controllers.get(chatId) === controller) {
+    controllers.delete(chatId);
+  }
+}


### PR DESCRIPTION
## Summary

`useChat`'s default `sendAutomaticallyWhen = lastAssistantMessageIsCompleteWithToolCalls` auto-fires a new request as soon as a tool result arrives. When the user pressed **Stop**, `useChat` aborted the current fetch — but the next step immediately kicked off because the tool-call-completion condition was true. The LLM kept making calls.

Fix: guard the auto-send with a `stoppedRef` that flips `true` in our `stop()` wrapper and resets `false` on the next user-initiated `sendMessage`. Stop now halts the loop; typing a new message resumes normal auto-continue.

Refs AI SDK issues [vercel/ai#6422](https://github.com/vercel/ai/issues/6422) and [vercel/ai#7502](https://github.com/vercel/ai/issues/7502).

## Test plan

- [ ] Start a long browser-tool workflow (e.g. WIC form fill). Hit Stop mid-loop. LLM should not fire any new tool calls after the current one drains.
- [ ] After stopping, type a new message. Normal multi-step behavior resumes.
- [ ] Regenerate still works after a stop.