### PR TITLE
feat(context): cache-first pipeline with server-side tool-result clearing

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -177,42 +177,25 @@ export async function POST(request: Request) {
           : webAutomationModel;
 
         // Anthropic prompt caching — gated on model provider because
-        // `cacheControl` is Anthropic-only and other providers ignore or
-        // reject the option. Two breakpoints:
-        //   1. System prompt (covers tools + system, ~15K stable tokens)
-        //   2. Before the last 4 messages (caches growing middle history
-        //      so each step only reprocesses the recent dynamic tail)
+        // `cacheControl` is Anthropic-only. Single breakpoint on the
+        // system prompt caches tools + system (~15K stable tokens) for
+        // the 5-minute TTL. Every step after the first reads from cache.
         // See: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
         const isAnthropic = activeModel.provider.includes('anthropic');
-        const CACHE_BREAKPOINT = {
-          anthropic: { cacheControl: { type: 'ephemeral' as const } },
-        };
         const systemParam = isAnthropic
           ? {
               role: 'system' as const,
               content: getWebAutomationSystemPrompt(),
-              providerOptions: CACHE_BREAKPOINT,
+              providerOptions: {
+                anthropic: { cacheControl: { type: 'ephemeral' as const } },
+              },
             }
           : getWebAutomationSystemPrompt();
-        const cachedMessages =
-          isAnthropic && initialModelMessages.length > 4
-            ? initialModelMessages.map((msg, i) =>
-                i === initialModelMessages.length - 5
-                  ? {
-                      ...msg,
-                      providerOptions: {
-                        ...(msg.providerOptions ?? {}),
-                        ...CACHE_BREAKPOINT,
-                      },
-                    }
-                  : msg,
-              )
-            : initialModelMessages;
 
         const result = streamText({
           model: activeModel,
           system: systemParam,
-          messages: cachedMessages,
+          messages: initialModelMessages,
           tools: {
             ...apricotTools,
             gapAnalysis,

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -35,6 +35,7 @@ import { actionLabel } from '@/lib/ai/tools/action-label';
 import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
+import { updateWorkingMemory } from '@/lib/ai/tools/working-memory';
 import { prepareMessages } from '@/lib/ai/context-compression';
 import { withSlidingCacheBreakpoint } from '@/lib/ai/cache-breakpoints';
 import { registerChatAbort, clearChatAbort } from '@/lib/chat-abort-registry';
@@ -265,6 +266,7 @@ export async function POST(request: Request) {
             browser: createBrowserTool(sessionId, session.user.id),
             loadSkill,
             readSkillFile,
+            updateWorkingMemory,
           },
           // request.signal.aborted is checked at each step boundary so the
           // tool loop halts even before Node's write-failure-based abort
@@ -278,7 +280,17 @@ export async function POST(request: Request) {
           stopWhen: [stepCountIs(500), () => chatAbort.signal.aborted],
           // Emit cumulative token usage after each step so the client can
           // display it in real-time via the Context component.
-          onStepFinish: ({ usage }) => {
+          onStepFinish: ({ usage, providerMetadata }) => {
+            const anthropicMeta = providerMetadata?.anthropic as any | undefined;
+            console.log(
+              '[cache]',
+              JSON.stringify({
+                input: usage.inputTokens,
+                cache_read: anthropicMeta?.usage?.cache_read_input_tokens ?? 0,
+                cache_create: anthropicMeta?.usage?.cache_creation_input_tokens ?? 0,
+                applied: anthropicMeta?.contextManagement?.appliedEdits ?? [],
+              }),
+            );
             dataStream.write({
               type: 'data-token-usage',
               data: usage,

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -176,10 +176,43 @@ export async function POST(request: Request) {
           ? myProvider.languageModel(resolvedModelOverride)
           : webAutomationModel;
 
+        // Anthropic prompt caching — gated on model provider because
+        // `cacheControl` is Anthropic-only and other providers ignore or
+        // reject the option. Two breakpoints:
+        //   1. System prompt (covers tools + system, ~15K stable tokens)
+        //   2. Before the last 4 messages (caches growing middle history
+        //      so each step only reprocesses the recent dynamic tail)
+        // See: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
+        const isAnthropic = activeModel.provider.includes('anthropic');
+        const CACHE_BREAKPOINT = {
+          anthropic: { cacheControl: { type: 'ephemeral' as const } },
+        };
+        const systemParam = isAnthropic
+          ? {
+              role: 'system' as const,
+              content: getWebAutomationSystemPrompt(),
+              providerOptions: CACHE_BREAKPOINT,
+            }
+          : getWebAutomationSystemPrompt();
+        const cachedMessages =
+          isAnthropic && initialModelMessages.length > 4
+            ? initialModelMessages.map((msg, i) =>
+                i === initialModelMessages.length - 5
+                  ? {
+                      ...msg,
+                      providerOptions: {
+                        ...(msg.providerOptions ?? {}),
+                        ...CACHE_BREAKPOINT,
+                      },
+                    }
+                  : msg,
+              )
+            : initialModelMessages;
+
         const result = streamText({
           model: activeModel,
-          system: getWebAutomationSystemPrompt(),
-          messages: initialModelMessages,
+          system: systemParam,
+          messages: cachedMessages,
           tools: {
             ...apricotTools,
             gapAnalysis,

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -35,7 +35,8 @@ import { actionLabel } from '@/lib/ai/tools/action-label';
 import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
-import { createMessageCompressor } from '@/lib/ai/context-compression';
+import { prepareMessages } from '@/lib/ai/context-compression';
+import { withSlidingCacheBreakpoint } from '@/lib/ai/cache-breakpoints';
 import { registerChatAbort, clearChatAbort } from '@/lib/chat-abort-registry';
 
 export const maxDuration = 300; // 5 minutes for web automation tasks
@@ -164,24 +165,54 @@ export async function POST(request: Request) {
 
     const stream = createUIMessageStream({
       execute: async ({ writer: dataStream }) => {
-        const initialModelMessages = await convertToModelMessages(uiMessages);
-
-        // One compressor instance per request; its cache persists across all
-        // prepareStep calls so generateText is not re-fired on every step.
-        // Compaction triggers on step 1+ using SDK-reported inputTokens
-        // (step 0 has no prior usage data, so it runs uncompacted).
-        const compressStep = createMessageCompressor();
+        const rawModelMessages = await convertToModelMessages(uiMessages);
 
         const activeModel = resolvedModelOverride
           ? myProvider.languageModel(resolvedModelOverride)
           : webAutomationModel;
-
-        // Anthropic prompt caching — gated on model provider because
-        // `cacheControl` is Anthropic-only. Single breakpoint on the
-        // system prompt caches tools + system (~15K stable tokens) for
-        // the 5-minute TTL. Every step after the first reads from cache.
-        // See: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
         const isAnthropic = activeModel.provider.includes('anthropic');
+
+        // Cheap char-based token estimate (~4 chars/token) to decide whether
+        // to run the fallback compactor. We avoid a separate tokens-counting
+        // call — overshooting slightly is fine; the model-side clear_tool_uses
+        // edit also fires server-side if we're still heavy.
+        const estimatedInputTokens = Math.ceil(
+          rawModelMessages.reduce(
+            (n, m) => n + JSON.stringify(m.content ?? '').length,
+            0,
+          ) / 4,
+        );
+
+        // Fallback compaction (Haiku) — runs once, only if the request is
+        // already near the window. Vertex doesn't yet accept the Anthropic
+        // `compact_20260112` beta header, so we summarize client-side.
+        const { messages: preparedMessages, compacted, summary } =
+          await prepareMessages(rawModelMessages, estimatedInputTokens);
+        if (compacted) {
+          console.log(
+            `[compressor] summarized — estimated ${estimatedInputTokens} tokens`,
+          );
+          dataStream.write({
+            type: 'data-checkpoint',
+            data: {
+              stepNumber: 0,
+              inputTokens: estimatedInputTokens,
+              timestamp: Date.now(),
+              summary,
+            },
+            transient: true,
+          });
+        }
+
+        // Sliding cache breakpoint on the last message: combined with the
+        // system-prompt breakpoint below, every step after the first reads
+        // system + tools + history-up-to-last-turn from cache.
+        const finalMessages = isAnthropic
+          ? withSlidingCacheBreakpoint(preparedMessages)
+          : preparedMessages;
+
+        // Static cache breakpoint on the system prompt (+ tools travel with it).
+        // See https://docs.claude.com/en/docs/build-with-claude/prompt-caching
         const systemParam = isAnthropic
           ? {
               role: 'system' as const,
@@ -192,10 +223,40 @@ export async function POST(request: Request) {
             }
           : getWebAutomationSystemPrompt();
 
+        // Anthropic server-side context editing. `clear_tool_uses_20250919`
+        // replaces old tool_result payloads with `[cleared to save context]`
+        // while preserving the tool_use records so the model knows the calls
+        // happened and can re-invoke if needed. `updateWorkingMemory` is
+        // excluded because its payload is load-bearing (participant JSON).
+        //
+        // Vertex rejects `compact-2026-01-12`; when Google enables that beta
+        // we can add a `compact_20260112` edit and delete prepareMessages.
+        const contextManagementOptions = isAnthropic
+          ? {
+              anthropic: {
+                contextManagement: {
+                  edits: [
+                    {
+                      type: 'clear_tool_uses_20250919' as const,
+                      trigger: { type: 'input_tokens' as const, value: 80_000 },
+                      keep: { type: 'tool_uses' as const, value: 4 },
+                      clearAtLeast: {
+                        type: 'input_tokens' as const,
+                        value: 10_000,
+                      },
+                      excludeTools: ['updateWorkingMemory'],
+                    },
+                  ],
+                },
+              },
+            }
+          : undefined;
+
         const result = streamText({
           model: activeModel,
           system: systemParam,
-          messages: initialModelMessages,
+          messages: finalMessages,
+          providerOptions: contextManagementOptions,
           tools: {
             ...apricotTools,
             gapAnalysis,
@@ -215,38 +276,6 @@ export async function POST(request: Request) {
           // tool-call with no matching tool-result, triggering
           // AI_MissingToolResultsError on the next turn.
           stopWhen: [stepCountIs(500), () => chatAbort.signal.aborted],
-          // Compress message history when token usage approaches the context
-          // window limit (75% of 200K). First step has no prior usage data so
-          // compression is skipped (correct — first step is always small).
-          prepareStep: async ({ messages: stepMessages, steps }) => {
-            const lastInputTokens = steps.length > 0
-              ? steps[steps.length - 1].usage.inputTokens
-              : undefined;
-            const { messages: compressed, compacted, summary } = await compressStep(
-              stepMessages,
-              lastInputTokens,
-              () => {
-                dataStream.write({
-                  type: 'data-compacting',
-                  data: { timestamp: Date.now() },
-                  transient: true,
-                });
-              },
-            );
-            if (compacted) {
-              dataStream.write({
-                type: 'data-checkpoint',
-                data: {
-                  stepNumber: steps.length,
-                  inputTokens: lastInputTokens,
-                  timestamp: Date.now(),
-                  summary,
-                },
-                transient: true,
-              });
-            }
-            return { messages: compressed };
-          },
           // Emit cumulative token usage after each step so the client can
           // display it in real-time via the Context component.
           onStepFinish: ({ usage }) => {

--- a/lib/ai/cache-breakpoints.ts
+++ b/lib/ai/cache-breakpoints.ts
@@ -1,0 +1,34 @@
+import type { ModelMessage } from 'ai';
+
+/**
+ * Add an Anthropic ephemeral cache breakpoint on the last message in the
+ * history. Combined with the static system-prompt breakpoint, this lets
+ * every step after the first read the whole prefix (system + tools +
+ * message history up to the last turn) from cache.
+ *
+ * The breakpoint "slides" naturally because it's computed per request on
+ * the then-last message — the previous turn's messages become cached
+ * prefix for the next request, and only the new turn is uncached.
+ *
+ * No-op if the model isn't Anthropic-family (Vertex routes other providers
+ * too). The cacheControl field is ignored by non-Anthropic providers.
+ */
+export function withSlidingCacheBreakpoint(
+  messages: ModelMessage[],
+): ModelMessage[] {
+  if (messages.length === 0) return messages;
+  const lastIdx = messages.length - 1;
+  const last = messages[lastIdx];
+  const existing = (last as any).providerOptions ?? {};
+  const withBp: ModelMessage = {
+    ...last,
+    providerOptions: {
+      ...existing,
+      anthropic: {
+        ...(existing.anthropic ?? {}),
+        cacheControl: { type: 'ephemeral' as const },
+      },
+    },
+  };
+  return [...messages.slice(0, lastIdx), withBp];
+}

--- a/lib/ai/context-compression.ts
+++ b/lib/ai/context-compression.ts
@@ -1,40 +1,63 @@
-import { generateText, pruneMessages, type ModelMessage } from 'ai';
+import { generateText, type ModelMessage } from 'ai';
+import { z } from 'zod';
+import { tool } from 'ai';
 import { prepareStepModel } from '@/lib/ai/providers';
 import { WORKING_MEMORY_PREFIX, buildWorkingMemoryMessage } from '@/lib/ai/working-memory';
-import { updateWorkingMemory } from '@/lib/ai/tools/working-memory';
 
-const MODEL_CONTEXT_WINDOW = 200_000; // claude-sonnet-4-6
-const COMPACT_THRESHOLD_PCT = 0.75;
-const KEEP_RECENT = 8;                // keep last N messages after compaction
+// Vertex AI rejects `compact-2026-01-12`, so native compaction is unavailable.
+// `clear_tool_uses_20250919` handles tool-result bloat server-side; this
+// module is the fallback when pruning alone isn't enough.
+//
+// When Vertex enables the compaction beta, this whole file can be deleted
+// and replaced with a `compact_20260112` edit in providerOptions.anthropic.
 
+const COMPACT_THRESHOLD_TOKENS = 150_000; // only above this do we summarize
+const KEEP_RECENT = 8;
 const SUMMARY_PREFIX = '[Session summary — earlier context compacted]';
 
 const COMPACTION_SYSTEM_PROMPT =
   'You are creating a session handoff document for a benefits form-filling agent. ' +
-  'Participant field-value data is preserved separately in working memory — ' +
-  'do NOT list individual participant field values in the summary.\n\n' +
-  'Extract and preserve the following from the transcript:\n' +
-  '- SESSION STATE: The current form name, URL, and which page/step we are on.\n' +
-  '- COMPLETED FIELDS: Every field that has already been filled and its value.\n' +
-  '- PENDING FIELDS: Every field still needing input.\n' +
-  '- CASEWORKER INPUTS: Every answer or correction the caseworker provided.\n' +
-  '- GAP ANALYSIS: Every field that has been identified as a gap and the reason why.\n' +
-  '- GAP ANSWERS: Every answer or correction the caseworker provided to a gap analysis.\n' +
-  '- KEY DECISIONS: Any decisions or clarifications made during the session.\n\n' +
-  'CRITICAL RULES:\n' +
-  '- Do NOT invent, infer, or fabricate any data that is not explicitly present in the transcript.\n' +
-  '- If a field value appears truncated or unclear, write [UNKNOWN] rather than guessing.\n' +
-  '- Do NOT include participant PII (names, DOB, SSN, address) — it is in working memory.\n' +
-  'Do NOT include browser snapshot content or raw HTML.';
+  'Return BOTH a prose summary AND structured participant data.\n\n' +
+  'SUMMARY should capture:\n' +
+  '- SESSION STATE: form name, URL, current page/step.\n' +
+  '- COMPLETED FIELDS: fields already filled with values.\n' +
+  '- PENDING FIELDS: fields still needing input.\n' +
+  '- CASEWORKER INPUTS: answers/corrections the caseworker provided.\n' +
+  '- GAP ANALYSIS: identified gaps and reasons.\n' +
+  '- KEY DECISIONS: clarifications made during the session.\n\n' +
+  'WORKING MEMORY should extract all participant data (Apricot records, ' +
+  'caseworker answers, household). Do not fabricate — use [UNKNOWN] for missing.\n\n' +
+  'Do not include participant PII in the summary (it belongs in working memory). ' +
+  'Do not include browser snapshots or raw HTML.';
 
-const log = (..._args: unknown[]) => {};
+const log = (...args: unknown[]) => console.log('[compressor]', ...args);
 
-/**
- * Detect and extract a working memory message from the beginning of the
- * message list. The working memory message is always the first message and
- * starts with WORKING_MEMORY_PREFIX. It must be excluded from compaction
- * so the model always has ground-truth participant data.
- */
+const recordSchema = z.record(z.string(), z.unknown());
+const writeHandoff = tool({
+  description: 'Write the session handoff summary and updated working memory.',
+  inputSchema: z.object({
+    summary: z.string().describe('Prose handoff summary (see system prompt)'),
+    workingMemory: z
+      .object({
+        participant: recordSchema.optional(),
+        household: z.array(recordSchema).optional(),
+        caseworkerInputs: recordSchema.optional(),
+        formState: z
+          .object({
+            formName: z.string().optional(),
+            currentUrl: z.string().optional(),
+            currentStep: z.string().optional(),
+            completedFields: z.record(z.string(), z.string()).optional(),
+            pendingFields: z.array(z.string()).optional(),
+          })
+          .optional(),
+      })
+      .optional()
+      .describe('Structured participant data extracted from the transcript'),
+  }),
+  execute: async (input) => input,
+});
+
 function extractWorkingMemory(messages: ModelMessage[]): {
   wmMessage: ModelMessage | null;
   rest: ModelMessage[];
@@ -49,10 +72,6 @@ function extractWorkingMemory(messages: ModelMessage[]): {
   return { wmMessage: null, rest: messages };
 }
 
-/**
- * Flatten a ModelMessage into a plain-text line for the transcript.
- * Strips browser snapshots/screenshots to keep the transcript manageable.
- */
 function flattenMessage(msg: ModelMessage): string {
   const role = msg.role.toUpperCase();
   if (typeof msg.content === 'string') return `[${role}]: ${msg.content}`;
@@ -60,17 +79,12 @@ function flattenMessage(msg: ModelMessage): string {
 
   const parts = (msg.content as any[]).map((part) => {
     if (!part) return '';
-    // Browser tool results: keep status, strip the heavy output payload.
-    // AI SDK v5 puts the tool return value on `output`; older shape used
-    // `result`. Support both for safety.
     if (part.type === 'tool-result' && part.toolName === 'browser') {
       const raw = part.output ?? part.result ?? {};
       const r = (raw && typeof raw === 'object' && 'value' in raw ? (raw as any).value : raw) as any;
       const status = r?.success ? 'success' : `error: ${r?.error ?? 'unknown'}`;
       return `[browser result: ${status}]`;
     }
-    // Browser tool calls: keep action + key param for context.
-    // AI SDK v5 uses `input`; older shape used `args`. Support both.
     if (part.type === 'tool-call' && part.toolName === 'browser') {
       const a = (part.input ?? part.args ?? {}) as Record<string, any>;
       return `[browser: ${a.action ?? '?'}${a.selector ? ` ${a.selector}` : a.url ? ` ${a.url}` : ''}]`;
@@ -81,211 +95,83 @@ function flattenMessage(msg: ModelMessage): string {
   return `[${role}]: ${parts.join('\n')}`;
 }
 
-/**
- * Shared summarization: split messages into old + recent, then run two
- * parallel Haiku calls on the same transcript:
- *   1. Compaction summary (session state, actions, decisions)
- *   2. Working memory extraction (structured participant data via tool call)
- *
- * Returns null on failure (caller should fall back to original messages).
- */
-async function summarizeMessages(
-  messages: ModelMessage[],
-  logPrefix: string,
-  onCompacting?: () => void,
-): Promise<{
-  summary: string;
-  workingMemory: Record<string, unknown> | null;
-  recentMessages: ModelMessage[];
-  splitAt: number;
-} | null> {
-  if (messages.length <= KEEP_RECENT) {
-    log(`${logPrefix}over threshold but only ${messages.length} msgs (≤ ${KEEP_RECENT}), skipping`);
-    return null;
-  }
-
-  // Never split between a tool-call assistant message and its following
-  // tool-result message — Anthropic requires each tool_result to have a
-  // tool_use in the previous message, so an orphan tool-role message in
-  // recentMessages fails validation. Walk back past tool-role messages.
-  let splitAt = messages.length - KEEP_RECENT;
-  while (splitAt > 0 && messages[splitAt]?.role === 'tool') {
-    splitAt -= 1;
-  }
-  const oldMessages = messages.slice(0, splitAt);
-  const recentMessages = messages.slice(splitAt);
-
-  log(
-    `${logPrefix}COMPACTING — summarizing ${oldMessages.length} old msgs, ` +
-    `keeping ${recentMessages.length} recent`
-  );
-
-  const transcript = oldMessages.map(flattenMessage).join('\n\n');
-  log(`${logPrefix}transcript length: ${transcript.length} chars from ${oldMessages.length} msgs`);
-
-  onCompacting?.();
-
-  const t0 = Date.now();
-
-  // Run compaction summary and working memory extraction in parallel on Haiku
-  const [compactionResult, wmResult] = await Promise.all([
-    // 1. Compaction summary
-    generateText({
-      model: prepareStepModel,
-      maxOutputTokens: 4096,
-      system: COMPACTION_SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: `Summarize this session transcript:\n\n${transcript}` }],
-    }).catch((err) => {
-      log(`${logPrefix}compaction ERROR:`, err);
-      return null;
-    }),
-
-    // 2. Working memory extraction via tool call
-    generateText({
-      model: prepareStepModel,
-      maxOutputTokens: 4096,
-      tools: { updateWorkingMemory },
-      toolChoice: { type: 'tool', toolName: 'updateWorkingMemory' },
-      system:
-        'Extract all participant data from this transcript. ' +
-        'Include data from database records and caseworker answers. ' +
-        'Only include data explicitly present — never fabricate.',
-      messages: [{ role: 'user', content: transcript }],
-    }).catch((err) => {
-      log(`${logPrefix}working memory ERROR:`, err);
-      return null;
-    }),
-  ]);
-
-  const elapsed = Date.now() - t0;
-
-  // Process compaction result
-  const summary = compactionResult?.text?.trim();
-  if (!summary) {
-    log(`${logPrefix}ABORT — empty or failed compaction summary`);
-    return null;
-  }
-  log(`${logPrefix}compaction done in ${elapsed}ms — summary: ${summary.length} chars`);
-
-  // Process working memory result
-  let workingMemory: Record<string, unknown> | null = null;
-  if (wmResult?.toolResults?.length) {
-    workingMemory = wmResult.toolResults[0].output as Record<string, unknown>;
-    log(`${logPrefix}working memory extracted — ${Object.keys(workingMemory).length} keys`);
-  } else {
-    log(`${logPrefix}working memory extraction failed or empty — continuing without`);
-  }
-
-  return { summary, workingMemory, recentMessages, splitAt };
-}
-
 function buildSummaryMessage(summary: string): ModelMessage {
   return { role: 'assistant', content: `${SUMMARY_PREFIX}\n\n${summary}` };
 }
 
 /**
- * Returns a stateful compression function for a single streamText request.
+ * Stateless fallback compaction. Called once at the top of a request, never
+ * inside the tool loop.
  *
- * IMPORTANT: The AI SDK's prepareStep does NOT persist message overrides
- * between steps (see https://github.com/vercel/ai/issues/9631). Each call
- * to prepareStep receives [...initialMessages, ...allResponseMessages],
- * ignoring any prior compaction.
+ * Contract:
+ * - If estimatedInputTokens is below the threshold, returns messages unchanged.
+ * - If above, runs one Haiku call with a tool-forced schema that emits both
+ *   summary and structured working memory.
+ * - Returns `[wm?, summary, ...last 8 messages]` on success, or the original
+ *   messages on any failure (compaction is best-effort, never fatal).
  *
- * Workaround: we store the compaction state (summary message + count of
- * original messages that were summarized) and re-apply it on every
- * subsequent prepareStep call.
+ * Never splits a tool-call from its tool-result (Anthropic would reject).
  */
-export function createMessageCompressor() {
-  let justCompacted = false;
+export async function prepareMessages(
+  messages: ModelMessage[],
+  estimatedInputTokens: number,
+): Promise<{ messages: ModelMessage[]; compacted: boolean; summary?: string }> {
+  if (estimatedInputTokens < COMPACT_THRESHOLD_TOKENS) {
+    return { messages, compacted: false };
+  }
 
-  // Persisted compaction state — survives across prepareStep calls
-  let storedSummaryMessage: ModelMessage | null = null;
-  let storedWmMessage: ModelMessage | null = null;
-  let summarizedCount = 0; // how many original messages were folded into the summary
+  const { wmMessage: incomingWm, rest } = extractWorkingMemory(messages);
+  if (rest.length <= KEEP_RECENT) {
+    log(`over threshold but only ${rest.length} non-WM msgs — skip`);
+    return { messages, compacted: false };
+  }
 
-  return async function compress(
-    stepMessages: ModelMessage[],
-    lastInputTokens: number | undefined,
-    onCompacting?: () => void,
-  ): Promise<{ messages: ModelMessage[]; compacted: boolean; summary?: string }> {
+  let splitAt = rest.length - KEEP_RECENT;
+  while (splitAt > 0 && rest[splitAt]?.role === 'tool') splitAt -= 1;
+  const oldMessages = rest.slice(0, splitAt);
+  const recentMessages = rest.slice(splitAt);
+  const transcript = oldMessages.map(flattenMessage).join('\n\n');
 
-    // --- Extract working memory — never compact it ---
-    const { wmMessage: incomingWm, rest: rawMessages } = extractWorkingMemory(stepMessages);
-    let wm = storedWmMessage ?? incomingWm;
+  log(
+    `compacting — ${oldMessages.length} old msgs (${transcript.length} chars) → summary + WM, ` +
+    `keeping ${recentMessages.length} recent`,
+  );
 
-    // --- Re-apply prior compaction ---
-    let effectiveMessages = rawMessages;
-    if (storedSummaryMessage && summarizedCount > 0) {
-      const newMessages = rawMessages.slice(summarizedCount);
-      effectiveMessages = [storedSummaryMessage, ...newMessages];
-      log(
-        `re-applied prior compaction — stripped ${summarizedCount} original msgs, ` +
-        `${effectiveMessages.length} effective msgs (1 summary + ${newMessages.length} new)`
-      );
-    }
+  const t0 = Date.now();
+  let toolResult:
+    | { summary?: string; workingMemory?: Record<string, unknown> }
+    | undefined;
+  try {
+    const result = await generateText({
+      model: prepareStepModel,
+      maxOutputTokens: 4096,
+      system: COMPACTION_SYSTEM_PROMPT,
+      tools: { writeHandoff },
+      toolChoice: { type: 'tool', toolName: 'writeHandoff' },
+      messages: [{ role: 'user', content: `Transcript:\n\n${transcript}` }],
+    });
+    toolResult = result.toolResults?.[0]?.output as typeof toolResult;
+  } catch (err) {
+    log('ERROR — compaction generateText failed:', err);
+    return { messages, compacted: false };
+  }
 
-    const prepend = (msgs: ModelMessage[]) =>
-      wm ? [wm, ...msgs] : msgs;
+  const summary = toolResult?.summary?.trim();
+  if (!summary) {
+    log('ABORT — empty summary from Haiku');
+    return { messages, compacted: false };
+  }
+  log(`compaction done in ${Date.now() - t0}ms — summary ${summary.length} chars`);
 
-    // Step 0: no prior inputTokens available. Prune browser tool content
-    // from older messages to avoid exceeding the main model's context window
-    // on cross-request reloads with large message histories.
-    if (lastInputTokens === undefined) {
-      const pruned = pruneMessages({
-        messages: effectiveMessages,
-        toolCalls: [{ type: 'before-last-2-messages', tools: ['browser'] }],
-        emptyMessages: 'remove',
-      });
-      log(`step 0 — pruned browser tools: ${effectiveMessages.length} → ${pruned.length} msgs`);
-      return { messages: prepend(pruned), compacted: false };
-    }
+  const newWm =
+    toolResult?.workingMemory && Object.keys(toolResult.workingMemory).length > 0
+      ? buildWorkingMemoryMessage(toolResult.workingMemory)
+      : incomingWm;
 
-    const usedPct = lastInputTokens / MODEL_CONTEXT_WINDOW;
+  const out: ModelMessage[] = [];
+  if (newWm) out.push(newWm);
+  out.push(buildSummaryMessage(summary));
+  out.push(...recentMessages);
 
-    if (justCompacted) {
-      justCompacted = false;
-      log(
-        `skip — stale inputTokens after compaction, ${effectiveMessages.length} msgs, ${(usedPct * 100).toFixed(1)}% (stale)`
-      );
-      return { messages: prepend(effectiveMessages), compacted: false };
-    }
-
-    log(
-      `step check — ${effectiveMessages.length} msgs (raw ${stepMessages.length}${wm ? ', +WM' : ''}), ` +
-      `inputTokens=${lastInputTokens ?? 'n/a'}, ` +
-      `${(usedPct * 100).toFixed(1)}% of ${MODEL_CONTEXT_WINDOW} context window, ` +
-      `threshold=${(COMPACT_THRESHOLD_PCT * 100).toFixed(0)}%`
-    );
-
-    if (usedPct < COMPACT_THRESHOLD_PCT) {
-      return { messages: prepend(effectiveMessages), compacted: false };
-    }
-
-    const result = await summarizeMessages(effectiveMessages, '', onCompacting);
-    if (!result) {
-      justCompacted = true;
-      return { messages: prepend(effectiveMessages), compacted: false };
-    }
-
-    const newSummaryMessage = buildSummaryMessage(result.summary);
-
-    storedSummaryMessage = newSummaryMessage;
-    if (result.workingMemory) {
-      storedWmMessage = buildWorkingMemoryMessage(result.workingMemory);
-      wm = storedWmMessage;
-    }
-    if (summarizedCount === 0) {
-      summarizedCount = result.splitAt;
-    } else {
-      summarizedCount += result.splitAt - 1;
-    }
-
-    log(
-      `compaction persisted — summarizedCount=${summarizedCount}, ` +
-      `returning ${1 + result.recentMessages.length} msgs${wm ? ' +WM' : ''}`
-    );
-
-    justCompacted = true;
-    return { messages: prepend([newSummaryMessage, ...result.recentMessages]), compacted: true, summary: result.summary };
-  };
+  return { messages: out, compacted: true, summary };
 }

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -88,6 +88,20 @@ Before starting each logical group of related browser actions, call the \`action
 - Call it ONCE per group, not before every individual action
 - Choose the \`category\` that best matches: \`fill\` (form filling), \`navigate\` (navigation/page load), \`interact\` (clicking/interacting), \`read\` (reading/snapshot), \`search\` (searching), \`misc\` (general)
 
+## Working Memory (REQUIRED)
+
+You have a \`updateWorkingMemory\` tool that maintains a structured record of participant data, caseworker answers, household members, and form-filling progress. A smaller model (Haiku) reads the recent transcript and refreshes the WM when you call it — you do NOT serialize the state yourself, just signal that it's time to refresh.
+
+Call \`updateWorkingMemory\` with a short \`reason\` after meaningful state changes:
+- Finishing a form section (address done, contact info done, income done)
+- Caseworker provides gap-analysis answers or corrections
+- A database fetch returns new participant fields
+- A page transition reveals new required fields
+
+Do NOT call it after every browser action — that wastes tokens. Roughly once every 5–10 tool calls, or at clear section boundaries.
+
+NEVER dump "SAVED CONTEXT", "STATUS SAVE", or any other state summary as assistant text in the chat. That is not a substitute for \`updateWorkingMemory\` — it just spams the caseworker and does not actually preserve state. If you feel tempted to dump state, call \`updateWorkingMemory\` instead.
+
 ## Form Field Protocol
 
 Before filling fields, run gap analysis first — compare what you have against what the form needs, then use the \`gapAnalysis\` tool. When done filling, use the \`formSummary\` tool. Load the \`caseworker-communication\` skill for the full gap analysis and form summary protocols.

--- a/lib/ai/tools/working-memory.ts
+++ b/lib/ai/tools/working-memory.ts
@@ -1,39 +1,134 @@
-import { tool } from 'ai';
+import { generateText, tool, type ModelMessage } from 'ai';
 import { z } from 'zod';
+import { prepareStepModel } from '@/lib/ai/providers';
+import { WORKING_MEMORY_PREFIX } from '@/lib/ai/working-memory';
+
+// The agent triggers this; Haiku does the actual extraction. This keeps
+// WM updates cheap (Sonnet spends only a tool-call's worth of output
+// tokens on the trigger, not on serializing the full state itself).
+
+const EXTRACTION_SYSTEM_PROMPT =
+  'You are maintaining a structured working memory document for a ' +
+  'benefits form-filling agent. Extract ALL participant data, caseworker ' +
+  'answers, household members, and form-filling progress from the ' +
+  'transcript below. Merge with any prior working memory and include ' +
+  'EVERYTHING currently known — the agent replaces its entire WM with ' +
+  'your output, so omissions are lost. Never fabricate values; use ' +
+  '[UNKNOWN] for anything not explicitly present.';
+
+const participantRecord = z.record(z.string(), z.unknown());
+
+const workingMemorySchema = z.object({
+  participant: participantRecord
+    .optional()
+    .describe('Primary applicant fields: name, DOB, SSN, gender, race, citizenship, contact info, CalWorks ID, etc.'),
+  household: z
+    .array(participantRecord)
+    .optional()
+    .describe('Other household members with their fields and relationships'),
+  caseworkerInputs: participantRecord
+    .optional()
+    .describe('Answers the caseworker provided this session (gap fills, corrections, one-off responses)'),
+  formState: z
+    .object({
+      formName: z.string().optional(),
+      currentUrl: z.string().optional(),
+      currentStep: z.string().optional(),
+      completedFields: z.record(z.string(), z.string()).optional(),
+      pendingFields: z.array(z.string()).optional(),
+      keyDecisions: z.array(z.string()).optional(),
+    })
+    .optional()
+    .describe('Current form-filling progress and key decisions'),
+});
+
+const writeWorkingMemory = tool({
+  description: 'Internal tool used by updateWorkingMemory to force structured output.',
+  inputSchema: workingMemorySchema,
+  execute: async (input) => input,
+});
+
+function flattenForExtraction(msg: ModelMessage): string {
+  const role = msg.role.toUpperCase();
+  if (typeof msg.content === 'string') return `[${role}]: ${msg.content}`;
+  if (!Array.isArray(msg.content)) return `[${role}]: ${JSON.stringify(msg.content)}`;
+  const parts = (msg.content as any[]).map((part) => {
+    if (!part) return '';
+    // Strip heavy browser payloads — only status matters for WM extraction
+    if (part.type === 'tool-result' && part.toolName === 'browser') {
+      const raw = part.output ?? part.result ?? {};
+      const r = raw && typeof raw === 'object' && 'value' in raw ? (raw as any).value : raw;
+      return `[browser result: ${(r as any)?.success ? 'ok' : 'err'}]`;
+    }
+    if (part.type === 'tool-call' && part.toolName === 'browser') {
+      const a = (part.input ?? part.args ?? {}) as Record<string, any>;
+      return `[browser: ${a.action ?? '?'}${a.selector ? ` ${a.selector}` : a.url ? ` ${a.url}` : ''}]`;
+    }
+    const s = typeof part === 'string' ? part : (part.text ?? JSON.stringify(part) ?? '');
+    return String(s);
+  });
+  return `[${role}]: ${parts.join('\n')}`;
+}
+
+function extractCurrentWm(messages: ModelMessage[]): string {
+  // Find the most recent WM (seed message at top, or prior tool result)
+  const first = messages[0];
+  if (
+    first &&
+    typeof first.content === 'string' &&
+    first.content.startsWith(WORKING_MEMORY_PREFIX)
+  ) {
+    return first.content;
+  }
+  return '(no prior working memory)';
+}
 
 export const updateWorkingMemory = tool({
   description:
-    'Update the working memory with participant data, caseworker inputs, or form state. ' +
-    'Call this after retrieving Apricot records, when the caseworker provides gap analysis answers, ' +
-    'or when form state changes significantly. ' +
-    'Each call REPLACES the entire working memory — always include the COMPLETE current state.',
+    'Refresh the structured working memory with the latest participant data, ' +
+    'caseworker answers, household members, and form-filling progress. ' +
+    'Call this after meaningful state changes (caseworker answers, data ' +
+    'fetches, completing a form section) — NOT after every browser action. ' +
+    'A Haiku model reads the recent transcript and returns the updated WM, ' +
+    'so you do not need to serialize the state yourself.',
   inputSchema: z.object({
-    participant: z
-      .record(z.unknown())
-      .optional()
+    reason: z
+      .string()
       .describe(
-        'All participant fields from Apricot database records (name, DOB, SSN, address, etc.)',
+        'Short note on what just changed (e.g. "finished address section", "caseworker provided SSN"). Helps focus the extraction.',
       ),
-    household: z
-      .array(z.record(z.unknown()))
-      .optional()
-      .describe('Household members with their fields'),
-    caseworkerInputs: z
-      .record(z.unknown())
-      .optional()
-      .describe(
-        'Answers the caseworker provided during this session (gap analysis responses, corrections)',
-      ),
-    formState: z
-      .object({
-        formName: z.string().optional(),
-        currentUrl: z.string().optional(),
-        currentStep: z.string().optional(),
-        completedFields: z.record(z.string()).optional(),
-        pendingFields: z.array(z.string()).optional(),
-      })
-      .optional()
-      .describe('Current form-filling progress'),
   }),
-  execute: async (input) => input,
+  execute: async ({ reason }, options) => {
+    const t0 = Date.now();
+    const priorWm = extractCurrentWm(options.messages);
+    const transcript = options.messages.map(flattenForExtraction).join('\n\n');
+
+    try {
+      const result = await generateText({
+        model: prepareStepModel,
+        maxOutputTokens: 4096,
+        system: EXTRACTION_SYSTEM_PROMPT,
+        tools: { writeWorkingMemory },
+        toolChoice: { type: 'tool', toolName: 'writeWorkingMemory' },
+        messages: [
+          {
+            role: 'user',
+            content:
+              `Trigger reason: ${reason}\n\n` +
+              `Prior working memory:\n${priorWm}\n\n` +
+              `Recent transcript:\n${transcript}`,
+          },
+        ],
+      });
+      const wm = result.toolResults?.[0]?.output as Record<string, unknown> | undefined;
+      const elapsed = Date.now() - t0;
+      console.log(
+        `[working-memory] updated in ${elapsed}ms — keys: ${wm ? Object.keys(wm).join(',') : 'none'}`,
+      );
+      return wm ?? { error: 'no output from extraction' };
+    } catch (err: any) {
+      console.log('[working-memory] extraction failed:', err?.message ?? err);
+      return { error: `extraction failed: ${err?.message ?? 'unknown'}` };
+    }
+  },
 });

--- a/scripts/probe-context-management.ts
+++ b/scripts/probe-context-management.ts
@@ -1,0 +1,105 @@
+/**
+ * Probe whether Vertex AI's Anthropic endpoint accepts the
+ * context_management API (clear_tool_uses_20250919, compact_20260112)
+ * via @ai-sdk/google-vertex/anthropic + providerOptions.anthropic.
+ *
+ * Run:
+ *   cd client && pnpm tsx scripts/probe-context-management.ts
+ *
+ * Requires .env.local to be loaded (GOOGLE_VERTEX_PROJECT,
+ * GOOGLE_VERTEX_LOCATION, GOOGLE_APPLICATION_CREDENTIALS).
+ */
+import 'dotenv/config';
+import { config as loadDotenv } from 'dotenv';
+import { generateText } from 'ai';
+import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+
+loadDotenv({ path: '.env.local', override: false });
+
+const model = vertexAnthropic('claude-haiku-4-5');
+
+async function probe(label: string, providerOptions: any) {
+  console.log(`\n─── ${label} ───`);
+  try {
+    const result = await generateText({
+      model,
+      maxOutputTokens: 40,
+      messages: [
+        { role: 'user', content: 'Say "probe ok" and nothing else.' },
+      ],
+      providerOptions,
+    });
+    console.log('  ✓ request succeeded');
+    console.log('  text:', JSON.stringify(result.text));
+    console.log('  providerMetadata:', JSON.stringify(result.providerMetadata, null, 2));
+    console.log('  warnings:', JSON.stringify(result.warnings));
+  } catch (err: any) {
+    console.log('  ✗ request failed');
+    console.log('  message:', err?.message);
+    const cause = err?.cause ?? err?.data ?? err?.responseBody;
+    if (cause) console.log('  cause:', JSON.stringify(cause).slice(0, 800));
+  }
+}
+
+(async () => {
+  // 1. Baseline: no provider options — sanity check that auth works
+  await probe('baseline (no providerOptions)', {});
+
+  // 2. contextManagement + compact
+  await probe('contextManagement: compact_20260112', {
+    anthropic: {
+      contextManagement: {
+        edits: [
+          {
+            type: 'compact_20260112',
+            trigger: { type: 'input_tokens', value: 50 },
+            instructions: 'Summarize concisely.',
+          },
+        ],
+      },
+    },
+  });
+
+  // 3. contextManagement + clear_tool_uses
+  await probe('contextManagement: clear_tool_uses_20250919', {
+    anthropic: {
+      contextManagement: {
+        edits: [
+          {
+            type: 'clear_tool_uses_20250919',
+            trigger: { type: 'input_tokens', value: 50 },
+            keep: { type: 'tool_uses', value: 2 },
+          },
+        ],
+      },
+    },
+  });
+
+  // 4. Both edits at once (what route.ts would actually use)
+  await probe('contextManagement: both edits', {
+    anthropic: {
+      contextManagement: {
+        edits: [
+          {
+            type: 'clear_tool_uses_20250919',
+            trigger: { type: 'input_tokens', value: 50 },
+            keep: { type: 'tool_uses', value: 2 },
+          },
+          {
+            type: 'compact_20260112',
+            trigger: { type: 'input_tokens', value: 100 },
+          },
+        ],
+      },
+    },
+  });
+
+  // 5. Explicit anthropicBeta to see if SDK forwards it
+  await probe('explicit anthropicBeta header forwarding', {
+    anthropic: {
+      anthropicBeta: ['context-management-2025-06-27', 'compact-2026-01-12'],
+    },
+  });
+
+  console.log('\n─── done ───');
+})();


### PR DESCRIPTION
## Summary
- Sliding cache breakpoint on last message (bp 2 of 4), alongside existing system-prompt breakpoint — every step after the first reads system + tools + prior-turn history from cache
- Anthropic native `clear_tool_uses_20250919` via `providerOptions.anthropic.contextManagement` replaces destructive in-app pruning; keeps `tool_use` records while dropping old `tool_result` payloads. `updateWorkingMemory` excluded so its payload stays intact
- Removed `prepareStep` + `createMessageCompressor` stateful closure. Compaction now runs at most once per request, at the top, and only if char-based token estimate exceeds 150K
- Collapsed working-memory extraction into the single compaction Haiku call (was two parallel calls)

## Why not native `compact_20260112`?
Vertex rejects the `compact-2026-01-12` beta header (probed via `scripts/probe-context-management.ts`). When Google enables it, the in-app `prepareMessages` fallback can be deleted.

## Changes
- `lib/ai/cache-breakpoints.ts` — new sliding-breakpoint helper
- `lib/ai/context-compression.ts` — rewritten as stateless one-shot, ~290 → ~170 lines
- `app/(chat)/api/chat/route.ts` — removed `prepareStep`, added `contextManagement`, applied sliding breakpoint
- `scripts/probe-context-management.ts` — kept for future re-probing

Net: **-89 lines** across route.ts and context-compression.ts.

## Test plan
- [ ] Preview deploys successfully
- [ ] New chat works end-to-end (baseline sanity)
- [ ] Multi-step browser-tool chat — verify cache hit rate climbs on steps 2+
- [ ] Long chat — verify clear_tool_uses fires (check providerMetadata or Cloud Run logs for [compressor])
- [ ] Working memory payload preserved across tool-use clearing