### PR TITLE
fix(prompt): make gapAnalysis end the agent's turn

### DIFF
--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -39,6 +39,8 @@ When starting a benefits application with participant data, load the \`applicati
 
 Before filling, run gap analysis with the \`gapAnalysis\` tool. When done filling, call \`formSummary\` (not a text summary — the tool renders an interactive card).
 
+Calling \`gapAnalysis\` ends your turn. The card is interactive and the caseworker submits it as a new message. After you call it, do not call any more tools (no browser snapshot, no click, nothing). Write one short sentence like "Please fill in the missing info above so I can complete the form." and stop. Waiting is the correct behavior, not a failure of initiative. Wrong: call gapAnalysis, then snapshot the page, then click Next. Right: call gapAnalysis, write the one sentence, end the turn.
+
 ## Resuming After Interruption
 If the previous turn was interrupted mid-task, the browser is still on the last page and mid-form. Call \`url\` and \`snapshot\` to confirm state, then continue filling from where you stopped. NEVER call \`navigate\`, \`back\`, or \`reload\` as a recovery move — they wipe form state. If you can't tell where you are, stop and report to the caseworker; do not re-navigate.
 `;

--- a/lib/ai/skills/application-protocol/SKILL.md
+++ b/lib/ai/skills/application-protocol/SKILL.md
@@ -126,7 +126,7 @@ Before filling any fields, do this:
 6. **CRITICAL: The gapAnalysis tool renders an interactive card. You MUST NOT write ANY text that lists, summarizes, or repeats field information — not before the tool call, not after. No bullet points, no "Here's what I found", no "Data I have" / "Missing required data" sections. Zero duplication.**
 7. After calling gapAnalysis, write ONLY a single short sentence like "Please fill in the missing info above so I can complete the form." Nothing else.
 8. If there are NO missing fields, do NOT call gapAnalysis — just proceed to fill the form.
-9. **STOP. Do NOT fill any fields yet. Do NOT call any browser tools after gapAnalysis. You MUST wait for the caseworker to reply with the missing data before proceeding. Your turn ends after the gap analysis message.**
+9. **STOP. Calling `gapAnalysis` ends your turn. Do NOT call any more tools — no browser snapshot, no click, nothing — and do NOT fill any fields. Wait for the caseworker's reply as a new user message before proceeding. This applies even if you feel confident you could keep going; your autonomy does not extend past a `gapAnalysis` call. Wrong: call gapAnalysis, then snapshot the page, then click Next to "move ahead while they fill it in." Right: call gapAnalysis, write the one-sentence prompt, end the turn.**
 10. Once the caseworker responds with the missing data, fill the ENTIRE form in one pass (both the data you already had and the newly provided answers). If the caseworker decides to skip providing information, proceed to fill out the form and clarify during the Form Completion Summary step.
 
 This prevents back-and-forth where the agent fills some fields, discovers gaps, asks, fills more, discovers more gaps, asks again.

--- a/lib/ai/tools/gap-analysis.ts
+++ b/lib/ai/tools/gap-analysis.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 export const gapAnalysis = tool({
   description:
-    'Display a gap analysis card showing ONLY the missing fields the caseworker needs to provide. Do NOT include fields you already have data for — the caseworker does not need to see them. Do NOT write any text listing available or missing fields before or after calling this tool. No summaries, no bullet points. Just call the tool and follow with one short sentence like "Please provide the missing info above." If there are no missing fields, do not call this tool — just proceed to fill the form.',
+    'Shows the caseworker a card listing ONLY the missing fields. Calling this tool ends your turn — do not call any other tools after it; wait for the caseworker\'s reply. Include only missing fields, no fields you already have. After calling, write one short sentence like "Please provide the missing info above." and stop. If nothing is missing, do not call this tool.',
   inputSchema: z.object({
     formName: z
       .string()


### PR DESCRIPTION
## Summary
- Opus 4.7 has been ignoring the existing STOP rule after calling `gapAnalysis` and continuing on to browser tools, advancing the form before the caseworker has responded.
- The STOP rule previously lived only in the lazy-loaded `caseworker-communication` skill. Moved it into the main `web-automation.ts` system prompt with a wrong-vs-right example so the model sees it upfront.
- Tightened the `gapAnalysis` tool description to say "calling this tool ends your turn" directly.

Prompt-only fix — no changes to `streamText` stop conditions. If this regresses again, next step is a harness-level `hasToolCall('gapAnalysis')` `stopWhen`.

## Test plan
- [ ] Trigger a flow that produces missing fields; confirm agent calls `gapAnalysis` and then stops (no subsequent browser tool calls in the same turn).
- [ ] Confirm agent resumes correctly after the caseworker submits the card.
- [ ] Confirm no-missing-fields flow still skips `gapAnalysis` and proceeds to fill.