### PR TITLE
feat: enable Anthropic prompt caching on system prompt

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -32,7 +32,7 @@ import { createBrowserTool } from '@/lib/ai/tools/browser';
 import { gapAnalysis } from '@/lib/ai/tools/gap-analysis';
 import { formSummary } from '@/lib/ai/tools/form-summary';
 import { actionLabel } from '@/lib/ai/tools/action-label';
-import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
+import { getWebAutomationSystemPrompt, getCurrentDateString } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
 import { createMessageCompressor } from '@/lib/ai/context-compression';
@@ -178,8 +178,20 @@ export async function POST(request: Request) {
 
         const result = streamText({
           model: activeModel,
-          system: getWebAutomationSystemPrompt(),
-          messages: initialModelMessages,
+          messages: [
+            {
+              role: 'system',
+              content: getWebAutomationSystemPrompt(),
+              providerOptions: {
+                anthropic: { cacheControl: { type: 'ephemeral' } },
+              },
+            },
+            {
+              role: 'system',
+              content: getCurrentDateString(),
+            },
+            ...initialModelMessages,
+          ],
           tools: {
             ...apricotTools,
             gapAnalysis,

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -3,7 +3,7 @@ import { getSkillCatalog } from '../tools/load-skill';
 
 const skillCatalog = getSkillCatalog();
 
-function getCurrentDateString(): string {
+export function getCurrentDateString(): string {
   const now = new Date();
   const formatted = now.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
   const iso = now.toISOString().split('T')[0];
@@ -11,8 +11,6 @@ function getCurrentDateString(): string {
 }
 
 export const getWebAutomationSystemPrompt = () => `
-${getCurrentDateString()}
-
 You are an expert web automation specialist who intelligently does web searches, navigates websites, queries database information, and performs multi-step web automation tasks to help caseworkers apply for benefits for families seeking public support.
 
 ## Core Approach


### PR DESCRIPTION
## Summary
- Split the web-automation system prompt into a stable cached block + a daily-rotating date block.
- The stable body is sent as a `role: 'system'` message with `providerOptions.anthropic.cacheControl: { type: 'ephemeral' }` so subsequent turns hit Anthropic's prompt cache.
- The date string follows as a second uncached system message so cache hits survive across days.

Pattern follows the AI SDK cookbook: https://ai-sdk.dev/cookbook/node/dynamic-prompt-caching

## Test plan
- [ ] Deploy on parent repo's preview env and exercise a multi-turn chat.
- [ ] Confirm `cache_read_input_tokens` > 0 on the second turn in BigQuery (`nava-labs.anthropic_logging.request_response_logging`).
- [ ] Confirm `cache_creation_input_tokens` > 0 on the first turn.
- [ ] Confirm system-prompt behavior is unchanged (gapAnalysis flow, skill loading, action labels).