### PR TITLE
fix: changes for prompt for form summary

### DIFF
--- a/lib/ai/prompts/application-protocol.ts
+++ b/lib/ai/prompts/application-protocol.ts
@@ -138,7 +138,21 @@ Pass \`fields\`: a single array of every form field **in the order they appear o
 
 **Field order**: List fields in the order they appear on the original form. Do NOT reorder by source or by any other grouping.
 
-**Field types**: For every field — including \`missing\` fields — you MUST set \`inputType\` based on the actual form control you observed: \`"select"\` for dropdowns, \`"radio"\` for single-choice radio buttons (pick one), \`"checkbox"\` for multi-select checkboxes (pick many), \`"text"\` for plain text inputs (or omit for text). For \`"select"\`, \`"radio"\`, and \`"checkbox"\` fields you MUST also include the \`options\` array with all available choices you observed on the form. Set \`required: true\` on any field that is marked as required on the form (e.g. asterisk, "required" label, or validation that blocks submission). This applies even if you could not fill the field.
+**EXCLUDE these — they are NOT form fields and must NEVER appear in \`fields\`:**
+
+- CAPTCHA, reCAPTCHA, Turnstile, hCaptcha, "I'm not a robot", or any bot-challenge widget. These are handled automatically by the browser's auto-solver and are not fields the caseworker fills. Never list them as required, never list them as missing, never list them at all.
+- Submit / Apply / Continue / Next buttons.
+- Honeypot fields, hidden inputs, CSRF tokens.
+- Decorative section headers, instructional text, terms-of-service blurbs (acknowledgment checkboxes ARE fields — list those).
+
+**Field types**: For every field — including \`missing\` fields — you MUST set \`inputType\` based on the actual form control you observed: \`"select"\` for dropdowns, \`"radio"\` for single-choice radio buttons (pick one), \`"checkbox"\` for multi-select checkboxes (pick many), \`"text"\` for plain text inputs (or omit for text). Set \`required: true\` on any field that is marked as required on the form (e.g. asterisk, "required" label, or validation that blocks submission). This applies even if you could not fill the field.
+
+**Options + value matching for \`select\`, \`radio\`, and \`checkbox\` (CRITICAL — the card breaks without this):**
+
+1. You MUST include the \`options\` array with EVERY available choice you observed on the form, written EXACTLY as the form labels them. If the form shows "Yes" / "No", pass \`["Yes", "No"]\` — not \`["yes", "no"]\`, not \`["True", "False"]\`.
+2. The \`value\` you pass MUST be one of the strings in \`options\`, character-for-character. If \`options: ["Male", "Female", "Non-binary"]\` then \`value\` must be \`"Male"\`, \`"Female"\`, or \`"Non-binary"\` — not \`"M"\`, not \`"male"\`, not \`"Man"\`. Mismatches make the dropdown render empty and the caseworker can't see what was selected.
+3. For \`checkbox\` (multi-select), \`value\` is a comma-separated list where each entry exactly matches an option, e.g. \`"English, Spanish"\`.
+4. If you didn't capture the options from the form, re-snapshot the form to read them before calling \`formSummary\`. Do NOT guess, do NOT make up generic options like \`["Yes", "No"]\` if the actual options were different, and do NOT call \`formSummary\` with a select/radio/checkbox field missing its \`options\` array.
 
 After calling \`formSummary\`, write ONE short sentence like: "The form is filled out. Please review it and submit when you're ready."
 

--- a/lib/ai/prompts/browser-and-forms.ts
+++ b/lib/ai/prompts/browser-and-forms.ts
@@ -181,17 +181,23 @@ Re-snapshot to get fresh refs. If the snapshot shows \`[id="..."]\` on the targe
 
 ## Form Submission Protocol
 
-This protocol ONLY enables the submit button — it does NOT submit the form. Actually clicking submit is a Forbidden Action (see below). The goal is to unlock the button so the caseworker can review via \`formSummary\` and submit themselves.
+This protocol's only goal is to **enable** the submit button so the caseworker can review and click it themselves. It does NOT submit the form. Read this carefully — the distinction matters:
+
+- **Allowed**: inspecting the DOM (reading the \`disabled\` attribute, checking the Turnstile token field, reading gating JS variables), and as a last resort flipping the \`disabled\` attribute via \`evaluate\`.
+- **Forbidden**: clicking the submit button, calling \`.click()\` on it via \`evaluate\`, calling \`form.submit()\`, or dispatching submit events. See Forbidden Actions below.
+
+If the caseworker asks you to "enable the button" or "make submit clickable," that is NOT a request to submit — proceed. If they ask you to "submit," "send," or "click submit," refuse and hand off to \`formSummary\`.
 
 When the submit button is disabled, follow these steps IN ORDER. Do NOT use \`evaluate\` before completing steps 1–3.
 
 1. **Check for missing fields**: Snapshot and verify all required fields are filled.
 2. **Check for expand/acknowledge sections**: Look for collapsible sections ("+ Expand", "Please expand and read"). Click them using refs. If no ref available, use ONE evaluate: \`{ action: "evaluate", script: "document.querySelector('.header').click();" }\` then wait 700ms.
-3. **Wait for the auto-solver**: \`{ action: "wait", timeout: 5000 }\` then re-snapshot. The browser has a Turnstile/reCAPTCHA auto-solver — do NOT click challenge widgets.
+3. **Wait for the Turnstile/reCAPTCHA auto-solver**: The browser auto-solves these challenges — do NOT click challenge widgets. Auto-solving can take 10–30 seconds. Use \`{ action: "wait", timeout: 8000 }\`, re-snapshot, and check whether submit is now enabled. If still disabled, wait another 8000ms (up to ~30s total) before moving on. Most disabled-submit cases resolve here.
 4. **Verification checklist**: Fresh snapshot. Confirm: (a) all required fields filled, (b) expand sections open, (c) no error messages. Just observe — no corrective actions.
-5. **Still disabled?** Call \`readReference({ path: "form-submission.md" })\` for advanced JS debugging.
+5. **Diagnose before forcing**: If still disabled after ~30s of waiting, inspect the gate before flipping anything. Read the Turnstile token: \`{ action: "evaluate", script: "document.querySelector('[name=cf-turnstile-response]')?.value || 'EMPTY'" }\`. If the token is EMPTY, the auto-solver has not finished — **do not force-enable**. Report to the caseworker: "Submit is gated on Turnstile and the token is still empty. Please wait ~30s for it to auto-solve, then take control to submit." If the token is present but submit is still disabled, call \`readReference({ path: "form-submission.md" })\` for advanced JS debugging.
+6. **Force-enable as last resort only**: If diagnosis shows the gate is purely client-side JS (not a missing Turnstile token), follow the reference's Step 6 to satisfy the gating variables AND remove \`disabled\`. Just running \`document.getElementById('btnSubmit').disabled = false\` is insufficient — the page's JS may re-disable it, and if a server-side token is missing the submission will be rejected. **When you force-enable, explicitly tell the caseworker**: "I enabled the button in the DOM, but the Turnstile token is [present/empty]. If empty, the server may reject the submission — wait for the token to populate before submitting."
 
-After unlocking submit, do NOT click it. Proceed with \`formSummary\` so the caseworker can review.
+After the button is enabled, do NOT click it. Proceed with \`formSummary\` so the caseworker can review and submit.
 
 ## Forbidden Actions
 

--- a/lib/ai/prompts/browser-and-forms.ts
+++ b/lib/ai/prompts/browser-and-forms.ts
@@ -181,6 +181,8 @@ Re-snapshot to get fresh refs. If the snapshot shows \`[id="..."]\` on the targe
 
 ## Form Submission Protocol
 
+This protocol ONLY enables the submit button — it does NOT submit the form. Actually clicking submit is a Forbidden Action (see below). The goal is to unlock the button so the caseworker can review via \`formSummary\` and submit themselves.
+
 When the submit button is disabled, follow these steps IN ORDER. Do NOT use \`evaluate\` before completing steps 1–3.
 
 1. **Check for missing fields**: Snapshot and verify all required fields are filled.

--- a/lib/ai/tools/form-summary.ts
+++ b/lib/ai/tools/form-summary.ts
@@ -21,7 +21,9 @@ const fieldSchema = z.object({
   options: z
     .array(z.string())
     .optional()
-    .describe('Available choices for select, radio, or checkbox fields'),
+    .describe(
+      'REQUIRED for select/radio/checkbox fields. Every available choice exactly as the form labels it (e.g. ["Yes", "No"], ["Male", "Female", "Non-binary"]). The `value` you pass MUST match one of these strings character-for-character or the dropdown will render empty. Re-snapshot the form to read the real options — never guess.',
+    ),
   required: z
     .boolean()
     .optional()
@@ -36,7 +38,7 @@ const fieldSchema = z.object({
 
 export const formSummary = tool({
   description:
-    'Display a form summary card showing what was filled in and where each value came from. Call this INSTEAD of writing a summary message at the end of form completion. List fields in the order they appear on the original form. The card already displays all information — do NOT write any text listing the fields before or after calling this tool. Just call the tool, then follow with one short sentence like "Please review and submit when ready."',
+    'Display a form summary card showing what was filled in and where each value came from. Call this INSTEAD of writing a summary message at the end of form completion. List fields in the order they appear on the original form. NEVER include CAPTCHA, reCAPTCHA, Turnstile, "I\'m not a robot", or any bot-challenge widget — they are not form fields. Also exclude submit buttons, hidden inputs, and decorative text. The card already displays all information — do NOT write any text listing the fields before or after calling this tool. Just call the tool, then follow with one short sentence like "Please review and submit when ready."',
   inputSchema: z.object({
     formName: z
       .string()


### PR DESCRIPTION
## Checklist

- [ ] Update PR Title to follow this pattern: `[INTENT]:[MESSAGE]`
  > The title will become a one-line commit message in the git log, so be as concise and specific as possible -- refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/). Prepend [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) intent (`fix:`, `feat:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`).

## Ticket

Resolves #{TICKET NUMBER or URL or description} or Adds {new capability or feature}

## Changes

CAPTCHA exclusion — added explicit "EXCLUDE these" list in application-protocol.ts (CAPTCHA / reCAPTCHA / Turnstile / hCaptcha / "I'm not a robot", plus submit buttons, hidden inputs,         
  decorative text), and reinforced it in the formSummary tool's top-level description. The model sees this guidance both in the system prompt and again when the tool schema is loaded.
                                                                                                                                                                                                  
  Dropdown options + value matching — replaced the one-line "include the options array" rule with a 4-point CRITICAL block in application-protocol.ts that spells out:                            
  1. options must contain every choice exactly as the form labels it                                                                                                                            
  2. value must match one of the option strings character-for-character (this is what was breaking the rendered dropdown — the shadcn Select only displays a value when it matches a SelectItem)  
  3. Multi-select value is comma-separated with each entry matching an option                                                                                                                   
  4. Re-snapshot to read real options rather than guess                                                                                                                                           
                                                                                                                                                                                                  
  Also tightened the options field description in the tool schema itself to mirror this. Note: the prompt guidance is what the agent reads — the rendering bug at form-summary-card.tsx:122-135 is
   correct behavior given good inputs, so no component code change is needed.

## Testing

> What was tested? How did you test it? Add unit tests for new functions, integration tests for API/database interactions, and E2E tests for critical user flows.
> * https://martinfowler.com/articles/practical-test-pyramid.html
> * https://blog.logrocket.com/javascript-testing-best-practices/
> * https://www.testim.io/blog/typescript-unit-testing-101/

## Context for reviewers

> Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.
> Add comments to your code under the "Files Changed" tab to explain complex logic or code
> * https://betterprogramming.pub/how-to-make-a-perfect-pull-request-3578fb4c112 