### PR TITLE
feat: cherry-pick safe + card work from dev to main

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -30,6 +30,7 @@ import { after } from 'next/server';
 import { ChatSDKError } from '@/lib/errors';
 import { apricotTools } from '@/lib/ai/tools/apricot';
 import { createBrowserTool } from '@/lib/ai/tools/browser';
+import { createCheckSubmitGateTool } from '@/lib/ai/tools/check-submit-gate';
 import { gapAnalysis } from '@/lib/ai/tools/gap-analysis';
 import { formSummary } from '@/lib/ai/tools/form-summary';
 import { actionLabel } from '@/lib/ai/tools/action-label';
@@ -226,6 +227,7 @@ export async function POST(request: Request) {
             formSummary,
             actionLabel,
             browser: createBrowserTool(sessionId, session.user.id),
+            checkSubmitGate: createCheckSubmitGateTool(sessionId, session.user.id),
             loadSkill,
             readSkillFile,
           },

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -33,7 +33,7 @@ import { createBrowserTool } from '@/lib/ai/tools/browser';
 import { gapAnalysis } from '@/lib/ai/tools/gap-analysis';
 import { formSummary } from '@/lib/ai/tools/form-summary';
 import { actionLabel } from '@/lib/ai/tools/action-label';
-import { getWebAutomationSystemPrompt } from '@/lib/ai/prompts/web-automation';
+import { getWebAutomationSystemPrompt, getCurrentDateString } from '@/lib/ai/prompts/web-automation';
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
 import { createMessageCompressor, preCompactMessages } from '@/lib/ai/context-compression';
@@ -200,8 +200,20 @@ export async function POST(request: Request) {
 
         const result = streamText({
           model: activeModel,
-          system: getWebAutomationSystemPrompt(),
-          messages: preCompacted,
+          messages: [
+            {
+              role: 'system',
+              content: getWebAutomationSystemPrompt(),
+              providerOptions: {
+                anthropic: { cacheControl: { type: 'ephemeral' } },
+              },
+            },
+            {
+              role: 'system',
+              content: getCurrentDateString(),
+            },
+            ...preCompacted,
+          ],
           tools: {
             ...apricotTools,
             gapAnalysis,

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -37,6 +37,7 @@ import { getWebAutomationSystemPrompt, getCurrentDateString } from '@/lib/ai/pro
 import { loadSkill } from '@/lib/ai/tools/load-skill';
 import { readSkillFile } from '@/lib/ai/tools/read-skill-file';
 import { createMessageCompressor, preCompactMessages } from '@/lib/ai/context-compression';
+import { registerChatAbort, clearChatAbort } from '@/lib/chat-abort-registry';
 
 export const maxDuration = 300; // 5 minutes for web automation tasks
 
@@ -162,6 +163,11 @@ export async function POST(request: Request) {
     // sessionId includes both chatId and userId to ensure global uniqueness
     const sessionId = `${id}-${session.user.id}`;
 
+    // Cloud Run over HTTP/1.1 does not propagate client disconnects
+    // to request.signal, so this explicit channel is the only reliable
+    // way to abort an in-flight run from the browser via /api/chat/stop.
+    const chatAbort = registerChatAbort(id);
+
     const stream = createUIMessageStream({
       execute: async ({ writer: dataStream }) => {
         // Pre-compact messages loaded from DB if they exceed the context
@@ -223,8 +229,11 @@ export async function POST(request: Request) {
             loadSkill,
             readSkillFile,
           },
-          stopWhen: stepCountIs(500),
-          abortSignal: request.signal,
+          // Abort is checked at step boundaries via stopWhen — not
+          // passed as abortSignal. Mid-tool abort would leave a
+          // tool-call with no matching tool-result, triggering
+          // AI_MissingToolResultsError on the next turn.
+          stopWhen: [stepCountIs(500), () => chatAbort.signal.aborted],
           // Compress message history when token usage approaches the context
           // window limit (75% of 200K). First step has no prior usage data so
           // compression is skipped (correct — first step is always small).
@@ -280,6 +289,7 @@ export async function POST(request: Request) {
       },
       generateId: generateUUID,
       onFinish: async ({ messages }) => {
+        clearChatAbort(id, chatAbort);
         await saveNewMessages(messages);
       },
       onError: () => {

--- a/app/(chat)/api/chat/stop/route.ts
+++ b/app/(chat)/api/chat/stop/route.ts
@@ -1,0 +1,40 @@
+import { auth } from '@/app/(auth)/auth';
+import { abortChat } from '@/lib/chat-abort-registry';
+import { getChatById } from '@/lib/db/queries';
+import { ChatSDKError } from '@/lib/errors';
+
+/**
+ * Explicit cancellation endpoint.
+ *
+ * Cloud Run over HTTP/1.1 does not propagate client disconnects, so
+ * pressing Stop on the client can't rely on `request.signal` firing in
+ * the in-flight POST /api/chat request. The client instead hits this
+ * endpoint with the chatId to abort the registered AbortController.
+ */
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return new ChatSDKError('unauthorized:chat').toResponse();
+  }
+
+  let body: { chatId?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new ChatSDKError('bad_request:api').toResponse();
+  }
+
+  const chatId = body.chatId;
+  if (!chatId) {
+    return new ChatSDKError('bad_request:api').toResponse();
+  }
+
+  const chat = await getChatById({ id: chatId });
+  if (chat && chat.userId !== session.user.id) {
+    return new ChatSDKError('forbidden:chat').toResponse();
+  }
+
+  const aborted = abortChat(chatId);
+  console.log(`[chat-stop] chatId=${chatId} aborted=${aborted}`);
+  return Response.json({ aborted });
+}

--- a/components/ai-elements/context.tsx
+++ b/components/ai-elements/context.tsx
@@ -30,7 +30,7 @@ function getUsage({ modelId, usage }: {
   usage: { input?: number; output?: number; cacheReads?: number; reasoningTokens?: number };
 }): { costUSD?: { totalUSD: number } } {
   // Strip provider prefix (e.g. "anthropic:claude-sonnet-4-6" → "claude-sonnet-4-6")
-  const model = modelId.includes(':') ? modelId.split(':').pop()! : modelId;
+  const model = modelId.includes(':') ? (modelId.split(':').pop() ?? modelId) : modelId;
   const pricing = MODEL_PRICING[model];
   if (!pricing) return {};
 

--- a/components/ai-elements/form-card-shared.tsx
+++ b/components/ai-elements/form-card-shared.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronLeft, ChevronRight, CircleHelp, TriangleAlert, WandSparkles, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type CardShellProps = {
+  children: ReactNode;
+  variant: 'cta' | 'detail';
+  className?: string;
+};
+
+// Inline shell used in the chat thread. `cta` = pink/accent summary card,
+// `detail` = white card (used inside the modal or for non-CTA chat states
+// like "Information submitted" / "Skipped for now"). Modal expansion is
+// handled by the `Modal` component below.
+export function CardShell({ children, variant, className }: CardShellProps) {
+  const baseCls =
+    variant === 'cta'
+      ? 'relative rounded-2xl border overflow-hidden bg-[hsl(318_50%_97%)] border-[hsl(320_47%_85%)]'
+      : 'relative bg-white rounded-2xl border border-border overflow-hidden shadow-[0_1px_2px_rgba(16,24,40,0.04),0_1px_3px_rgba(16,24,40,0.04)]';
+  return <div className={cn(baseCls, className)}>{children}</div>;
+}
+
+type ModalProps = {
+  children: ReactNode;
+  onCollapse: () => void;
+};
+
+// Full-screen modal portaled to document.body so the overlay covers the
+// chat panel + the artifact pane. Backdrop click and ESC both call
+// onCollapse. The wrapper allows up to 90vh; children are typically a
+// CardShell sized to a fixed height (e.g. 70vh) with their own internal
+// scroll between a sticky header and footer.
+export function Modal({ children, onCollapse }: ModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCollapse();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onCollapse]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-[rgba(16,24,40,0.45)]"
+      onClick={onCollapse}
+    >
+      {/* biome-ignore lint/nursery/noStaticElementInteractions: stopPropagation keeps clicks inside the content wrapper from closing the modal */}
+      <div
+        className="w-full max-w-[640px] max-h-[90vh] overflow-y-auto rounded-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+type SectionHeaderProps = {
+  title: string;
+  eyebrow?: string;
+  onClose?: () => void;
+};
+
+export function SectionHeader({ title, eyebrow, onClose }: SectionHeaderProps) {
+  return (
+    <div className="px-5 pt-5 pb-3 border-b border-border flex items-start justify-between gap-4">
+      <div className="min-w-0">
+        {eyebrow && (
+          <div className="text-[12px] font-inter text-muted-foreground mb-1">{eyebrow}</div>
+        )}
+        {title && (
+          <h3 className="font-source-serif text-[22px] font-semibold text-foreground">
+            {title}
+          </h3>
+        )}
+      </div>
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="-mr-1 -mt-1 p-1.5 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted"
+        >
+          <X size={18} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+type ProgressDotsProps = {
+  ids: string[];
+  current: number;
+};
+
+// Pill-shaped active dot (w-6) and round inactive dots (w-2). Dots are
+// non-interactive in the modal footer; navigation happens via Back/Next.
+export function ProgressDots({ ids, current }: ProgressDotsProps) {
+  return (
+    <div className="flex items-center justify-center gap-1.5">
+      {ids.map((id, i) => (
+        <div
+          key={id}
+          aria-hidden="true"
+          className={cn(
+            'h-2 rounded-full transition-all',
+            i === current ? 'w-6 bg-primary' : 'w-2 bg-[hsl(220_13%_86%)]',
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
+type FieldSourceBadgeProps = {
+  source: 'database' | 'caseworker' | 'inferred' | 'missing';
+  required?: boolean;
+  inferredFrom?: string;
+};
+
+// Maps the four-value source enum to a design pill variant + a tooltip
+// explaining what the source means. The `database` label keeps the
+// Nava-specific "Apricot 360" wording.
+export function FieldSourceBadge({ source, required, inferredFrom }: FieldSourceBadgeProps) {
+  const baseCls =
+    'inline-flex items-center gap-1.5 text-[10px] font-medium uppercase font-mono leading-[1.5] px-1.5 py-1 rounded-[4px] border whitespace-nowrap cursor-default';
+
+  let label: string;
+  let toneCls: string;
+  let tooltip: string;
+  let Icon: typeof WandSparkles | null = null;
+
+  if (source === 'missing') {
+    if (required) {
+      label = 'Required';
+      toneCls = 'bg-red-50 text-red-700 border-red-100';
+      tooltip = 'Required to submit.';
+      Icon = TriangleAlert;
+    } else {
+      label = 'Optional';
+      toneCls = 'bg-stone-50 text-zinc-700 border-stone-200';
+      tooltip = 'Not required to submit.';
+      Icon = CircleHelp;
+    }
+  } else if (source === 'inferred') {
+    label = 'Auto-filled';
+    toneCls = 'bg-[#fff2fb] text-[#a11e83] border-[#f5e4f0]';
+    tooltip = inferredFrom ? `Filled by AI; based on ${inferredFrom}.` : 'Filled by AI.';
+    Icon = WandSparkles;
+  } else if (source === 'database') {
+    label = 'Apricot 360';
+    toneCls = 'bg-stone-50 text-stone-700 border-stone-200';
+    tooltip = 'Filled in automatically from Apricot 360.';
+  } else {
+    label = 'Manual';
+    toneCls = 'bg-stone-50 text-stone-700 border-stone-200';
+    tooltip = 'Entered by you.';
+  }
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={cn(baseCls, toneCls)}>
+            {Icon && <Icon size={12} aria-hidden="true" />}
+            {label}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent align="end">{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+type SectionFooterProps = {
+  current: number;
+  sectionIds: string[];
+  onPrev: () => void;
+  onNext: () => void;
+  isLast: boolean;
+  rightSlot?: ReactNode;
+};
+
+// Sticky bottom bar inside the detail modal: Back | dots | Next/right slot.
+// `rightSlot` renders on the last section (typically a Submit or Done
+// button). On non-last sections, Next is shown automatically.
+export function SectionFooter({ current, sectionIds, onPrev, onNext, isLast, rightSlot }: SectionFooterProps) {
+  return (
+    <div className="px-5 py-4 border-t border-border grid grid-cols-3 items-center gap-3 bg-white sticky bottom-0">
+      <button
+        type="button"
+        onClick={onPrev}
+        disabled={current === 0}
+        className="justify-self-start flex items-center gap-1.5 text-[14px] font-semibold px-4 py-2.5 rounded-full border border-border hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+      >
+        <ChevronLeft size={14} /> Back
+      </button>
+      <ProgressDots ids={sectionIds} current={current} />
+      <div className="justify-self-end flex items-center gap-2">
+        {isLast ? (
+          rightSlot
+        ) : (
+          <button
+            type="button"
+            onClick={onNext}
+            className="flex items-center gap-1.5 text-[14px] font-semibold px-5 py-2.5 rounded-full border border-border hover:bg-muted"
+          >
+            Next <ChevronRight size={14} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Filled circle with a white check inside, matching the design mockup.
+// Used in success-state CTAs alongside primary-colored copy.
+export function CheckCircleFilled({ size = 16, className }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" fill="currentColor" />
+      <path
+        d="m9 12 2 2 4-4"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}

--- a/components/ai-elements/form-summary-card.tsx
+++ b/components/ai-elements/form-summary-card.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-import { CheckIcon, PencilIcon, Sparkles, TriangleAlert, Info } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
+import { useMemo, useState, type ReactNode } from 'react';
+import { Info, MinusCircle } from 'lucide-react';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -14,128 +13,119 @@ import {
 } from '@/components/ui/select';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { ChatMessage } from '@/lib/types';
-
-type FieldWithSource = {
-  field: string;
-  value?: string;
-  source: 'database' | 'caseworker' | 'inferred' | 'missing';
-  inputType?: 'text' | 'select' | 'radio' | 'checkbox';
-  options?: string[];
-  required?: boolean;
-  inferredFrom?: string;
-};
+import type { ReviewField, ReviewSection } from '@/lib/types/form-cards';
+import {
+  CardShell,
+  CheckCircleFilled,
+  FieldSourceBadge,
+  Modal,
+  SectionFooter,
+  SectionHeader,
+} from './form-card-shared';
 
 interface FormSummaryCardProps {
   formName?: string;
-  fields: FieldWithSource[];
+  clientName?: string;
+  sections: ReviewSection[];
   sendMessage?: UseChatHelpers<ChatMessage>['sendMessage'];
-  isArtifactVisible?: boolean;
+  isReadonly?: boolean;
+  hasUserReplyAfter?: boolean;
   className?: string;
 }
 
-function AutofilledBadge({ inferredFrom }: { inferredFrom?: string }) {
-  const tooltip = inferredFrom
-    ? `Filled by AI; based on ${inferredFrom}.`
-    : 'Filled by AI.';
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="text-[10px] font-medium uppercase tracking-wide font-mono whitespace-nowrap inline-flex items-center gap-1 bg-pink-50 text-fuchsia-700 border border-pink-100 rounded px-2 py-0.5 cursor-default">
-            <Sparkles className="w-3 h-3 shrink-0" />
-            Auto-filled
-          </span>
-        </TooltipTrigger>
-        <TooltipContent align="end">{tooltip}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
-function SourceLabel({
-  label,
-  variant = 'default',
-  tooltip,
-}: {
-  label: string;
-  variant?: 'default' | 'missing';
-  tooltip?: string;
-}) {
-  if (variant === 'missing' && label === 'Required') {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="text-[10px] font-medium uppercase tracking-wide font-mono whitespace-nowrap inline-flex items-center gap-1 bg-red-50 text-red-700 border border-red-200 rounded px-2 py-0.5 cursor-default">
-              <TriangleAlert className="w-3 h-3 shrink-0" />
-              {label}
-            </span>
-          </TooltipTrigger>
-          {tooltip && <TooltipContent align="end">{tooltip}</TooltipContent>}
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
-  if (label === 'Optional') {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="text-[10px] font-medium uppercase tracking-wide font-mono whitespace-nowrap inline-flex items-center gap-1 bg-stone-50 text-zinc-700 border border-stone-200 rounded px-2 py-0.5 cursor-default">
-              <Info className="w-3 h-3 shrink-0" />
-              {label}
-            </span>
-          </TooltipTrigger>
-          {tooltip && <TooltipContent align="end">{tooltip}</TooltipContent>}
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="text-[10px] font-medium uppercase tracking-wide font-mono whitespace-nowrap inline-flex items-center gap-1 bg-stone-50 text-zinc-700 border border-stone-200 rounded px-2 py-0.5 cursor-default">
-            {label}
-          </span>
-        </TooltipTrigger>
-        {tooltip && <TooltipContent align="end">{tooltip}</TooltipContent>}
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
+type ModalView = null | 'detail' | 'readonly';
 
 export function FormSummaryCard({
   formName,
-  fields,
+  clientName,
+  sections,
   sendMessage,
-  isArtifactVisible = true,
+  isReadonly = false,
+  hasUserReplyAfter = false,
   className,
 }: FormSummaryCardProps) {
-  const [uiMode, setUiMode] = useState<'view' | 'edit' | 'confirmed'>('view');
-  const [savedValues, setSavedValues] = useState<Record<string, string>>({});
   const [editValues, setEditValues] = useState<Record<string, string>>({});
+  const [confirmed, setConfirmed] = useState(hasUserReplyAfter);
+  const [skipped, setSkipped] = useState(false);
+  const [modalView, setModalView] = useState<ModalView>(null);
+  const [current, setCurrent] = useState(0);
 
-  const allFields: FieldWithSource[] = fields;
+  const hasIssues = useMemo(
+    () => sections.some((s) => s.fields.some((f) => f.source === 'missing' && f.required)),
+    [sections],
+  );
+  const hasData = sections.some((s) => s.fields.some((f) => f.value));
+  const interactionDisabled = isReadonly;
 
-  function renderEditInput(item: FieldWithSource) {
-    const currentValue = editValues[item.field] ?? getDisplayValue(item);
-    const onChange = (val: string) =>
-      setEditValues((prev) => ({ ...prev, [item.field]: val }));
+  function setEdit(name: string, value: string) {
+    setEditValues((prev) => ({ ...prev, [name]: value }));
+  }
 
-    switch (item.inputType) {
+  function valueFor(field: ReviewField) {
+    return editValues[field.field] ?? field.value ?? '';
+  }
+
+  function openDetail() {
+    setCurrent(0);
+    setModalView('detail');
+  }
+
+  function openReadonly() {
+    setCurrent(0);
+    setModalView('readonly');
+  }
+
+  function closeModal() {
+    setModalView(null);
+  }
+
+  function handleSkip() {
+    setSkipped(true);
+  }
+
+  function handleConfirm() {
+    if (sendMessage) {
+      const changes: string[] = [];
+      for (const section of sections) {
+        for (const field of section.fields) {
+          const next = editValues[field.field];
+          if (next !== undefined && next !== (field.value ?? '') && next.trim() !== '') {
+            changes.push(`- ${field.field}: ${next}`);
+          }
+        }
+      }
+      const formContext = formName ? ` for ${formName}` : '';
+      const text =
+        changes.length > 0
+          ? `Please update the following form fields${formContext}:\n${changes.join('\n')}\n\nOnce updated, please ask the user to click the "Take control" button to take control and submit the form.`
+          : `The form${formContext} looks good. The form is complete, please ask the user to click the "Take control" button to take control and submit the form.`;
+      sendMessage({ role: 'user', parts: [{ type: 'text', text }] });
+    }
+    setConfirmed(true);
+    closeModal();
+  }
+
+  function renderEditableField(field: ReviewField) {
+    const value = valueFor(field);
+    const onChange = (v: string) => setEdit(field.field, v);
+    const isMissingRequired = field.source === 'missing' && field.required;
+    const inputClass = cn(
+      'mt-1 h-9 text-sm bg-background',
+      isMissingRequired && !value && 'border-[hsl(6_65%_60%)] bg-[hsl(6_80%_98%)]',
+    );
+
+    switch (field.inputType) {
       case 'select':
         return (
-          <Select value={currentValue} onValueChange={onChange}>
-            <SelectTrigger className="mt-1 h-8 text-sm bg-background">
-              <SelectValue placeholder="Select…" />
+          <Select value={value} onValueChange={onChange}>
+            <SelectTrigger className={inputClass}>
+              <SelectValue placeholder={isMissingRequired ? 'Required — select an option' : 'Select…'} />
             </SelectTrigger>
             <SelectContent>
-              {(item.options ?? []).map((opt) => (
+              {(field.options ?? []).map((opt) => (
                 <SelectItem key={opt} value={opt}>
                   {opt}
                 </SelectItem>
@@ -143,27 +133,21 @@ export function FormSummaryCard({
             </SelectContent>
           </Select>
         );
-
       case 'radio':
         return (
-          <RadioGroup
-            value={currentValue}
-            onValueChange={onChange}
-            className="mt-2 flex flex-col gap-1.5"
-          >
-            {(item.options ?? []).map((opt) => (
+          <RadioGroup value={value} onValueChange={onChange} className="mt-2 flex flex-col gap-1.5">
+            {(field.options ?? []).map((opt) => (
               <div key={opt} className="flex items-center gap-2">
-                <RadioGroupItem value={opt} id={`${item.field}-${opt}`} />
-                <Label htmlFor={`${item.field}-${opt}`} className="text-sm font-normal">
+                <RadioGroupItem value={opt} id={`${field.field}-${opt}`} />
+                <Label htmlFor={`${field.field}-${opt}`} className="text-sm font-normal cursor-pointer">
                   {opt}
                 </Label>
               </div>
             ))}
           </RadioGroup>
         );
-
       case 'checkbox': {
-        const selected = currentValue ? currentValue.split(',').map((s) => s.trim()) : [];
+        const selected = value ? value.split(',').map((s) => s.trim()) : [];
         const toggle = (opt: string) => {
           const next = selected.includes(opt)
             ? selected.filter((s) => s !== opt)
@@ -172,17 +156,14 @@ export function FormSummaryCard({
         };
         return (
           <div className="mt-2 flex flex-col gap-1.5">
-            <p className="text-sm text-neutral-900 font-source-serif">
-              Select all that apply.
-            </p>
-            {(item.options ?? []).map((opt) => (
+            {(field.options ?? []).map((opt) => (
               <div key={opt} className="flex items-center gap-2">
                 <Checkbox
-                  id={`${item.field}-${opt}`}
+                  id={`${field.field}-${opt}`}
                   checked={selected.includes(opt)}
                   onCheckedChange={() => toggle(opt)}
                 />
-                <Label htmlFor={`${item.field}-${opt}`} className="text-sm font-normal">
+                <Label htmlFor={`${field.field}-${opt}`} className="text-sm font-normal cursor-pointer">
                   {opt}
                 </Label>
               </div>
@@ -190,177 +171,209 @@ export function FormSummaryCard({
           </div>
         );
       }
-
       default:
         return (
           <Input
-            value={currentValue}
+            value={value}
             onChange={(e) => onChange(e.target.value)}
-            className="mt-1 h-8 text-sm bg-background"
+            placeholder={isMissingRequired ? 'Required — enter a value' : ''}
+            className={inputClass}
           />
         );
     }
   }
 
-  function getDisplayValue(item: FieldWithSource) {
-    return savedValues[item.field] ?? item.value ?? '';
+  function renderRow(field: ReviewField, readOnly: boolean) {
+    const value = valueFor(field);
+    const isMissingRequired = field.source === 'missing' && field.required;
+    return (
+      <div key={field.field} className="px-5 py-2">
+        <div className="flex items-center justify-between gap-3 mb-2">
+          <span className="font-source-serif text-[15px] font-semibold text-foreground">
+            {field.field}
+            {field.required && <span className="text-red-700 ml-0.5">*</span>}
+          </span>
+          <FieldSourceBadge
+            source={field.source}
+            required={field.required}
+            inferredFrom={field.inferredFrom}
+          />
+        </div>
+        {readOnly ? (
+          <div className="text-[14px] font-inter text-muted-foreground">
+            {value ? value : <span className={cn('italic', isMissingRequired ? 'text-red-700 not-italic' : '')}>Not provided</span>}
+          </div>
+        ) : (
+          renderEditableField(field)
+        )}
+      </div>
+    );
   }
 
-  function isManuallyEdited(item: FieldWithSource) {
-    if (uiMode === 'edit') {
-      return editValues[item.field] !== undefined && editValues[item.field] !== item.value;
-    }
-    return savedValues[item.field] !== undefined && savedValues[item.field] !== item.value;
+  // ── Inline chat card ──────────────────────────────────────────────────────
+  let chatCard: ReactNode;
+  if (confirmed) {
+    chatCard = (
+      <CardShell variant="detail" className={className}>
+        <div className="p-5">
+          <div className="font-source-serif text-[14px]">
+            <div className="flex items-center gap-2 mb-3">
+              <CheckCircleFilled size={16} className="text-primary flex-shrink-0" />
+              <p className="font-bold">Review complete</p>
+            </div>
+            <p className="mb-4">
+              You&rsquo;ve reviewed {clientName ?? 'the'}&rsquo;s application. It&rsquo;s ready to submit.
+            </p>
+          </div>
+          {hasData && (
+            <button
+              type="button"
+              onClick={() => openReadonly()}
+              className="border border-border text-sm font-medium px-4 py-2 rounded-md hover:bg-muted"
+            >
+              View responses
+            </button>
+          )}
+        </div>
+      </CardShell>
+    );
+  } else if (skipped) {
+    chatCard = (
+      <CardShell variant="detail" className={className}>
+        <div className="p-5">
+          <div className="font-source-serif text-[14px]">
+            <div className="flex items-center gap-2 mb-3">
+              <MinusCircle size={14} className="text-muted-foreground flex-shrink-0" />
+              <p className="font-bold">Review skipped</p>
+            </div>
+            <p className="mb-4">
+              You can come back to review {clientName ? `${clientName}'s ` : ''}application before submitting.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => { setSkipped(false); openDetail(); }}
+            disabled={interactionDisabled || sections.length === 0}
+            className="bg-primary text-white text-sm font-medium px-4 py-2 rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Start review
+          </button>
+        </div>
+      </CardShell>
+    );
+  } else if (interactionDisabled && hasData) {
+    // Read-only chat (replay) but data exists → read-only access only.
+    chatCard = (
+      <CardShell variant="detail" className={className}>
+        <div className="p-5">
+          <div className="font-source-serif text-[14px]">
+            <div className="flex items-center gap-2 mb-2">
+              <Info size={14} className="text-primary flex-shrink-0" />
+              <p className="font-bold">{hasIssues ? 'Ready to review' : 'Ready to submit'}</p>
+            </div>
+            <p className="mb-4">
+              Confirm each field is accurate before submitting. You&rsquo;ll see how each one was filled.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => openReadonly()}
+            className="border border-border text-sm font-medium px-4 py-2 rounded-md hover:bg-muted"
+          >
+            View responses
+          </button>
+        </div>
+      </CardShell>
+    );
+  } else {
+    chatCard = (
+      <CardShell variant="cta" className={className}>
+        <div className="p-5">
+          <div className="flex items-center gap-2 mb-2">
+            <Info size={14} className="text-primary flex-shrink-0" />
+            <p className="font-source-serif text-[14px] font-bold">
+              {hasIssues ? 'Ready to review' : 'Ready to submit'}
+            </p>
+          </div>
+          <p className="font-source-serif text-[14px] mb-4">
+            Confirm each field is accurate before submitting. You&rsquo;ll see how each one was filled.
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => openDetail()}
+              disabled={interactionDisabled || sections.length === 0}
+              className="bg-primary text-white text-sm font-medium px-4 py-2 rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {hasIssues ? 'Start review' : 'Review & submit'}
+            </button>
+            <button
+              type="button"
+              onClick={handleSkip}
+              disabled={interactionDisabled}
+              className="bg-white text-sm font-medium px-4 py-2 rounded-md hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Skip for now
+            </button>
+          </div>
+        </div>
+      </CardShell>
+    );
   }
 
-  function handleEditStart() {
-    const initial: Record<string, string> = {};
-    for (const item of allFields) {
-      initial[item.field] = getDisplayValue(item);
-    }
-    setEditValues(initial);
-    setUiMode('edit');
-  }
+  // ── Modal content ─────────────────────────────────────────────────────────
+  let modalContent: ReactNode = null;
+  if (modalView && sections.length > 0) {
+    const section = sections[current];
+    const isLast = current === sections.length - 1;
+    const sectionIds = sections.map((s) => s.id);
+    const baseEyebrow = `Page ${current + 1} of ${sections.length}`;
+    const eyebrow = modalView === 'readonly' ? `${baseEyebrow} · Read only` : baseEyebrow;
 
-  const hasChanges = allFields.some(
-    (item) => editValues[item.field] !== undefined && editValues[item.field] !== getDisplayValue(item),
-  );
+    const rightSlot =
+      modalView === 'readonly' ? (
+        <button
+          type="button"
+          onClick={closeModal}
+          className="text-[14px] font-semibold px-5 py-2.5 rounded-full border border-border hover:bg-muted"
+        >
+          Done
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={handleConfirm}
+          className="text-[14px] font-semibold px-5 py-2.5 rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
+        >
+          Update and continue
+        </button>
+      );
 
-  function handleCancel() {
-    setEditValues({});
-    setUiMode('view');
-  }
-
-  function handleConfirm() {
-    const resolvedValues = { ...savedValues, ...editValues };
-    setSavedValues(resolvedValues);
-
-    if (sendMessage) {
-      const changes: string[] = [];
-      for (const item of allFields) {
-        const currentValue = resolvedValues[item.field] ?? item.value;
-        if (currentValue !== item.value && currentValue.trim() !== '') {
-          changes.push(`- ${item.field}: ${currentValue}`);
-        }
-      }
-
-      const formContext = formName ? ` for ${formName}` : '';
-
-      if (changes.length > 0) {
-        sendMessage({
-          role: 'user',
-          parts: [
-            {
-              type: 'text',
-              text: `Please update the following form fields${formContext}:\n${changes.join('\n')}\n\nOnce updated, please ask the user to click the "Take control" button to take control and submit the form.`,
-            },
-          ],
-        });
-      } else {
-        sendMessage({
-          role: 'user',
-          parts: [
-            {
-              type: 'text',
-              text: `The form${formContext} looks good. The form is complete, please ask the user to click the "Take control" button to take control and submit the form.`,
-            },
-          ],
-        });
-      }
-    }
-
-    setUiMode('confirmed');
+    modalContent = (
+      <CardShell variant="detail" className="h-[70vh] flex flex-col">
+        <SectionHeader title={section.title || formName || 'Review'} eyebrow={eyebrow} onClose={closeModal} />
+        <div className="flex-1 overflow-y-auto py-3">
+          {section.fields.map((f) => renderRow(f, modalView === 'readonly'))}
+          {section.fields.length === 0 && (
+            <p className="px-5 py-6 text-sm text-muted-foreground">No fields in this section.</p>
+          )}
+        </div>
+        <SectionFooter
+          current={current}
+          sectionIds={sectionIds}
+          onPrev={() => (current === 0 ? closeModal() : setCurrent((c) => Math.max(0, c - 1)))}
+          onNext={() => setCurrent((c) => Math.min(sections.length - 1, c + 1))}
+          isLast={isLast}
+          rightSlot={rightSlot}
+        />
+      </CardShell>
+    );
   }
 
   return (
-    <div
-      className={cn(
-        'rounded-lg border shadow-none bg-background overflow-hidden flex flex-col font-inter',
-        uiMode === 'edit' ? 'border-accent' : 'border-border',
-        className,
-      )}
-    >
-      
-    <div className="px-6 pt-5 pb-3 border-b border-border">
-      <p className="text-base font-bold text-foreground font-source-serif">Review and confirm</p>
-      <p className="text-sm text-neutral-900 font-source-serif">Verify the details before submitting. Required fields are marked with an asterisk (<span className="text-red-700">*</span>).</p>
-    </div>
-
-      <div>
-        <div className="px-6">
-          {allFields.map((item, i) => (
-            <div key={i} className="py-4 border-b border-border last:border-b-0">
-              <div className="flex items-center justify-between gap-4 mb-1">
-                <span className="text-sm font-bold text-card-foreground leading-snug font-source-serif">
-                  {item.field}
-                  {item.required && <span className="text-red-700 ml-0.5">*</span>}
-                </span>
-                {isManuallyEdited(item) ? (
-                  <SourceLabel label="Manual" tooltip="Entered by you." />
-                ) : item.source === 'missing' && item.required ? (
-                  <SourceLabel label="Required" variant="missing" tooltip="Required to submit." />
-                ) : item.source === 'missing' && !item.required ? (
-                  <SourceLabel label="Optional" tooltip="Not required to submit." />
-                ) : item.source === 'inferred' ? (
-                  <AutofilledBadge inferredFrom={item.inferredFrom} />
-                ) : (
-                  <SourceLabel
-                    label={item.source === 'database' ? 'Apricot 360' : 'Manual'}
-                    tooltip={item.source === 'database' ? 'Filled in automatically from Apricot 360.' : 'Entered by you.'}
-                  />
-                )}
-              </div>
-
-              {uiMode === 'edit' ? (
-                renderEditInput(item)
-              ) : (
-                getDisplayValue(item) ? (
-                  <p className="text-sm text-foreground font-inter">{getDisplayValue(item)}</p>
-                ) : (
-                  <p className={cn('text-sm font-inter', item.required ? 'text-red-700' : 'text-neutral-900')}>Not provided</p>
-                )
-              )}
-            </div>
-          ))}
-
-          {allFields.length === 0 && (
-            <p className="py-6 text-sm text-muted-foreground">No fields to display.</p>
-          )}
-        </div>
-      </div>
-
-      <div className="px-6 py-4 border-t border-border flex flex-col gap-2">
-        {uiMode === 'edit' ? (
-          <>
-            <Button size="sm" className="w-full" onClick={handleConfirm} disabled={!isArtifactVisible}>
-              <CheckIcon className="w-3 h-3 mr-1.5" />
-              Update and continue
-            </Button>
-            <Button variant="outline" size="sm" className="w-full" onClick={handleCancel} disabled={!isArtifactVisible}>
-              Discard changes
-            </Button>
-          </>
-        ) : (
-          <>
-            <Button
-              className="w-full"
-              onClick={handleEditStart}
-              disabled={uiMode === 'confirmed' || !isArtifactVisible}
-            >
-              <PencilIcon className="w-3 h-3 mr-1.5" />
-              Edit responses
-            </Button>
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={handleConfirm}
-              disabled={uiMode === 'confirmed' || !isArtifactVisible}
-            >
-              Confirm
-            </Button>
-          </>
-        )}
-      </div>
-    </div>
+    <>
+      {chatCard}
+      {modalView && modalContent && <Modal onCollapse={closeModal}>{modalContent}</Modal>}
+    </>
   );
 }

--- a/components/ai-elements/gap-analysis-card.tsx
+++ b/components/ai-elements/gap-analysis-card.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Check } from 'lucide-react';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
+import { AlertTriangle, MinusCircle } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -16,40 +14,54 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { cn } from '@/lib/utils';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { ChatMessage } from '@/lib/types';
-
-interface MissingField {
-  field: string;
-  options?: string[];
-  inputType?: string;
-  multiSelect?: boolean;
-  condition?: string;
-}
+import type { GapField, GapSection } from '@/lib/types/form-cards';
+import {
+  CardShell,
+  CheckCircleFilled,
+  Modal,
+  SectionFooter,
+  SectionHeader,
+} from './form-card-shared';
 
 interface GapAnalysisCardProps {
   formName?: string;
-  missingFields: MissingField[];
+  clientName?: string;
+  sections: GapSection[];
   sendMessage?: UseChatHelpers<ChatMessage>['sendMessage'];
   isSubmitted?: boolean;
   isSkipped?: boolean;
+  isReadonly?: boolean;
+  hasUserReplyAfter?: boolean;
   className?: string;
 }
 
+type ModalView = null | 'detail' | 'readonly';
+
 export function GapAnalysisCard({
   formName,
-  missingFields,
+  clientName,
+  sections,
   sendMessage,
-  isSubmitted: initialSubmitted = false,
-  isSkipped: initialSkipped = false,
+  isSubmitted = false,
+  isSkipped = false,
+  isReadonly = false,
+  hasUserReplyAfter = false,
   className,
 }: GapAnalysisCardProps) {
+  const assumeSubmitted = hasUserReplyAfter;
   const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
-  const [submitted, setSubmitted] = useState(initialSubmitted);
-  const [skipped, setSkipped] = useState(initialSkipped);
+  const [submitted, setSubmitted] = useState(isSubmitted || assumeSubmitted);
+  const [skipped, setSkipped] = useState(isSkipped);
+  const [modalView, setModalView] = useState<ModalView>(null);
+  const [current, setCurrent] = useState(0);
 
-  const disabled = submitted || skipped;
+  const firstName = clientName?.split(' ')[0];
+
+  // Replays / read-only chats lock the inline buttons. Submitted state
+  // still allows opening the read-only "View responses" modal.
+  const interactionDisabled = isReadonly;
 
   function updateAnswer(field: string, value: string | string[]) {
     setAnswers((prev) => ({ ...prev, [field]: value }));
@@ -57,20 +69,30 @@ export function GapAnalysisCard({
 
   function toggleCheckbox(field: string, option: string, checked: boolean) {
     setAnswers((prev) => {
-      const current = (prev[field] as string[]) ?? [];
+      const cur = (prev[field] as string[]) ?? [];
       return {
         ...prev,
-        [field]: checked
-          ? [...current, option]
-          : current.filter((v) => v !== option),
+        [field]: checked ? [...cur, option] : cur.filter((v) => v !== option),
       };
     });
   }
 
+  function openDetail(at = 0) {
+    setCurrent(at);
+    setModalView('detail');
+  }
+
+  function openReadonly(at = 0) {
+    setCurrent(at);
+    setModalView('readonly');
+  }
+
+  function closeModal() {
+    setModalView(null);
+  }
+
   function handleSkip() {
     if (!sendMessage) return;
-
-    const name = formName || 'gap analysis';
     sendMessage({
       role: 'user',
       parts: [
@@ -85,61 +107,52 @@ export function GapAnalysisCard({
 
   function handleSubmit() {
     if (!sendMessage) return;
-
     const lines: string[] = [];
-    if (formName) {
-      lines.push(`Answers for ${formName}:`);
-    } else {
-      lines.push('Answers for gap analysis:');
-    }
-
-    for (const field of missingFields) {
-      const answer = answers[field.field];
-      if (answer !== undefined && answer !== '') {
+    lines.push(formName ? `Answers for ${formName}:` : 'Answers for gap analysis:');
+    for (const section of sections) {
+      for (const field of section.fields) {
+        const answer = answers[field.field];
+        if (answer === undefined || answer === '') continue;
         const value = Array.isArray(answer) ? answer.join(', ') : answer;
-        if (value) {
-          const separator = field.field.endsWith('?') ? '' : ':';
-          lines.push(`- ${field.field}${separator} ${value}`);
-        }
+        if (!value) continue;
+        const separator = field.field.endsWith('?') ? '' : ':';
+        lines.push(`- ${field.field}${separator} ${value}`);
       }
     }
-
     if (lines.length <= 1) return;
-
-    sendMessage({
-      role: 'user',
-      parts: [{ type: 'text', text: lines.join('\n') }],
-    });
+    sendMessage({ role: 'user', parts: [{ type: 'text', text: lines.join('\n') }] });
     setSubmitted(true);
+    closeModal();
   }
 
-  function renderField(field: MissingField) {
-    const { field: name, options, inputType, multiSelect, condition } = field;
+  function renderEditableField(field: GapField) {
+    const { field: name, options, inputType, multiSelect, condition, note, placeholder, required } = field;
+    const helperText = note ?? condition;
 
-    // multiSelect with options → checkbox group
+    const fieldLabel = (
+      <div className="mb-2">
+        <span className="font-source-serif text-[15px] font-semibold">{name}</span>
+        {required && <span className="text-red-700 ml-0.5">*</span>}
+        {helperText && (
+          <div className="text-[13px] text-muted-foreground mt-0.5 font-inter">{helperText}</div>
+        )}
+      </div>
+    );
+
     if (multiSelect && options && options.length > 0) {
       const selected = (answers[name] as string[]) ?? [];
       return (
-        <fieldset key={name} className="space-y-3">
-          <Label className="text-sm font-bold font-source-serif">{name}</Label>
-          <p className="text-sm text-neutral-900 font-source-serif">
-            {condition || 'Select all that apply.'}
-          </p>
-          <div className="flex flex-col gap-3">
+        <fieldset>
+          {fieldLabel}
+          <div className="flex flex-col gap-2">
             {options.map((option) => (
               <div key={option} className="flex items-center gap-2">
                 <Checkbox
                   id={`${name}-${option}`}
                   checked={selected.includes(option)}
-                  onCheckedChange={(checked) =>
-                    toggleCheckbox(name, option, !!checked)
-                  }
-                  disabled={disabled}
+                  onCheckedChange={(checked) => toggleCheckbox(name, option, !!checked)}
                 />
-                <Label
-                  htmlFor={`${name}-${option}`}
-                  className="text-sm font-normal cursor-pointer"
-                >
+                <Label htmlFor={`${name}-${option}`} className="text-sm font-normal cursor-pointer">
                   {option}
                 </Label>
               </div>
@@ -148,19 +161,14 @@ export function GapAnalysisCard({
         </fieldset>
       );
     }
-
-    // boolean → radio Yes/No
     if (inputType === 'boolean') {
       return (
-        <div key={name} className="space-y-2">
-          <Label className="text-sm font-bold font-source-serif">{name}</Label>
-          {condition && (
-            <p className="text-sm text-neutral-900 font-source-serif">{condition}</p>
-          )}
+        <div>
+          {fieldLabel}
           <RadioGroup
             value={(answers[name] as string) ?? ''}
             onValueChange={(value) => updateAnswer(name, value)}
-            disabled={disabled}
+            className="flex items-center gap-5"
           >
             <div className="flex items-center gap-2">
               <RadioGroupItem value="Yes" id={`${name}-yes`} />
@@ -178,22 +186,16 @@ export function GapAnalysisCard({
         </div>
       );
     }
-
-    // select (single) with options → dropdown
     if (inputType === 'select' && options && options.length > 0) {
       return (
-        <div key={name} className="space-y-2">
-          <Label className="text-sm font-bold font-source-serif">{name}</Label>
-          {condition && (
-            <p className="text-sm text-neutral-900 font-source-serif">{condition}</p>
-          )}
+        <div>
+          {fieldLabel}
           <Select
             value={(answers[name] as string) ?? ''}
             onValueChange={(value) => updateAnswer(name, value)}
-            disabled={disabled}
           >
             <SelectTrigger>
-              <SelectValue placeholder="Select an option" />
+              <SelectValue placeholder={placeholder ?? 'Select an option'} />
             </SelectTrigger>
             <SelectContent>
               {options.map((option) => (
@@ -206,126 +208,198 @@ export function GapAnalysisCard({
         </div>
       );
     }
-
-    // textarea
     if (inputType === 'textarea') {
       return (
-        <div key={name} className="space-y-2">
-          <Label className="text-sm font-bold font-source-serif">{name}</Label>
-          {condition && (
-            <p className="text-sm text-neutral-900 font-source-serif">{condition}</p>
-          )}
+        <div>
+          {fieldLabel}
           <Textarea
             value={(answers[name] as string) ?? ''}
             onChange={(e) => updateAnswer(name, e.target.value)}
-            placeholder={`Enter ${name.toLowerCase()}`}
-            disabled={disabled}
+            placeholder={placeholder ?? `Enter ${name.toLowerCase()}`}
           />
         </div>
       );
     }
-
-    // date
     if (inputType === 'date') {
       return (
-        <div key={name} className="space-y-2">
-          <Label className="text-sm font-bold font-source-serif">{name}</Label>
-          {condition && (
-            <p className="text-sm text-neutral-900 font-source-serif">{condition}</p>
-          )}
+        <div>
+          {fieldLabel}
           <Input
             type="date"
             value={(answers[name] as string) ?? ''}
             onChange={(e) => updateAnswer(name, e.target.value)}
-            disabled={disabled}
           />
         </div>
       );
     }
-
-    // text / default → text input
     return (
-      <div key={name} className="space-y-2">
-        <Label className="text-sm font-bold font-source-serif">{name}</Label>
-        {condition && (
-          <p className="text-sm text-neutral-900 font-source-serif">{condition}</p>
-        )}
+      <div>
+        {fieldLabel}
         <Input
           type="text"
           value={(answers[name] as string) ?? ''}
           onChange={(e) => updateAnswer(name, e.target.value)}
-          placeholder={`Enter ${name.toLowerCase()}`}
-          disabled={disabled}
+          placeholder={placeholder ?? `Enter ${name.toLowerCase()}`}
         />
       </div>
     );
   }
 
-  if (skipped) {
+  function renderReadonlyAnswer(field: GapField) {
+    const value = answers[field.field];
+    const display = Array.isArray(value) ? value.join(', ') : value;
     return (
-      <Alert
-        className={cn(
-          'rounded-lg border-accent shadow-none bg-background p-6 font-inter',
-          className,
-        )}
-      >
-        <AlertDescription>
-          <p className="font-source-serif text-base text-muted-foreground">
-            {formName || 'Gap Analysis'}
+      <div key={field.field} className="px-5 py-2">
+        <div className="font-source-serif text-[15px] font-semibold mb-1">{field.field}</div>
+        <div className="text-[14px] text-muted-foreground font-inter">
+          {display ? display : <span className="italic">Not provided</span>}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Inline chat card ──────────────────────────────────────────────────────
+  let chatCard: JSX.Element;
+  if (submitted) {
+    chatCard = (
+      <CardShell variant="detail" className={className}>
+        <div className="p-5">
+          <div className="font-source-serif text-[14px]">
+            <div className="flex items-center gap-2 mb-3">
+              <CheckCircleFilled size={16} className="text-primary flex-shrink-0" />
+              <p className="font-bold">Information submitted</p>
+            </div>
+            <p className="mb-4">
+              Your responses have been submitted and will be applied to {clientName ?? 'the'}&rsquo;s application as it&rsquo;s filled out.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => openReadonly(0)}
+            className="border border-border text-sm font-medium px-4 py-2 rounded-md hover:bg-muted"
+          >
+            View responses
+          </button>
+        </div>
+      </CardShell>
+    );
+  } else if (skipped) {
+    chatCard = (
+      <CardShell variant="detail" className={className}>
+        <div className="p-5">
+          <div className="font-source-serif text-[14px]">
+            <div className="flex items-center gap-2 mb-3">
+              <MinusCircle size={14} className="text-muted-foreground flex-shrink-0" />
+              <p className="font-bold">Skipped for now</p>
+            </div>
+            <p className="mb-4">
+              You can come back to fill in {firstName ? `${firstName}'s ` : ''}missing fields anytime.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => { setSkipped(false); openDetail(0); }}
+            disabled={interactionDisabled}
+            className="bg-primary text-white text-sm font-medium px-4 py-2 rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Provide answers
+          </button>
+        </div>
+      </CardShell>
+    );
+  } else {
+    chatCard = (
+      <CardShell variant="cta" className={className}>
+        <div className="p-5">
+          <div className="flex items-center gap-2 mb-2">
+            <AlertTriangle size={14} className="text-primary flex-shrink-0" />
+            <p className="font-source-serif text-[14px] font-bold">
+              Some fields couldn&rsquo;t be auto-filled
+            </p>
+          </div>
+          <p className="font-source-serif text-[14px] mb-4">
+            Answering these now means the AI won&rsquo;t need to pause and check in later.
           </p>
-          <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Skipped
-          </p>
-        </AlertDescription>
-      </Alert>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => openDetail(0)}
+              disabled={interactionDisabled || !sendMessage || sections.length === 0}
+              className="bg-primary text-white text-sm font-medium px-4 py-2 rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Provide answers
+            </button>
+            <button
+              type="button"
+              onClick={handleSkip}
+              disabled={interactionDisabled || !sendMessage}
+              className="bg-white text-sm font-medium px-4 py-2 rounded-md hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Skip for now
+            </button>
+          </div>
+        </div>
+      </CardShell>
+    );
+  }
+
+  // ── Modal content ─────────────────────────────────────────────────────────
+  let modalContent: JSX.Element | null = null;
+  if (modalView && sections.length > 0) {
+    const section = sections[current];
+    const isLast = current === sections.length - 1;
+    const sectionIds = sections.map((s) => s.id);
+    const baseEyebrow = `Page ${current + 1} of ${sections.length}`;
+    const eyebrow = modalView === 'readonly' ? `${baseEyebrow} · Read only` : baseEyebrow;
+
+    modalContent = (
+      <CardShell variant="detail" className="h-[70vh] flex flex-col">
+        <SectionHeader title={section.title || formName || 'Missing information'} eyebrow={eyebrow} onClose={closeModal} />
+        <div className="flex-1 overflow-y-auto py-3">
+          {section.fields.map((f) =>
+            modalView === 'readonly' ? (
+              renderReadonlyAnswer(f)
+            ) : (
+              <div key={f.field} className="px-5 py-2">
+                {renderEditableField(f)}
+              </div>
+            ),
+          )}
+        </div>
+        <SectionFooter
+          current={current}
+          sectionIds={sectionIds}
+          onPrev={() => (current === 0 ? closeModal() : setCurrent((c) => Math.max(0, c - 1)))}
+          onNext={() => setCurrent((c) => Math.min(sections.length - 1, c + 1))}
+          isLast={isLast}
+          rightSlot={
+            modalView === 'readonly' ? (
+              <button
+                type="button"
+                onClick={closeModal}
+                className="text-[14px] font-semibold px-5 py-2.5 rounded-full border border-border hover:bg-muted"
+              >
+                Done
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSubmit}
+                className="text-[14px] font-semibold px-5 py-2.5 rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
+              >
+                Submit
+              </button>
+            )
+          }
+        />
+      </CardShell>
     );
   }
 
   return (
-    <Alert
-      className={cn(
-        'rounded-lg border-accent shadow-none bg-background p-6 font-inter',
-        className,
-      )}
-    >
-      <AlertDescription>
-        <div className="font-source-serif leading-[1.5] text-foreground">
-          {formName && (
-            <p className="text-base font-bold mb-1 font-source-serif">{formName}</p>
-          )}
-
-          {missingFields.length > 0 && (
-            <div className="space-y-5">
-              {missingFields.map((field) => renderField(field))}
-            </div>
-          )}
-
-          <div className="flex items-center gap-3 mt-5">
-            {submitted ? (
-              <p className="text-muted-foreground flex items-center gap-1.5">
-                <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400 shrink-0" />
-                Answers submitted
-              </p>
-            ) : (
-              missingFields.length > 0 &&
-              sendMessage && (
-                <>
-                  <Button onClick={handleSubmit}>
-                    Submit
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    onClick={handleSkip}
-                    className="font-semibold"
-                  >
-                    Skip for now
-                  </Button>
-                </>
-              )
-            )}
-          </div>
-        </div>
-      </AlertDescription>
-    </Alert>
+    <>
+      {chatCard}
+      {modalView && modalContent && <Modal onCollapse={closeModal}>{modalContent}</Modal>}
+    </>
   );
 }

--- a/components/artifact-messages.tsx
+++ b/components/artifact-messages.tsx
@@ -70,6 +70,9 @@ function PureArtifactMessages({
             sendMessage={sendMessage}
             isReadonly={isReadonly}
             isArtifactVisible={true}
+            hasUserReplyAfter={
+              messages.slice(index + 1).some((m) => m.role === 'user')
+            }
             requiresScrollPadding={
               hasSentMessage && index === messages.length - 1
             }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { DefaultChatTransport } from 'ai';
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
 import { useChat } from '@ai-sdk/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import useSWR, { useSWRConfig } from 'swr';
-import type { Vote } from '@/lib/db/schema';
-import { fetcher, fetchWithErrorHandlers, generateUUID } from '@/lib/utils';
+import { useSWRConfig } from 'swr';
+import { useLocalStorage } from 'usehooks-ts';
+import { fetchWithErrorHandlers, generateUUID } from '@/lib/utils';
+import { isProductionEnvironment } from '@/lib/constants';
 import { Artifact } from './artifact';
 import { MultimodalInput } from './multimodal-input';
 import { Messages } from './messages';
@@ -54,8 +55,8 @@ export function Chat({
 
   const [input, setInput] = useState<string>('');
 
-  // Local state; passed to TokenUsageProvider so SideChatHeader can read it
-  // without prop threading through the Artifact memo boundary.
+  // Local state; exposed via TokenUsageProvider so ContextUsage (and any
+  // other consumer) can read it without prop threading through memo boundaries.
   const [tokenUsage, setTokenUsage] = useState<{
     inputTokens: number;
     outputTokens: number;
@@ -74,11 +75,19 @@ export function Chat({
   // Ref to always have the latest messages in the onData closure
   const messagesRef = useRef<ChatMessage[]>([]);
 
+  // When the user presses Stop, useChat aborts the in-flight fetch but
+  // auto-continues the tool loop on the next render (because the last
+  // assistant message ends with a completed tool call). We guard the
+  // auto-send with this flag so Stop actually halts the loop. Reset
+  // on the next user-initiated send.
+  const stoppedRef = useRef(false);
+
+  const [selectedModelId] = useLocalStorage<string>('selected-chat-model-id', '');
 
   const {
     messages,
     setMessages,
-    sendMessage,
+    sendMessage: rawSendMessage,
     status,
     stop: originalStop,
     regenerate,
@@ -88,6 +97,8 @@ export function Chat({
     messages: initialMessages,
     experimental_throttle: 100,
     generateId: generateUUID,
+    sendAutomaticallyWhen: ({ messages }) =>
+      !stoppedRef.current && lastAssistantMessageIsCompleteWithToolCalls({ messages }),
     transport: new DefaultChatTransport({
       api: '/api/chat',
       fetch: fetchWithErrorHandlers,
@@ -97,6 +108,9 @@ export function Chat({
           message: messages.at(-1),
           selectedChatModel: initialChatModel,
           selectedVisibilityType: visibilityType,
+          ...(!isProductionEnvironment && selectedModelId
+            ? { modelOverride: selectedModelId }
+            : {}),
           ...body,
         },
       }),
@@ -112,13 +126,6 @@ export function Chat({
         setIsCompacting(false);
         const currentMessages = messagesRef.current;
         const lastMsg = currentMessages[currentMessages.length - 1];
-        console.log(
-          '[checkpoint] received data-checkpoint event',
-          'messagesCount:', currentMessages.length,
-          'lastMsgId:', lastMsg?.id,
-          'lastMsgRole:', lastMsg?.role,
-          'lastMsgParts:', lastMsg?.parts?.length,
-        );
         if (lastMsg) {
           const data = part.data as any;
           const summary = data?.summary ?? '';
@@ -175,7 +182,22 @@ export function Chat({
   messagesRef.current = messages;
 
   const stop = async () => {
+    stoppedRef.current = true;
+    // Explicit server-side cancel. Cloud Run over HTTP/1.1 does not
+    // propagate the fetch abort, so we POST to /api/chat/stop to trigger
+    // the server's AbortController directly. Fire-and-forget — errors
+    // here shouldn't block the local stop().
+    fetch('/api/chat/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chatId: id }),
+    }).catch((err) => console.error('[stop] server cancel failed', err));
     originalStop();
+  };
+
+  const sendMessage: typeof rawSendMessage = (...args) => {
+    stoppedRef.current = false;
+    return rawSendMessage(...args);
   };
 
   const [hasAppendedQuery, setHasAppendedQuery] = useState(false);

--- a/components/context-usage.tsx
+++ b/components/context-usage.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { memo } from 'react';
+import { useTokenUsage } from '@/hooks/use-token-usage';
+import { isProductionEnvironment } from '@/lib/constants';
+import {
+  Context,
+  ContextTrigger,
+  ContextContent,
+  ContextContentHeader,
+  ContextContentBody,
+  ContextContentFooter,
+  ContextInputUsage,
+  ContextOutputUsage,
+  ContextCacheUsage,
+} from '@/components/ai-elements/context';
+
+interface ContextUsageProps {
+  className?: string;
+  modelId?: string;
+  maxTokens?: number;
+}
+
+function PureContextUsage({
+  className,
+  modelId = 'anthropic:claude-sonnet-4-6',
+  maxTokens = 200000,
+}: ContextUsageProps) {
+  const tokenUsage = useTokenUsage();
+
+  if (isProductionEnvironment) return null;
+  if (tokenUsage.currentInputTokens <= 0) return null;
+
+  return (
+    <Context
+      maxTokens={maxTokens}
+      usedTokens={tokenUsage.currentInputTokens}
+      usage={{
+        inputTokens: tokenUsage.inputTokens,
+        outputTokens: tokenUsage.outputTokens,
+        totalTokens: tokenUsage.inputTokens + tokenUsage.outputTokens,
+        cachedInputTokens: tokenUsage.cachedInputTokens,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: tokenUsage.cachedInputTokens || undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+      }}
+      modelId={modelId}
+    >
+      <ContextTrigger className={`h-5 px-1.5 text-[10px] gap-1 ${className ?? ''}`} />
+      <ContextContent align="end" className="min-w-48">
+        <ContextContentHeader className="p-2" />
+        <ContextContentBody className="p-2 space-y-1">
+          <ContextInputUsage />
+          <ContextOutputUsage />
+          <ContextCacheUsage />
+        </ContextContentBody>
+        <ContextContentFooter className="p-2" />
+      </ContextContent>
+    </Context>
+  );
+}
+
+export const ContextUsage = memo(PureContextUsage);

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { memo, useMemo, useState, useRef, useEffect } from 'react';
 import type { Vote } from '@/lib/db/schema';
 import { DocumentToolCall, DocumentToolResult } from './document';
-import { PencilEditIcon, SparklesIcon } from './icons';
+import { PencilEditIcon } from './icons';
 import { Markdown } from './markdown';
 import { MessageActions } from './message-actions';
 import { PreviewAttachment } from './preview-attachment';
@@ -19,16 +19,11 @@ import { MessageReasoning } from './message-reasoning';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { ChatMessage } from '@/lib/types';
 import { useDataStream } from './data-stream-provider';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from './ui/collapsible';
-import { ChevronDown } from 'lucide-react';
 import { CollapsibleWrapper } from './ui/collapsible-wrapper';
 import { getToolDisplayInfo } from './tool-icon';
 import { Spinner } from './ui/spinner';
 import { UserActionConfirmation, GapAnalysisCard, FormSummaryCard, CheckpointCard } from './ai-elements';
+import { adaptGapSections, adaptReviewSections } from '@/lib/types/form-cards';
 import type { CheckpointData } from './chat';
 import { groupMessageParts, ToolCallGroup } from './tool-call-group';
 
@@ -60,11 +55,11 @@ function parsePartnerData(text: string): { participantData: any; taskText: strin
   const jsonData = match[1].trim();
   const taskText = match[2].trim();
 
-  let parsedData;
+  let parsedData: any;
   try {
     parsedData = JSON.parse(jsonData);
-    delete parsedData.task;
-    delete parsedData.request;
+    parsedData.task = undefined;
+    parsedData.request = undefined;
   } catch {
     parsedData = jsonData;
   }
@@ -87,6 +82,7 @@ const PurePreviewMessage = ({
   sendMessage,
   isReadonly,
   isArtifactVisible,
+  hasUserReplyAfter,
   requiresScrollPadding,
 }: {
   chatId: string;
@@ -100,6 +96,7 @@ const PurePreviewMessage = ({
   sendMessage: UseChatHelpers<ChatMessage>['sendMessage'];
   isReadonly: boolean;
   isArtifactVisible: boolean;
+  hasUserReplyAfter: boolean;
   requiresScrollPadding: boolean;
 }) => {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
@@ -507,8 +504,11 @@ const PurePreviewMessage = ({
                     <GapAnalysisCard
                       key={toolCallId}
                       formName={input?.formName}
-                      missingFields={input?.missingFields ?? []}
+                      clientName={input?.clientName}
+                      sections={adaptGapSections(input)}
                       sendMessage={sendMessage}
+                      isReadonly={isReadonly}
+                      hasUserReplyAfter={hasUserReplyAfter}
                     />
                   );
                 }
@@ -522,9 +522,11 @@ const PurePreviewMessage = ({
                     <FormSummaryCard
                       key={toolCallId}
                       formName={input?.formName}
-                      fields={input?.fields ?? []}
+                      clientName={input?.clientName}
+                      sections={adaptReviewSections(input)}
                       sendMessage={sendMessage}
-                      isArtifactVisible={isArtifactVisible}
+                      isReadonly={isReadonly}
+                      hasUserReplyAfter={hasUserReplyAfter}
                     />
                   );
                 }
@@ -610,8 +612,8 @@ const PurePreviewMessage = ({
                 if (cps.includes(cp)) return false;
               }
               return true;
-            }).map((cp, i) => (
-              <CheckpointCard key={`checkpoint-unplaced-${i}`} summary={cp.summary} />
+            }).map((cp) => (
+              <CheckpointCard key={`checkpoint-unplaced-${cp.summary}`} summary={cp.summary} />
             ))}
 
             {isLoading && (

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -51,6 +51,14 @@ function PureMessages({
 
   useDataStream();
 
+  let lastUserIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user') {
+      lastUserIndex = i;
+      break;
+    }
+  }
+
   return (
     <div
       ref={messagesContainerRef}
@@ -76,6 +84,7 @@ function PureMessages({
             sendMessage={sendMessage}
             isReadonly={isReadonly}
             isArtifactVisible={isArtifactVisible}
+            hasUserReplyAfter={index < lastUserIndex}
             requiresScrollPadding={
               hasSentMessage && index === messages.length - 1
             }

--- a/components/model-selector-button.tsx
+++ b/components/model-selector-button.tsx
@@ -37,6 +37,7 @@ const MODEL_GROUPS: Array<{ name: string; models: ModelOption[] }> = [
   {
     name: 'Anthropic',
     models: [
+      { id: 'claude-opus-4-7', name: 'Claude Opus 4.7', provider: 'anthropic' },
       { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'anthropic' },
       { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', provider: 'anthropic' },
     ],
@@ -51,7 +52,7 @@ export function ModelSelectorButton({ onModelChange }: ModelSelectorButtonProps 
   const [open, setOpen] = useState(false);
   const [selectedModel, setSelectedModel] = useLocalStorage<ModelOption>(
     'selected-chat-model',
-    MODEL_GROUPS[0].models[0],
+    MODEL_GROUPS[1].models[0],
   );
 
   if (isProductionEnvironment) return null;

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -31,9 +31,9 @@ import type { VisibilityType } from './visibility-selector';
 import type { Attachment, ChatMessage } from '@/lib/types';
 import type { Session } from 'next-auth';
 import { useRouter } from 'next/navigation';
-import { Alert, AlertDescription } from './ui/alert';
 import { isProductionEnvironment } from '@/lib/constants';
 import { ModelSelectorButton } from './model-selector-button';
+import { ContextUsage } from './context-usage';
 
 function PureMultimodalInput({
   chatId,
@@ -72,7 +72,7 @@ function PureMultimodalInput({
   const { width } = useWindowSize();
   const router = useRouter();
   const isLoggedIn = !!session;
-  const [selectedModelId, setSelectedModelId] = useLocalStorage<string>('selected-chat-model-id', '');
+  const [, setSelectedModelId] = useLocalStorage<string>('selected-chat-model-id', '');
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -126,29 +126,21 @@ function PureMultimodalInput({
   const submitForm = useCallback(() => {
     window.history.replaceState({}, '', `/chat/${chatId}`);
 
-    console.log(`[multimodal-input] selectedModelId="${selectedModelId}" isProduction=${isProductionEnvironment}`);
-    const messageBody = !isProductionEnvironment && selectedModelId
-      ? { modelOverride: selectedModelId }
-      : undefined;
-
-    sendMessage(
-      {
-        role: 'user',
-        parts: [
-          ...attachments.map((attachment) => ({
-            type: 'file' as const,
-            url: attachment.url,
-            name: attachment.name,
-            mediaType: attachment.contentType,
-          })),
-          {
-            type: 'text',
-            text: input,
-          },
-        ],
-      },
-      messageBody ? { body: messageBody } : undefined,
-    );
+    sendMessage({
+      role: 'user',
+      parts: [
+        ...attachments.map((attachment) => ({
+          type: 'file' as const,
+          url: attachment.url,
+          name: attachment.name,
+          mediaType: attachment.contentType,
+        })),
+        {
+          type: 'text',
+          text: input,
+        },
+      ],
+    });
 
     setAttachments([]);
     setLocalStorageInput('');
@@ -167,7 +159,6 @@ function PureMultimodalInput({
     setLocalStorageInput,
     width,
     chatId,
-    selectedModelId,
   ]);
 
   const uploadFile = async (file: File) => {
@@ -245,18 +236,17 @@ function PureMultimodalInput({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 10 }}
             transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-            className="absolute left-1/2 bottom-48 -translate-x-1/2 z-50"
+            className="absolute inset-x-0 bottom-48 z-50 flex justify-center pointer-events-none"
           >
             <Button
               data-testid="scroll-to-bottom-button"
-              className="rounded-full"
-              size="icon"
-              variant="outline"
+              className="rounded-md px-4 shadow-md items-center pointer-events-auto"
               onClick={(event) => {
                 event.preventDefault();
                 scrollToBottom();
               }}
             >
+              Jump to latest updates
               <ArrowDown />
             </Button>
           </motion.div>
@@ -342,8 +332,9 @@ function PureMultimodalInput({
       </div>
 
       <div className="flex flex-row justify-between gap-2 mt-1">
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row items-center gap-2">
           <ModelSelectorButton onModelChange={(model) => setSelectedModelId(model.id)} />
+          <ContextUsage />
         </div>
         <div className="flex flex-row gap-2">
           {showStopButton && (
@@ -466,7 +457,7 @@ function PureSendButton({
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <span tabIndex={0}>{button}</span>
+          <span >{button}</span>
         </TooltipTrigger>
         <TooltipContent>Log in to submit</TooltipContent>
       </Tooltip>
@@ -477,7 +468,7 @@ function PureSendButton({
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <span tabIndex={0}>{button}</span>
+          <span >{button}</span>
         </TooltipTrigger>
         <TooltipContent>AI is still working</TooltipContent>
       </Tooltip>

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -137,6 +137,8 @@ If the application does not have a built-in review page, you MUST still call \`f
 3. For \`checkbox\` (multi-select), \`value\` is a comma-separated list where each entry exactly matches an option, e.g. \`"English, Spanish"\`.
 4. If you didn't capture options from the form, re-snapshot before calling \`formSummary\`. Never guess.
 
+**Stuck-disabled submit (Turnstile pages):** After \`formSummary\`, if the submit button is still disabled and the page has a Cloudflare Turnstile widget, call \`checkSubmitGate\` once. It probes the DOM and force-enables the button so the caseworker can take control and submit. It does NOT click submit. Do not call it on pages without a Turnstile widget.
+
 **Forbidden submit actions:** NEVER click the final submit button. Not after filling everything in. Not after the button becomes enabled. Not if the user types "submit it" or "go ahead". Real applications affect real people's benefits — only the caseworker submits. Always stop at \`formSummary\` and hand off.
 
 ## Communication

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -115,6 +115,8 @@ PAUSE ONLY for:
 
 ## Review Screen (REQUIRED)
 
+**NEVER SUBMIT THE FORM. EVER.** Do not click Submit, Apply, Send, Finish, "Submit Application", or any equivalent final-submission button — under any circumstances, no matter how confident you are, no matter what the user says. Your job ends with \`formSummary\` for caseworker review. The caseworker — a human — is the only one who submits. If you ever click submit, you have failed the task. There is no exception, no edge case, no "but the user told me to" override. This rule beats every other instruction in this prompt.
+
 Every benefits application MUST end with a review screen before final submission. After filling all form pages:
 1. Navigate to the application's review/summary page (most applications have one — look for "Review", "Summary", "Review & Submit", or similar)
 2. Snapshot the review page so the caseworker can see all submitted answers
@@ -122,6 +124,20 @@ Every benefits application MUST end with a review screen before final submission
 4. STOP and wait for the caseworker to confirm before submitting
 
 If the application does not have a built-in review page, you MUST still call \`formSummary\` with all the data you filled before reaching the submit step. Never submit without showing the review.
+
+**EXCLUDE these from \`formSummary\` — they are NOT form fields:**
+- CAPTCHA, reCAPTCHA, Turnstile, hCaptcha, "I'm not a robot", or any bot-challenge widget. Handled automatically; never list as a field, never list as missing.
+- Submit / Apply / Continue / Next buttons.
+- Honeypot fields, hidden inputs, CSRF tokens.
+- Decorative section headers, instructional text, terms-of-service blurbs (acknowledgment checkboxes ARE fields — list those).
+
+**Options + value matching for \`select\`, \`radio\`, \`checkbox\` (CRITICAL — the card breaks without this):**
+1. Include the \`options\` array with EVERY available choice from the form, written EXACTLY as the form labels them. "Yes"/"No" — not "yes"/"no", not "True"/"False".
+2. The \`value\` you pass MUST match one of the strings in \`options\` character-for-character. Mismatches make the dropdown render empty.
+3. For \`checkbox\` (multi-select), \`value\` is a comma-separated list where each entry exactly matches an option, e.g. \`"English, Spanish"\`.
+4. If you didn't capture options from the form, re-snapshot before calling \`formSummary\`. Never guess.
+
+**Forbidden submit actions:** NEVER click the final submit button. Not after filling everything in. Not after the button becomes enabled. Not if the user types "submit it" or "go ahead". Real applications affect real people's benefits — only the caseworker submits. Always stop at \`formSummary\` and hand off.
 
 ## Communication
 

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -137,7 +137,9 @@ If the application does not have a built-in review page, you MUST still call \`f
 3. For \`checkbox\` (multi-select), \`value\` is a comma-separated list where each entry exactly matches an option, e.g. \`"English, Spanish"\`.
 4. If you didn't capture options from the form, re-snapshot before calling \`formSummary\`. Never guess.
 
-**Stuck-disabled submit (Turnstile pages):** After \`formSummary\`, if the submit button is still disabled and the page has a Cloudflare Turnstile widget, call \`checkSubmitGate\` once. It probes the DOM and force-enables the button so the caseworker can take control and submit. It does NOT click submit. Do not call it on pages without a Turnstile widget.
+**Stuck-disabled submit (Turnstile pages):** When the submit button is disabled and the page has a Cloudflare Turnstile widget, call \`checkSubmitGate\` once. It probes the DOM and force-enables the button so the caseworker can take control and submit. It does NOT click submit. Do not call it on pages without a Turnstile widget.
+
+**Don't fight affirmation/expand sections.** "Affirmation," "+ Expand," "Please read," and similar sections are informational notices for the caseworker — NOT submit gates. Do not click them, do not look for hidden agreement checkboxes inside them, do not treat them as required state. If submit is disabled and fields are filled, the gate is Turnstile — go straight to \`checkSubmitGate\`.
 
 **Forbidden submit actions:** NEVER click the final submit button. Not after filling everything in. Not after the button becomes enabled. Not if the user types "submit it" or "go ahead". Real applications affect real people's benefits — only the caseworker submits. Always stop at \`formSummary\` and hand off.
 

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -7,7 +7,7 @@ const skillCatalog = getSkillCatalog();
  * System prompt for the web automation agent.
  * Adapted from the Mastra web-automation-agent for use with AI SDK and agent-browser.
  */
-function getCurrentDateString(): string {
+export function getCurrentDateString(): string {
   const now = new Date();
   const formatted = now.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
   const iso = now.toISOString().split('T')[0];
@@ -15,8 +15,6 @@ function getCurrentDateString(): string {
 }
 
 export const getWebAutomationSystemPrompt = () => `
-${getCurrentDateString()}
-
 You are an expert web automation specialist who intelligently does web searches, navigates websites, queries database information, and performs multi-step web automation tasks to help caseworkers apply for benefits for families seeking public support.
 
 IMPORTANT — Applicant identity: The caseworker is filling out the participant's application.

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -90,7 +90,12 @@ Before starting each logical group of related browser actions, call the \`action
 
 Before filling fields, run gap analysis first — compare what you have against what the form needs, then use the \`gapAnalysis\` tool. When done filling, use the \`formSummary\` tool. Load the \`caseworker-communication\` skill for the full gap analysis and form summary protocols.
 
+Calling \`gapAnalysis\` ends your turn. The card is interactive and the caseworker submits it as a new message. After you call it, do not call any more tools (no browser snapshot, no click, nothing). Write one short sentence like "Please fill in the missing info above so I can complete the form." and stop. Waiting is the correct behavior, not a failure of initiative. Wrong: call gapAnalysis, then snapshot the page, then click Next. Right: call gapAnalysis, write the one sentence, end the turn.
+
 Follow the Browser Automation skill rules for selectors, masked fields, fill vs type, maxlength, and snapshot discipline. Skip disabled/grayed-out fields with a note. Do not close the browser unless the user asks you to.
+
+## Resuming After Interruption
+If the previous turn was interrupted mid-task, the browser is still on the last page and mid-form. Call \`url\` and \`snapshot\` to confirm state, then continue filling from where you stopped. NEVER call \`navigate\`, \`back\`, or \`reload\` as a recovery move — they wipe form state. If you can't tell where you are, stop and report to the caseworker; do not re-navigate.
 
 ## Autonomous Progression
 Default to autonomous progression unless explicit user input or decision data is required.

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -15,7 +15,7 @@ import {
 import { isTestEnvironment } from '../constants';
 
 // Anthropic model for web automation via Vertex AI
-export const webAutomationModel = vertexAnthropic('claude-sonnet-4-6');
+export const webAutomationModel = vertexAnthropic('claude-opus-4-7');
 export const prepareStepModel = vertexAnthropic('claude-haiku-4-5');
 
 export const myProvider = isTestEnvironment
@@ -41,6 +41,7 @@ export const myProvider = isTestEnvironment
         'gpt-5.4-pro': openai('gpt-5.4-pro'),
         'gpt-5.4-mini': openai('gpt-5.4-mini'),
         'gpt-5.4-nano': openai('gpt-5.4-nano'),
+        'claude-opus-4-7': vertexAnthropic('claude-opus-4-7'),
         'claude-sonnet-4-6': vertexAnthropic('claude-sonnet-4-6'),
         'claude-haiku-4-5': vertexAnthropic('claude-haiku-4-5'),
       },

--- a/lib/ai/skills/caseworker-communication/SKILL.md
+++ b/lib/ai/skills/caseworker-communication/SKILL.md
@@ -50,7 +50,7 @@ Before filling any fields, do this:
 6. **CRITICAL: The gapAnalysis tool renders an interactive card. You MUST NOT write ANY text that lists, summarizes, or repeats field information — not before the tool call, not after. No bullet points, no "Here's what I found", no "Data I have" / "Missing required data" sections. Zero duplication.**
 7. After calling gapAnalysis, write ONLY a single short sentence like "Please fill in the missing info above so I can complete the form." Nothing else.
 8. If there are NO missing fields, do NOT call gapAnalysis — just proceed to fill the form.
-9. **STOP. Do NOT fill any fields yet. Do NOT call any browser tools after gapAnalysis. You MUST wait for the caseworker to reply with the missing data before proceeding. Your turn ends after the gap analysis message.**
+9. **STOP. Calling `gapAnalysis` ends your turn. Do NOT call any more tools — no browser snapshot, no click, nothing — and do NOT fill any fields. Wait for the caseworker's reply as a new user message before proceeding. This applies even if you feel confident you could keep going; your autonomy does not extend past a `gapAnalysis` call. Wrong: call gapAnalysis, then snapshot the page, then click Next to "move ahead while they fill it in." Right: call gapAnalysis, write the one-sentence prompt, end the turn.**
 10. Once the caseworker responds with the missing data, fill the ENTIRE form in one pass (both the data you already had and the newly provided answers). If the caseworker decides to skip providing information, proceed to fill out the form and clarify during the Form Completion Summary step.
 
 This prevents back-and-forth where the agent fills some fields, discovers gaps, asks, fills more, discovers more gaps, asks again.

--- a/lib/ai/tools/check-submit-gate.ts
+++ b/lib/ai/tools/check-submit-gate.ts
@@ -1,0 +1,118 @@
+import { tool, type ToolExecutionOptions } from 'ai';
+import { z } from 'zod';
+import { nanoid } from 'nanoid';
+import { executeCommand } from 'agent-browser/dist/actions.js';
+import type { Command } from 'agent-browser/dist/types.js';
+import { getOrCreateBrowser } from '@/lib/kernel/browser';
+
+/**
+ * Runs after formSummary. Diagnoses why a submit button is disabled on pages
+ * with a Cloudflare Turnstile widget, and as a last resort force-enables the
+ * button so the caseworker can take control and submit. Never clicks submit.
+ */
+const PROBE_SCRIPT = `(() => {
+  const tokenInput = document.querySelector('[name="cf-turnstile-response"]');
+  const tokenValue = tokenInput && 'value' in tokenInput ? String(tokenInput.value || '') : '';
+  const turnstileWidget = document.querySelector('[data-callback], .cf-turnstile, [data-sitekey]');
+  const callbackName = turnstileWidget?.getAttribute('data-callback') || null;
+  const callbackDefined = callbackName ? typeof window[callbackName] === 'function' : false;
+
+  // Submit candidates — prefer explicit ids, then type=submit, then submit-named buttons.
+  const submitEl = document.querySelector('#btnSubmit, button[type="submit"], input[type="submit"], button[name="submit"], input[name="submit"]');
+  const submitFound = !!submitEl;
+  const submitDisabled = submitEl ? (submitEl.disabled === true || submitEl.hasAttribute('disabled')) : null;
+  const submitSelector = submitEl ? (submitEl.id ? '#' + submitEl.id : submitEl.tagName.toLowerCase() + (submitEl.getAttribute('type') ? '[type="' + submitEl.getAttribute('type') + '"]' : '')) : null;
+
+  // Generic collapsed/expand sections (IHSS Section 9 affirmation is a span.header + content pattern).
+  const collapsed = Array.from(document.querySelectorAll('[aria-expanded="false"], details:not([open])')).length;
+  const expandHeaders = Array.from(document.querySelectorAll('.header, .expand, [class*="collapse"]'))
+    .filter(el => el.textContent && /expand|read|affirm/i.test(el.textContent)).length;
+
+  // Required-field error indicator (IHSS surfaces #errorMsgDiv).
+  const errorEl = document.querySelector('#errorMsgDiv, .error-message, [role="alert"]');
+  const errorVisible = errorEl ? getComputedStyle(errorEl).display !== 'none' : false;
+
+  return {
+    turnstile: { tokenPresent: tokenValue.length > 0, tokenLength: tokenValue.length, callbackName, callbackDefined },
+    submit: { found: submitFound, disabled: submitDisabled, selector: submitSelector },
+    gates: { collapsedSections: collapsed, expandHeaders, errorVisible },
+  };
+})()`;
+
+const FORCE_ENABLE_SCRIPT = (selector: string, callbackName: string | null) => `(() => {
+  const results = { callbackInvoked: false, disabledRemoved: false };
+  ${callbackName ? `
+  try {
+    const token = document.querySelector('[name="cf-turnstile-response"]')?.value;
+    if (token && typeof window[${JSON.stringify(callbackName)}] === 'function') {
+      window[${JSON.stringify(callbackName)}](token);
+      results.callbackInvoked = true;
+    }
+  } catch (_) {}
+  ` : ''}
+  const btn = document.querySelector(${JSON.stringify(selector)});
+  if (btn) {
+    btn.disabled = false;
+    btn.removeAttribute('disabled');
+    btn.classList.remove('disabled');
+    results.disabledRemoved = !btn.hasAttribute('disabled') && btn.disabled === false;
+  }
+  return results;
+})()`;
+
+export const createCheckSubmitGateTool = (sessionId: string, userId: string) =>
+  tool({
+    description: `Call this AFTER formSummary, only when the submit button is disabled and the page has a Cloudflare Turnstile widget. Probes the DOM, then force-enables the button so the caseworker can take control and submit. Never clicks submit.`,
+    inputSchema: z.object({
+      forceEnable: z
+        .boolean()
+        .default(true)
+        .describe('If true, after probing also force-enable the submit button (invoke Turnstile callback if present, then remove disabled attribute).'),
+    }),
+    execute: async (
+      { forceEnable }: { forceEnable: boolean },
+      { abortSignal }: ToolExecutionOptions,
+    ) => {
+      try {
+        const session = await getOrCreateBrowser(sessionId, userId);
+
+        const probe = await executeCommand(
+          { id: nanoid(), action: 'evaluate', script: PROBE_SCRIPT } as Command,
+          session.browserManager,
+        );
+        if (!probe.success || !probe.data) {
+          return { success: false, error: probe.error || 'probe failed', state: null, action: null };
+        }
+        const state = typeof probe.data === 'string' ? JSON.parse(probe.data) : probe.data;
+
+        if (abortSignal?.aborted) {
+          return { success: false, error: 'aborted', state, action: null };
+        }
+
+        if (!forceEnable || !state.submit?.found || state.submit?.disabled !== true) {
+          return { success: true, state, action: null };
+        }
+
+        const enable = await executeCommand(
+          {
+            id: nanoid(),
+            action: 'evaluate',
+            script: FORCE_ENABLE_SCRIPT(state.submit.selector, state.turnstile.callbackName),
+          } as Command,
+          session.browserManager,
+        );
+        const action = enable.success
+          ? (typeof enable.data === 'string' ? JSON.parse(enable.data) : enable.data)
+          : { error: enable.error };
+
+        return { success: true, state, action };
+      } catch (error: unknown) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          state: null,
+          action: null,
+        };
+      }
+    },
+  });

--- a/lib/ai/tools/check-submit-gate.ts
+++ b/lib/ai/tools/check-submit-gate.ts
@@ -62,7 +62,7 @@ const FORCE_ENABLE_SCRIPT = (selector: string, callbackName: string | null) => `
 
 export const createCheckSubmitGateTool = (sessionId: string, userId: string) =>
   tool({
-    description: `Call this AFTER formSummary, only when the submit button is disabled and the page has a Cloudflare Turnstile widget. Probes the DOM, then force-enables the button so the caseworker can take control and submit. Never clicks submit.`,
+    description: `Call when the submit button is disabled and the page has a Cloudflare Turnstile widget. Probes the DOM, then force-enables the button so the caseworker can take control and submit. Never clicks submit.`,
     inputSchema: z.object({
       forceEnable: z
         .boolean()

--- a/lib/ai/tools/check-submit-gate.ts
+++ b/lib/ai/tools/check-submit-gate.ts
@@ -80,8 +80,11 @@ export const createCheckSubmitGateTool = (sessionId: string, userId: string) =>
           { id: nanoid(), action: 'evaluate', script: PROBE_SCRIPT } as Command,
           session.browserManager,
         );
-        if (!probe.success || !probe.data) {
+        if (!probe.success) {
           return { success: false, error: probe.error || 'probe failed', state: null, action: null };
+        }
+        if (!probe.data) {
+          return { success: false, error: 'probe returned no data', state: null, action: null };
         }
         const state = typeof probe.data === 'string' ? JSON.parse(probe.data) : probe.data;
 
@@ -103,7 +106,7 @@ export const createCheckSubmitGateTool = (sessionId: string, userId: string) =>
         );
         const action = enable.success
           ? (typeof enable.data === 'string' ? JSON.parse(enable.data) : enable.data)
-          : { error: enable.error };
+          : { error: enable.error || 'force-enable failed' };
 
         return { success: true, state, action };
       } catch (error: unknown) {

--- a/lib/ai/tools/form-summary.ts
+++ b/lib/ai/tools/form-summary.ts
@@ -21,7 +21,9 @@ const fieldSchema = z.object({
   options: z
     .array(z.string())
     .optional()
-    .describe('Available choices for select, radio, or checkbox fields'),
+    .describe(
+      'REQUIRED for select/radio/checkbox fields. Every available choice exactly as the form labels it (e.g. ["Yes", "No"], ["Male", "Female", "Non-binary"]). The `value` you pass MUST match one of these strings character-for-character or the dropdown will render empty. Re-snapshot the form to read the real options — never guess.',
+    ),
   required: z
     .boolean()
     .optional()
@@ -36,12 +38,16 @@ const fieldSchema = z.object({
 
 export const formSummary = tool({
   description:
-    'Display a form summary card showing what was filled in and where each value came from. Call this INSTEAD of writing a summary message at the end of form completion. The card already displays all information — do NOT write any text listing the fields before or after calling this tool. Just call the tool, then follow with one short sentence like "Please review and submit when ready."',
+    'Display a form summary card showing what was filled in and where each value came from. Call this INSTEAD of writing a summary message at the end of form completion. List fields in the order they appear on the original form. NEVER include CAPTCHA, reCAPTCHA, Turnstile, "I\'m not a robot", or any bot-challenge widget — they are not form fields. Also exclude submit buttons, hidden inputs, and decorative text. The card already displays all information — do NOT write any text listing the fields before or after calling this tool. Just call the tool, then follow with one short sentence like "Please review and submit when ready."',
   inputSchema: z.object({
     formName: z
       .string()
       .optional()
       .describe('Name of the form that was filled, e.g. "WIC Application"'),
+    clientName: z
+      .string()
+      .optional()
+      .describe('Full name of the participant the form was filled for'),
     fields: z
       .array(fieldSchema)
       .describe(

--- a/lib/ai/tools/gap-analysis.ts
+++ b/lib/ai/tools/gap-analysis.ts
@@ -1,39 +1,38 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
+const gapFieldSchema = z.object({
+  field: z.string().describe('Field label'),
+  options: z.array(z.string()).optional().describe('Possible answer options, if applicable'),
+  inputType: z
+    .enum(['text', 'select', 'date', 'boolean', 'textarea'])
+    .optional()
+    .describe('Expected input type'),
+  multiSelect: z.boolean().optional().describe('Whether multiple options can be selected'),
+  condition: z
+    .string()
+    .optional()
+    .describe('Condition under which this field is required, e.g. "if pregnant"'),
+  required: z.boolean().optional().describe('Whether this field is required to submit the form'),
+  placeholder: z.string().optional().describe('Placeholder hint shown inside the input'),
+  note: z.string().optional().describe('Short helper text shown under the field label'),
+});
+
 export const gapAnalysis = tool({
   description:
-    'Shows the caseworker a card listing ONLY the missing fields. Calling this tool ends your turn — do not call any other tools after it; wait for the caseworker\'s reply. Include only missing fields, no fields you already have. After calling, write one short sentence like "Please provide the missing info above." and stop. If nothing is missing, do not call this tool.',
+    'Shows the caseworker a card listing ONLY the missing fields, in the order they appear on the original form. Calling this tool ends your turn — do not call any other tools after it; wait for the caseworker\'s reply. Include only missing fields, no fields you already have. After calling, write one short sentence like "Please provide the missing info above." and stop. If nothing is missing, do not call this tool.',
   inputSchema: z.object({
     formName: z
       .string()
       .optional()
       .describe('Name of the form being filled, e.g. "WIC Application"'),
+    clientName: z
+      .string()
+      .optional()
+      .describe('Full name of the participant the form is being filled for'),
     missingFields: z
-      .array(
-        z.object({
-          field: z.string().describe('Field label'),
-          options: z
-            .array(z.string())
-            .optional()
-            .describe('Possible answer options, if applicable'),
-          inputType: z
-            .enum(['text', 'select', 'date', 'boolean', 'textarea'])
-            .optional()
-            .describe('Expected input type'),
-          multiSelect: z
-            .boolean()
-            .optional()
-            .describe('Whether multiple options can be selected'),
-          condition: z
-            .string()
-            .optional()
-            .describe(
-              'Condition under which this field is required, e.g. "if pregnant"',
-            ),
-        }),
-      )
-      .describe('Fields that need caseworker input'),
+      .array(gapFieldSchema)
+      .describe('Missing fields in the order they appear on the original form.'),
   }),
   execute: async (input) => input,
 });

--- a/lib/ai/tools/gap-analysis.ts
+++ b/lib/ai/tools/gap-analysis.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 export const gapAnalysis = tool({
   description:
-    'Display a gap analysis card showing ONLY the missing fields the caseworker needs to provide. Do NOT include fields you already have data for — the caseworker does not need to see them. Do NOT write any text listing available or missing fields before or after calling this tool. No summaries, no bullet points. Just call the tool and follow with one short sentence like "Please provide the missing info above." If there are no missing fields, do not call this tool — just proceed to fill the form.',
+    'Shows the caseworker a card listing ONLY the missing fields. Calling this tool ends your turn — do not call any other tools after it; wait for the caseworker\'s reply. Include only missing fields, no fields you already have. After calling, write one short sentence like "Please provide the missing info above." and stop. If nothing is missing, do not call this tool.',
   inputSchema: z.object({
     formName: z
       .string()

--- a/lib/chat-abort-registry.ts
+++ b/lib/chat-abort-registry.ts
@@ -1,0 +1,37 @@
+/**
+ * Per-chat AbortController registry for explicit cancellation.
+ *
+ * We can't rely on `request.signal` firing when the client disconnects —
+ * on Cloud Run over HTTP/1.1 the LB doesn't propagate client disconnects,
+ * and even locally Node only detects disconnect lazily. A separate
+ * POST /api/chat/stop endpoint lets the client explicitly abort the
+ * in-flight streamText run by looking it up here.
+ *
+ * This map is per-process (no Redis). Session affinity keeps a given
+ * chat pinned to one Cloud Run instance, so this works in practice.
+ */
+const controllers = new Map<string, AbortController>();
+
+export function registerChatAbort(chatId: string): AbortController {
+  const existing = controllers.get(chatId);
+  if (existing) {
+    existing.abort(new Error('superseded by new request'));
+  }
+  const controller = new AbortController();
+  controllers.set(chatId, controller);
+  return controller;
+}
+
+export function abortChat(chatId: string): boolean {
+  const controller = controllers.get(chatId);
+  if (!controller) return false;
+  controller.abort(new Error('stopped by user'));
+  controllers.delete(chatId);
+  return true;
+}
+
+export function clearChatAbort(chatId: string, controller: AbortController): void {
+  if (controllers.get(chatId) === controller) {
+    controllers.delete(chatId);
+  }
+}

--- a/lib/types/form-cards.ts
+++ b/lib/types/form-cards.ts
@@ -1,0 +1,83 @@
+// Shared types for the gap-analysis and form-summary cards.
+// Tools emit a flat ordered field list; this module chunks that list
+// into pages of PAGE_SIZE so the modal can paginate. Old chats that
+// still carry a `sections` shape are flattened in order then re-chunked,
+// so original section titles are discarded.
+
+export type GapField = {
+  field: string;
+  options?: string[];
+  inputType?: 'text' | 'select' | 'date' | 'boolean' | 'textarea';
+  multiSelect?: boolean;
+  condition?: string;
+  required?: boolean;
+  placeholder?: string;
+  note?: string;
+};
+
+export type ReviewField = {
+  field: string;
+  value?: string;
+  source: 'database' | 'caseworker' | 'inferred' | 'missing';
+  inputType?: 'text' | 'select' | 'radio' | 'checkbox';
+  options?: string[];
+  required?: boolean;
+  inferredFrom?: string;
+};
+
+export type GapSection = {
+  id: string;
+  title: string;
+  fields: GapField[];
+};
+
+export type ReviewSection = {
+  id: string;
+  title: string;
+  fields: ReviewField[];
+};
+
+const PAGE_SIZE = 5;
+
+type LegacyGapInput = {
+  sections?: GapSection[];
+  missingFields?: GapField[];
+};
+
+type LegacyReviewInput = {
+  sections?: ReviewSection[];
+  fields?: ReviewField[];
+};
+
+function chunk<T>(items: T[], size: number): T[][] {
+  if (items.length === 0) return [];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+export function adaptGapSections(input: LegacyGapInput | undefined): GapSection[] {
+  if (!input) return [];
+  const flat: GapField[] = input.missingFields?.length
+    ? input.missingFields
+    : (input.sections ?? []).flatMap((s) => s.fields);
+  return chunk(flat, PAGE_SIZE).map((fields, i) => ({
+    id: `page-${i}`,
+    title: '',
+    fields,
+  }));
+}
+
+export function adaptReviewSections(input: LegacyReviewInput | undefined): ReviewSection[] {
+  if (!input) return [];
+  const flat: ReviewField[] = input.fields?.length
+    ? input.fields
+    : (input.sections ?? []).flatMap((s) => s.fields);
+  return chunk(flat, PAGE_SIZE).map((fields, i) => ({
+    id: `page-${i}`,
+    title: '',
+    fields,
+  }));
+}

--- a/tests/client/form-cards-adapter.test.ts
+++ b/tests/client/form-cards-adapter.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest';
+import {
+  adaptGapSections,
+  adaptReviewSections,
+} from '@/lib/types/form-cards';
+
+describe('adaptGapSections', () => {
+  test('returns empty array when input is undefined', () => {
+    expect(adaptGapSections(undefined)).toEqual([]);
+  });
+
+  test('returns empty array when no fields are provided', () => {
+    expect(adaptGapSections({})).toEqual([]);
+    expect(adaptGapSections({ missingFields: [] })).toEqual([]);
+  });
+
+  test('chunks a flat missingFields list into pages of 5 in order', () => {
+    const fields = Array.from({ length: 14 }, (_, i) => ({ field: `f${i + 1}` }));
+    const pages = adaptGapSections({ missingFields: fields });
+    expect(pages).toHaveLength(3);
+    expect(pages[0]).toEqual({
+      id: 'page-0',
+      title: '',
+      fields: fields.slice(0, 5),
+    });
+    expect(pages[1]).toEqual({
+      id: 'page-1',
+      title: '',
+      fields: fields.slice(5, 10),
+    });
+    expect(pages[2]).toEqual({
+      id: 'page-2',
+      title: '',
+      fields: fields.slice(10, 14),
+    });
+  });
+
+  test('flattens legacy sections shape preserving order, then chunks by 5', () => {
+    const pages = adaptGapSections({
+      sections: [
+        { id: 's1', title: 'Identity', fields: [{ field: 'a' }, { field: 'b' }, { field: 'c' }] },
+        { id: 's2', title: 'Income', fields: [{ field: 'd' }, { field: 'e' }, { field: 'f' }, { field: 'g' }] },
+      ],
+    });
+    expect(pages).toHaveLength(2);
+    expect(pages[0].fields.map((f) => f.field)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(pages[1].fields.map((f) => f.field)).toEqual(['f', 'g']);
+    // Original section titles are discarded; pages have empty titles.
+    expect(pages.every((p) => p.title === '')).toBe(true);
+  });
+});
+
+describe('adaptReviewSections', () => {
+  test('returns empty array when input is undefined', () => {
+    expect(adaptReviewSections(undefined)).toEqual([]);
+  });
+
+  test('chunks a flat fields list into pages of 5 in order', () => {
+    const fields = Array.from({ length: 12 }, (_, i) => ({
+      field: `r${i + 1}`,
+      source: 'database' as const,
+    }));
+    const pages = adaptReviewSections({ fields });
+    expect(pages).toHaveLength(3);
+    expect(pages.map((p) => p.fields.length)).toEqual([5, 5, 2]);
+    expect(pages[0].id).toBe('page-0');
+    expect(pages[2].id).toBe('page-2');
+  });
+
+  test('flattens legacy sections shape preserving order, then chunks by 5', () => {
+    const pages = adaptReviewSections({
+      sections: [
+        {
+          id: 's1',
+          title: 'Identity',
+          fields: [
+            { field: 'a', source: 'database' as const },
+            { field: 'b', source: 'database' as const },
+            { field: 'c', source: 'database' as const },
+          ],
+        },
+        {
+          id: 's2',
+          title: 'Income',
+          fields: [
+            { field: 'd', source: 'database' as const },
+            { field: 'e', source: 'database' as const },
+            { field: 'f', source: 'database' as const },
+          ],
+        },
+      ],
+    });
+    expect(pages).toHaveLength(2);
+    expect(pages[0].fields.map((f) => f.field)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(pages[1].fields.map((f) => f.field)).toEqual(['f']);
+  });
+});

--- a/tests/client/form-summary-card.test.tsx
+++ b/tests/client/form-summary-card.test.tsx
@@ -1,0 +1,74 @@
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { FormSummaryCard } from '@/components/ai-elements/form-summary-card';
+
+const SECTIONS = [
+  {
+    id: 'identity',
+    title: 'Identity & eligibility',
+    fields: [
+      { field: 'Full name', value: 'Rosa Martinez', source: 'database' as const },
+      { field: 'SSN', value: '', source: 'missing' as const, required: true, inputType: 'text' as const },
+    ],
+  },
+];
+
+test('renders summary with Start review and Skip buttons', async () => {
+  const { getByRole } = render(
+    <FormSummaryCard formName="CalFresh" sections={SECTIONS} sendMessage={vi.fn()} />
+  );
+  await expect.element(getByRole('button', { name: /start review/i })).toBeInTheDocument();
+  await expect.element(getByRole('button', { name: /skip for now/i })).toBeInTheDocument();
+});
+
+test('Start review opens the editable modal at the first missing-required section', async () => {
+  const { getByRole, getByText } = render(
+    <FormSummaryCard formName="CalFresh" sections={SECTIONS} sendMessage={vi.fn()} />
+  );
+  await getByRole('button', { name: /start review/i }).click();
+  await expect.element(getByText('Identity & eligibility')).toBeInTheDocument();
+  await expect.element(getByRole('button', { name: /^submit$/i })).toBeInTheDocument();
+});
+
+test('readonly with data shows View responses', async () => {
+  const { getByRole } = render(
+    <FormSummaryCard
+      formName="CalFresh"
+      sections={SECTIONS}
+      sendMessage={vi.fn()}
+      isReadonly
+    />
+  );
+  await expect.element(getByRole('button', { name: /view responses/i })).toBeInTheDocument();
+});
+
+test('View responses opens a read-only modal (no Submit button)', async () => {
+  const { getByRole } = render(
+    <FormSummaryCard
+      formName="CalFresh"
+      sections={SECTIONS}
+      sendMessage={vi.fn()}
+      isReadonly
+    />
+  );
+  await getByRole('button', { name: /view responses/i }).click();
+  // Submit button must not be present in read-only mode; Done is shown instead.
+  await expect.element(getByRole('button', { name: /^submit$/i })).not.toBeInTheDocument();
+  await expect.element(getByRole('button', { name: /^done$/i })).toBeInTheDocument();
+});
+
+test('Submit posts changed values back to sendMessage', async () => {
+  const sendMessage = vi.fn();
+  const { getByRole } = render(
+    <FormSummaryCard formName="CalFresh" sections={SECTIONS} sendMessage={sendMessage} />
+  );
+  await getByRole('button', { name: /start review/i }).click();
+  // Target the SSN input by its required-empty placeholder; the populated
+  // Full name row also renders an editable input in the modal.
+  await getByRole('textbox', { name: /required — enter a value/i }).fill('123-45-6789');
+  await getByRole('button', { name: /^submit$/i }).click();
+  expect(sendMessage).toHaveBeenCalledTimes(1);
+  const text = sendMessage.mock.calls[0][0].parts[0].text;
+  expect(text).toContain('Please update the following form fields for CalFresh');
+  expect(text).toContain('SSN: 123-45-6789');
+});

--- a/tests/client/gap-analysis-card.test.tsx
+++ b/tests/client/gap-analysis-card.test.tsx
@@ -1,0 +1,59 @@
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { GapAnalysisCard } from '@/components/ai-elements/gap-analysis-card';
+
+const SECTIONS = [
+  {
+    id: 'identity',
+    title: 'Identity & eligibility',
+    fields: [
+      { field: 'Social Security Number', inputType: 'text' as const, required: true },
+    ],
+  },
+];
+
+test('renders the summary CTA with Provide answers and Skip buttons', async () => {
+  const sendMessage = vi.fn();
+  const { getByRole } = render(
+    <GapAnalysisCard sections={SECTIONS} sendMessage={sendMessage} />
+  );
+  await expect.element(getByRole('button', { name: /provide answers/i })).toBeInTheDocument();
+  await expect.element(getByRole('button', { name: /skip for now/i })).toBeInTheDocument();
+});
+
+test('Skip for now sends a message and switches to the skipped state', async () => {
+  const sendMessage = vi.fn();
+  const { getByRole } = render(
+    <GapAnalysisCard sections={SECTIONS} sendMessage={sendMessage} />
+  );
+  await getByRole('button', { name: /skip for now/i }).click();
+  expect(sendMessage).toHaveBeenCalledTimes(1);
+  // Skipped CTA shows an enabled "Provide answers" so the user can come back.
+  await expect.element(getByRole('button', { name: /provide answers/i })).toBeInTheDocument();
+});
+
+test('Provide answers opens the modal and Submit posts the answers', async () => {
+  const sendMessage = vi.fn();
+  const { getByRole } = render(
+    <GapAnalysisCard
+      formName="CalFresh"
+      sections={SECTIONS}
+      sendMessage={sendMessage}
+    />
+  );
+  await getByRole('button', { name: /provide answers/i }).click();
+  await getByRole('textbox').fill('123-45-6789');
+  await getByRole('button', { name: /^submit$/i }).click();
+  expect(sendMessage).toHaveBeenCalledTimes(1);
+  const args = sendMessage.mock.calls[0][0];
+  expect(args.parts[0].text).toContain('Answers for CalFresh');
+  expect(args.parts[0].text).toContain('123-45-6789');
+});
+
+test('readonly disables the CTA buttons', async () => {
+  const { getByRole } = render(
+    <GapAnalysisCard sections={SECTIONS} sendMessage={vi.fn()} isReadonly />
+  );
+  await expect.element(getByRole('button', { name: /provide answers/i })).toBeDisabled();
+  await expect.element(getByRole('button', { name: /skip for now/i })).toBeDisabled();
+});


### PR DESCRIPTION
## Summary

Brings the gap & review card redesign, Anthropic prompt caching, agent prompt fixes, and the Stop-button-halts-tool-loop fix from `develop` to `main`. Leaves the broken skills→references rewrite and architectural prompt restructure on `develop` for future work.

## What's included

- **`bfb6791`** — Anthropic prompt caching on system prompt (#233 cherry-pick). Splits prompt into a stable cached body + uncached daily date string so cache hits survive across days.
- **`a806f5f`** — gapAnalysis end-of-turn fix (#231 cherry-pick). Opus 4.7 was ignoring the STOP rule that lived only in the lazy-loaded skill; moves it into the main system prompt + tightens tool description.
- **`81bd22b`** — Card redesign squash. Final dev state of `gap-analysis-card.tsx`, `form-summary-card.tsx`, new `form-card-shared.tsx`, `lib/types/form-cards.ts`, updated `gap-analysis.ts`/`form-summary.ts` tool schemas, call-site wiring (`hasUserReplyAfter` prop), unit tests. **Restores `PencilEditIcon`/`MessageActions`/`Button`/`Tooltip` imports in `message.tsx` that were stripped on dev (would fail typecheck without).**
- **`1501bbc`** — Inline translation of dev's harsh-submit-language (`eb2d367`) and formSummary CAPTCHA exclusions (`89cab98`). Dev's originals edited `browser-and-forms.ts` and `application-protocol.ts` which don't exist on main, so applied the equivalent guidance to `web-automation.ts`'s Review Screen section.
- **`2ab10b8`** — Stop button actually halts the tool loop. Adds chat-abort-registry + `POST /api/chat/stop` endpoint, wires `chatAbort.signal.aborted` into `stopWhen` (instead of `abortSignal: request.signal` which Cloud Run's HTTP/1.1 LB doesn't propagate). Includes paired `chat.tsx` (`stoppedRef` + `sendAutomaticallyWhen` guard, model-override hoisted into transport body), `multimodal-input.tsx` cleanup, and new `ContextUsage` component.

## What's NOT included (intentionally left on dev)

- The skills→references architectural rewrite (`a812393` "skills redone", deletion of `loadSkill`/`readSkillFile`/`agentBrowserSkill`, new `read-reference.ts`)
- The new prompt files `application-protocol.ts` and `browser-and-forms.ts` (born from the rewrite)
- `web-automation.ts` restructure (the version that imports the new files)
- Removal of pre-compaction logic in chat route (kept main's `preCompactMessages` flow)

These appear to be involved in the agent-behavior failures currently happening on dev.

## Test plan

- [ ] CI passes (typecheck, lint, vitest, next build) — local validation skipped
- [ ] Card unit tests pass (`tests/client/form-cards-adapter.test.ts`, `tests/client/form-summary-card.test.tsx`, `tests/client/gap-analysis-card.test.tsx`)
- [ ] Manual smoke: gap analysis card renders with sectioned modal, page-1 always opens, source badges show
- [ ] Manual smoke: form summary card renders with sections and source badges
- [ ] Manual smoke: Anthropic prompt cache hit on second turn (check token usage in BigQuery — `cache_read_input_tokens > 0`)
- [ ] Manual smoke: pressing Stop during a long tool loop actually halts the agent (no auto-continue)
- [ ] Manual smoke: ContextUsage shows in input bar with live token counts

## Parent PR

navapbc/labs-asp `feat/cards-and-safe-merge` bumps the submodule to this branch's tip. **This PR must merge first.**