### PR TITLE
feat: enable submit workflow

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -198,7 +198,13 @@ export async function POST(request: Request) {
             formSummary,
             actionLabel,
             browser: createBrowserTool(sessionId, session.user.id),
-            enableSubmit: createEnableSubmitTool(sessionId, session.user.id),
+            enableSubmit: createEnableSubmitTool(sessionId, session.user.id, (label) => {
+              dataStream.write({
+                type: 'data-submit-progress',
+                data: { label, timestamp: Date.now() },
+                transient: true,
+              });
+            }),
             readReference,
           },
           // request.signal.aborted is checked at each step boundary so the

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -29,6 +29,7 @@ import { after } from 'next/server';
 import { ChatSDKError } from '@/lib/errors';
 import { apricotTools } from '@/lib/ai/tools/apricot';
 import { createBrowserTool } from '@/lib/ai/tools/browser';
+import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
 import { gapAnalysis } from '@/lib/ai/tools/gap-analysis';
 import { formSummary } from '@/lib/ai/tools/form-summary';
 import { actionLabel } from '@/lib/ai/tools/action-label';
@@ -197,6 +198,7 @@ export async function POST(request: Request) {
             formSummary,
             actionLabel,
             browser: createBrowserTool(sessionId, session.user.id),
+            enableSubmit: createEnableSubmitTool(sessionId, session.user.id),
             readReference,
           },
           // request.signal.aborted is checked at each step boundary so the

--- a/lib/ai/prompts/browser-and-forms.ts
+++ b/lib/ai/prompts/browser-and-forms.ts
@@ -181,23 +181,10 @@ Re-snapshot to get fresh refs. If the snapshot shows \`[id="..."]\` on the targe
 
 ## Form Submission Protocol
 
-This protocol's only goal is to **enable** the submit button so the caseworker can review and click it themselves. It does NOT submit the form. Read this carefully — the distinction matters:
+If the submit button is disabled, call \`enableSubmit\`. It runs the diagnose-and-enable sequence deterministically and returns one of: \`enabled\`, \`enabled-via-force\` (relay the warning to the caseworker), \`blocked-missing-fields\` (route the listed fields through \`gapAnalysis\`), \`pending-turnstile\` (relay the message and wait), or \`blocked-unknown\` (surface to the caseworker). Do NOT run the steps yourself — the tool's job is to enable; your job is still only to call \`formSummary\` and hand off.
 
-- **Allowed**: inspecting the DOM (reading the \`disabled\` attribute, checking the Turnstile token field, reading gating JS variables), and as a last resort flipping the \`disabled\` attribute via \`evaluate\`.
-- **Forbidden**: clicking the submit button, calling \`.click()\` on it via \`evaluate\`, calling \`form.submit()\`, or dispatching submit events. See Forbidden Actions below.
+After \`enableSubmit\` returns \`enabled\` or \`enabled-via-force\`, do NOT click the submit button. Proceed with \`formSummary\` so the caseworker can review and submit.
 
-If the caseworker asks you to "enable the button" or "make submit clickable," that is NOT a request to submit — proceed. If they ask you to "submit," "send," or "click submit," refuse and hand off to \`formSummary\`.
-
-When the submit button is disabled, follow these steps IN ORDER. Do NOT use \`evaluate\` before completing steps 1–3.
-
-1. **Check for missing fields**: Snapshot and verify all required fields are filled.
-2. **Check for expand/acknowledge sections**: Look for collapsible sections ("+ Expand", "Please expand and read"). Click them using refs. If no ref available, use ONE evaluate: \`{ action: "evaluate", script: "document.querySelector('.header').click();" }\` then wait 700ms.
-3. **Wait for the Turnstile/reCAPTCHA auto-solver**: The browser auto-solves these challenges — do NOT click challenge widgets. Auto-solving can take 10–30 seconds. Use \`{ action: "wait", timeout: 8000 }\`, re-snapshot, and check whether submit is now enabled. If still disabled, wait another 8000ms (up to ~30s total) before moving on. Most disabled-submit cases resolve here.
-4. **Verification checklist**: Fresh snapshot. Confirm: (a) all required fields filled, (b) expand sections open, (c) no error messages. Just observe — no corrective actions.
-5. **Diagnose before forcing**: If still disabled after ~30s of waiting, inspect the gate before flipping anything. Read the Turnstile token: \`{ action: "evaluate", script: "document.querySelector('[name=cf-turnstile-response]')?.value || 'EMPTY'" }\`. If the token is EMPTY, the auto-solver has not finished — **do not force-enable**. Report to the caseworker: "Submit is gated on Turnstile and the token is still empty. Please wait ~30s for it to auto-solve, then take control to submit." If the token is present but submit is still disabled, call \`readReference({ path: "form-submission.md" })\` for advanced JS debugging.
-6. **Force-enable as last resort only**: If diagnosis shows the gate is purely client-side JS (not a missing Turnstile token), follow the reference's Step 6 to satisfy the gating variables AND remove \`disabled\`. Just running \`document.getElementById('btnSubmit').disabled = false\` is insufficient — the page's JS may re-disable it, and if a server-side token is missing the submission will be rejected. **When you force-enable, explicitly tell the caseworker**: "I enabled the button in the DOM, but the Turnstile token is [present/empty]. If empty, the server may reject the submission — wait for the token to populate before submitting."
-
-After the button is enabled, do NOT click it. Proceed with \`formSummary\` so the caseworker can review and submit.
 
 ## Forbidden Actions
 
@@ -225,5 +212,4 @@ Use \`readReference\` to load:
 - \`field-patterns.md\` — JSON examples for text, date, SSN, phone, state, dropdowns, checkboxes, radios
 - \`custom-dropdowns.md\` — Select2 / Chosen / Drupal custom widget patterns
 - \`browser-commands.md\` — Full command reference with all actions, flags, and options
-- \`form-submission.md\` — Advanced JS debugging for stuck submit buttons
 `;

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -15,7 +15,7 @@ const COMMAND_TIMEOUT_MS = 120_000; // 2 minutes
  */
 const sessionQueues = new Map<string, Promise<unknown>>();
 
-function withSessionQueue<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+export function withSessionQueue<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
   const prev = sessionQueues.get(sessionId) ?? Promise.resolve();
   const next = prev.then(fn, fn); // always advance the queue even on error
   sessionQueues.set(sessionId, next.then(() => {}, () => {})); // swallow to prevent unhandled rejection on queue chain

--- a/lib/ai/tools/enable-submit-gates.ts
+++ b/lib/ai/tools/enable-submit-gates.ts
@@ -11,6 +11,7 @@ const cssSelectorForJs = (selector: string): string => {
   return `document.querySelector(${JSON.stringify(selector)})`;
 };
 
+// Order matters: more specific gates first; the catch-all (match: () => true) MUST remain last.
 export const submitGates: SubmitGate[] = [
   {
     name: 'expand-and-captcha-flags',

--- a/lib/ai/tools/enable-submit-gates.ts
+++ b/lib/ai/tools/enable-submit-gates.ts
@@ -1,0 +1,31 @@
+export type SubmitGate = {
+  name: string;
+  match: (snapshot: string) => boolean;
+  script: (selector: string) => string;
+};
+
+const cssSelectorForJs = (selector: string): string => {
+  if (selector.startsWith('@')) {
+    return `Array.from(document.querySelectorAll('button,input[type=submit]')).find(el => /submit|apply|send|finish/i.test(el.textContent || el.value || ''))`;
+  }
+  return `document.querySelector(${JSON.stringify(selector)})`;
+};
+
+export const submitGates: SubmitGate[] = [
+  {
+    name: 'expand-and-captcha-flags',
+    match: (snap) => /captcha|recaptcha|turnstile/i.test(snap) || /expand/i.test(snap),
+    script: (selector) => {
+      const target = cssSelectorForJs(selector);
+      return `(function(){try{if(typeof isExpanded!=='undefined') isExpanded=true;}catch(e){} try{if(typeof isCaptchaChecked!=='undefined') isCaptchaChecked=true;}catch(e){} const el=${target}; if(el){el.removeAttribute('disabled'); el.disabled=false;}})()`;
+    },
+  },
+  {
+    name: 'generic-disabled-attr',
+    match: () => true,
+    script: (selector) => {
+      const target = cssSelectorForJs(selector);
+      return `(function(){const el=${target}; if(!el) return; el.removeAttribute('disabled'); el.disabled=false;})()`;
+    },
+  },
+];

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -280,7 +280,7 @@ export async function phase6ForceEnable(input: Phase6Input): Promise<{ outcome: 
       return {
         outcome: {
           status: 'enabled-via-force',
-          warning: `I enabled the button by satisfying client-side gating (pattern: ${gate.name}). The Turnstile token is present; the server should accept the submission.`,
+          warning: `The submit button was enabled by satisfying client-side gating (pattern: ${gate.name}). The Turnstile token is present; the server should accept the submission.`,
         },
       };
     }

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { EnableSubmitResult, EmitFn } from './enable-submit-types';
+import { submitGates } from './enable-submit-gates';
 
 export type RunCommand = (cmd: Record<string, unknown>) => Promise<{
   success: boolean;
@@ -247,4 +248,49 @@ export async function phase5Diagnose({
     };
   }
   return { outcome: null, tokenPresent: true };
+}
+
+export type Phase6Input = PhaseInput & {
+  submitSelector: string;
+  tokenPresent: boolean;
+  lastSnapshot: string;
+};
+
+export async function phase6ForceEnable(input: Phase6Input): Promise<{ outcome: EnableSubmitResult | null }> {
+  if (!input.tokenPresent) {
+    return {
+      outcome: {
+        status: 'pending-turnstile',
+        message: 'Turnstile token is still empty — refusing to force-enable.',
+      },
+    };
+  }
+
+  for (const gate of submitGates) {
+    if (!gate.match(input.lastSnapshot)) continue;
+
+    await input.runCommand({ action: 'evaluate', script: gate.script(input.submitSelector) });
+    const snap = await input.runCommand({ action: 'snapshot', selector: 'form' });
+    if (!snap.success || !snap.output) continue;
+
+    if (!snapshotShowsDisabled(snap.output, input.submitSelector)) {
+      return {
+        outcome: {
+          status: 'enabled-via-force',
+          warning: `I enabled the button by satisfying client-side gating (pattern: ${gate.name}). The Turnstile token is present; the server should accept the submission.`,
+        },
+      };
+    }
+  }
+
+  return {
+    outcome: {
+      status: 'blocked-unknown',
+      diagnostic: {
+        reason: 'no-gate-pattern-matched',
+        tokenPresent: input.tokenPresent,
+        submitSelector: input.submitSelector,
+      },
+    },
+  };
 }

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -122,3 +122,54 @@ export async function phase1CheckRequiredFields({
     return { outcome: null };
   }
 }
+
+export type Phase2Output = { outcome: EnableSubmitResult | null };
+
+const expandSchema = z.object({
+  refs: z.array(z.string()).describe('Refs (like @e5) of collapsible sections that look unopened.'),
+});
+
+const PHASE2_PROMPT = `Find collapsible sections in this form snapshot that look UNOPENED and likely need to be expanded for the form to submit.
+
+Look for:
+- Buttons/links with labels like "+ Expand", "Show more", "Please expand and read"
+- Sections marked with chevrons or +/- icons in a closed state
+- Acknowledgment blocks the user must open to read
+
+Return the refs (like @e5) of each. If none, return an empty list.`;
+
+export async function phase2ExpandSections({
+  runCommand,
+  _generateText,
+  _model,
+}: PhaseInput): Promise<Phase2Output> {
+  const snap = await runCommand({ action: 'snapshot', selector: 'form' });
+  if (!snap.success || !snap.output) {
+    return { outcome: { status: 'browser-error', error: snap.error ?? 'snapshot failed' } };
+  }
+
+  const ai = await import('ai');
+  const gen: GenerateTextFn = _generateText ?? ai.generateText;
+  const model = _model ?? (await import('@/lib/ai/providers')).prepareStepModel;
+
+  let refs: string[];
+  try {
+    const result = await gen({
+      model,
+      prompt: `${PHASE2_PROMPT}\n\nSNAPSHOT:\n${snap.output}`,
+      output: ai.Output.object({ schema: expandSchema }),
+    });
+    refs = result.output.refs;
+  } catch (err) {
+    console.warn('[enable-submit] phase2 generateText failed; skipping expand', err);
+    return { outcome: null };
+  }
+
+  if (refs.length === 0) return { outcome: null };
+
+  for (const ref of refs) {
+    await runCommand({ action: 'click', selector: ref });
+  }
+  await runCommand({ action: 'snapshot', selector: 'form' });
+  return { outcome: null };
+}

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -217,3 +217,34 @@ export async function phase3WaitForTurnstile(
 
   return { outcome: null };
 }
+
+export async function phase4Verify({
+  runCommand,
+  submitSelector,
+}: PhaseInput & { submitSelector: string }): Promise<{ outcome: EnableSubmitResult | null }> {
+  const snap = await runCommand({ action: 'snapshot', selector: 'form' });
+  if (!snap.success || !snap.output) {
+    return { outcome: { status: 'browser-error', error: snap.error ?? 'snapshot failed' } };
+  }
+  if (!snapshotShowsDisabled(snap.output, submitSelector)) {
+    return { outcome: { status: 'enabled' } };
+  }
+  return { outcome: null };
+}
+
+const PENDING_TURNSTILE_MESSAGE = 'Turnstile token is still empty — wait ~30s and try again.';
+
+export async function phase5Diagnose({
+  runCommand,
+}: PhaseInput): Promise<{ outcome: EnableSubmitResult | null; tokenPresent: boolean }> {
+  const tokenRes = await runCommand({ action: 'evaluate', script: TOKEN_READ_SCRIPT });
+  const tokenPresent = !!(tokenRes.success && tokenRes.output && tokenRes.output.length > 0);
+
+  if (!tokenPresent) {
+    return {
+      outcome: { status: 'pending-turnstile', message: PENDING_TURNSTILE_MESSAGE },
+      tokenPresent: false,
+    };
+  }
+  return { outcome: null, tokenPresent: true };
+}

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -7,12 +7,13 @@ export type RunCommand = (cmd: Record<string, unknown>) => Promise<{
   error?: string | null;
 }>;
 
-export type GenerateObjectFn = typeof import('ai').generateObject;
+export type GenerateTextFn = typeof import('ai').generateText;
 
 export type PhaseInput = {
   runCommand: RunCommand;
   submitSelector?: string;
-  _generateObject?: GenerateObjectFn;
+  // Underscore-prefixed fields are test-only injection points; production calls leave them undefined.
+  _generateText?: GenerateTextFn;
   _model?: import('ai').LanguageModel;
 };
 
@@ -91,26 +92,33 @@ Return the human-readable LABEL (not the ref) of each required field that:
 Return ONLY labels. Ignore optional fields. Ignore CAPTCHA/Turnstile widgets.
 If everything looks filled, return an empty list.`;
 
-export async function phase1CheckRequiredFields({ runCommand, _generateObject, _model }: PhaseInput): Promise<Phase1Output> {
+export async function phase1CheckRequiredFields({
+  runCommand,
+  _generateText,
+  _model,
+}: PhaseInput): Promise<Phase1Output> {
   const snap = await runCommand({ action: 'snapshot', selector: 'form' });
   if (!snap.success || !snap.output) {
     return { outcome: { status: 'browser-error', error: snap.error ?? 'snapshot failed' } };
   }
 
-  const go: GenerateObjectFn = _generateObject ?? (await import('ai')).generateObject;
+  const ai = await import('ai');
+  const gen: GenerateTextFn = _generateText ?? ai.generateText;
   const model = _model ?? (await import('@/lib/ai/providers')).prepareStepModel;
+
   try {
-    const { object } = await go({
+    const result = await gen({
       model,
-      schema: missingFieldsSchema,
       prompt: `${PHASE1_PROMPT}\n\nSNAPSHOT:\n${snap.output}`,
+      output: ai.Output.object({ schema: missingFieldsSchema }),
     });
-    if (object.missing.length > 0) {
-      return { outcome: { status: 'blocked-missing-fields', fields: object.missing } };
+    const missing = result.output.missing;
+    if (missing.length > 0) {
+      return { outcome: { status: 'blocked-missing-fields', fields: missing } };
     }
     return { outcome: null };
   } catch (err) {
-    console.warn('[enable-submit] phase1 generateObject failed; assuming no missing fields', err);
+    console.warn('[enable-submit] phase1 generateText failed; assuming no missing fields', err);
     return { outcome: null };
   }
 }

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -19,19 +19,30 @@ export type Phase0Output = {
 const SUBMIT_LABEL_RE = /submit|apply|send|finish/i;
 
 function parseRefFromSnapshot(snapshot: string): string | null {
-  for (const line of snapshot.split('\n')) {
-    if (!line.includes('[button')) continue;
-    if (!SUBMIT_LABEL_RE.test(line)) continue;
-    const match = line.match(/^@e\d+/);
-    if (match) return match[0];
+  const candidates: { ref: string; disabled: boolean }[] = [];
+  for (const rawLine of snapshot.split('\n')) {
+    const line = rawLine.trimStart();
+    const match = line.match(/^-?\s*button\s+"([^"]*)".*\[ref=(e\d+)\]/);
+    if (!match) continue;
+    const [, label, refNum] = match;
+    if (!SUBMIT_LABEL_RE.test(label)) continue;
+    const disabled = /\[disabled\]/i.test(line);
+    candidates.push({ ref: `@${refNum}`, disabled });
   }
-  return null;
+  if (candidates.length === 0) return null;
+  const disabledOne = candidates.find((c) => c.disabled);
+  return disabledOne ? disabledOne.ref : candidates[candidates.length - 1].ref;
 }
 
-function snapshotShowsDisabled(snapshot: string, ref: string): boolean {
-  const line = snapshot.split('\n').find((l) => l.trim().startsWith(ref));
-  if (!line) return false;
-  return line.includes('disabled');
+function snapshotShowsDisabled(snapshot: string, selector: string): boolean {
+  if (selector.startsWith('@e')) {
+    const refNum = selector.slice(1);
+    const pattern = new RegExp(`\\[ref=${refNum}\\b[^\\]]*\\]`);
+    const line = snapshot.split('\n').find((l) => pattern.test(l));
+    if (!line) return false;
+    return /\[disabled\]/i.test(line);
+  }
+  return false;
 }
 
 export async function phase0LocateButton({

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { EnableSubmitResult } from './enable-submit-types';
 
 export type RunCommand = (cmd: Record<string, unknown>) => Promise<{
@@ -6,9 +7,13 @@ export type RunCommand = (cmd: Record<string, unknown>) => Promise<{
   error?: string | null;
 }>;
 
+export type GenerateObjectFn = typeof import('ai').generateObject;
+
 export type PhaseInput = {
   runCommand: RunCommand;
   submitSelector?: string;
+  _generateObject?: GenerateObjectFn;
+  _model?: import('ai').LanguageModel;
 };
 
 export type Phase0Output = {
@@ -69,4 +74,43 @@ export async function phase0LocateButton({
   }
 
   return { outcome: null, submitSelector: selector };
+}
+
+export type Phase1Output = { outcome: EnableSubmitResult | null };
+
+const missingFieldsSchema = z.object({
+  missing: z.array(z.string()).describe('Human-readable labels of required fields that are empty or have an error message.'),
+});
+
+const PHASE1_PROMPT = `You are reviewing a form snapshot to find required fields that are NOT filled in correctly.
+
+Return the human-readable LABEL (not the ref) of each required field that:
+- Is marked required (asterisk, "required" text, aria-required) AND is empty, OR
+- Has a visible error message indicating an invalid or missing value.
+
+Return ONLY labels. Ignore optional fields. Ignore CAPTCHA/Turnstile widgets.
+If everything looks filled, return an empty list.`;
+
+export async function phase1CheckRequiredFields({ runCommand, _generateObject, _model }: PhaseInput): Promise<Phase1Output> {
+  const snap = await runCommand({ action: 'snapshot', selector: 'form' });
+  if (!snap.success || !snap.output) {
+    return { outcome: { status: 'browser-error', error: snap.error ?? 'snapshot failed' } };
+  }
+
+  const go: GenerateObjectFn = _generateObject ?? (await import('ai')).generateObject;
+  const model = _model ?? (await import('@/lib/ai/providers')).prepareStepModel;
+  try {
+    const { object } = await go({
+      model,
+      schema: missingFieldsSchema,
+      prompt: `${PHASE1_PROMPT}\n\nSNAPSHOT:\n${snap.output}`,
+    });
+    if (object.missing.length > 0) {
+      return { outcome: { status: 'blocked-missing-fields', fields: object.missing } };
+    }
+    return { outcome: null };
+  } catch (err) {
+    console.warn('[enable-submit] phase1 generateObject failed; assuming no missing fields', err);
+    return { outcome: null };
+  }
 }

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { EnableSubmitResult } from './enable-submit-types';
+import type { EnableSubmitResult, EmitFn } from './enable-submit-types';
 
 export type RunCommand = (cmd: Record<string, unknown>) => Promise<{
   success: boolean;
@@ -171,5 +171,49 @@ export async function phase2ExpandSections({
     await runCommand({ action: 'click', selector: ref });
   }
   await runCommand({ action: 'snapshot', selector: 'form' });
+  return { outcome: null };
+}
+
+export type Phase3Opts = {
+  tickMs?: number;
+  maxTicks?: number;
+  emit?: EmitFn;
+  _sleep?: (ms: number) => Promise<void>;
+};
+
+const TOKEN_READ_SCRIPT = "document.querySelector('[name=cf-turnstile-response]')?.value || ''";
+
+function disabledReadScript(selector: string): string {
+  if (selector.startsWith('@')) {
+    return `(function(){const els=document.querySelectorAll('button,input[type=submit]');for(const el of els){if(/submit|apply|send|finish/i.test(el.textContent||el.value||'')){return el.disabled?'true':'false';}}return 'unknown';})()`;
+  }
+  return `document.querySelector(${JSON.stringify(selector)})?.disabled === true ? 'true' : 'false'`;
+}
+
+export async function phase3WaitForTurnstile(
+  input: PhaseInput & { submitSelector: string },
+  opts: Phase3Opts = {},
+): Promise<{ outcome: EnableSubmitResult | null }> {
+  const tickMs = opts.tickMs ?? 8000;
+  const maxTicks = opts.maxTicks ?? 4;
+  const emit = opts.emit ?? (() => {});
+  const sleep = opts._sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  for (let tick = 1; tick <= maxTicks; tick++) {
+    emit(`Waiting for security check (${(tickMs * tick) / 1000}s)`);
+    await sleep(tickMs);
+
+    const tokenRes = await input.runCommand({ action: 'evaluate', script: TOKEN_READ_SCRIPT });
+    const disRes = await input.runCommand({
+      action: 'evaluate',
+      script: disabledReadScript(input.submitSelector),
+    });
+
+    if (disRes.success && disRes.output === 'false') {
+      return { outcome: { status: 'enabled' } };
+    }
+    void tokenRes;
+  }
+
   return { outcome: null };
 }

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -1,0 +1,61 @@
+import type { EnableSubmitResult } from './enable-submit-types';
+
+export type RunCommand = (cmd: Record<string, unknown>) => Promise<{
+  success: boolean;
+  output?: string;
+  error?: string | null;
+}>;
+
+export type PhaseInput = {
+  runCommand: RunCommand;
+  submitSelector?: string;
+};
+
+export type Phase0Output = {
+  outcome: EnableSubmitResult | null;
+  submitSelector?: string;
+};
+
+const SUBMIT_LABEL_RE = /submit|apply|send|finish/i;
+
+function parseRefFromSnapshot(snapshot: string): string | null {
+  for (const line of snapshot.split('\n')) {
+    if (!line.includes('[button')) continue;
+    if (!SUBMIT_LABEL_RE.test(line)) continue;
+    const match = line.match(/^@e\d+/);
+    if (match) return match[0];
+  }
+  return null;
+}
+
+function snapshotShowsDisabled(snapshot: string, ref: string): boolean {
+  const line = snapshot.split('\n').find((l) => l.trim().startsWith(ref));
+  if (!line) return false;
+  return line.includes('disabled');
+}
+
+export async function phase0LocateButton({
+  runCommand,
+  submitSelector,
+}: PhaseInput): Promise<Phase0Output> {
+  const snap = await runCommand({ action: 'snapshot', selector: 'form' });
+  if (!snap.success || !snap.output) {
+    return { outcome: { status: 'browser-error', error: snap.error ?? 'snapshot failed' } };
+  }
+
+  const selector = submitSelector ?? parseRefFromSnapshot(snap.output);
+  if (!selector) {
+    return {
+      outcome: {
+        status: 'blocked-unknown',
+        diagnostic: { reason: 'submit-button-not-found' },
+      },
+    };
+  }
+
+  if (!snapshotShowsDisabled(snap.output, selector)) {
+    return { outcome: { status: 'enabled' }, submitSelector: selector };
+  }
+
+  return { outcome: null, submitSelector: selector };
+}

--- a/lib/ai/tools/enable-submit-phases.ts
+++ b/lib/ai/tools/enable-submit-phases.ts
@@ -13,6 +13,7 @@ export type GenerateTextFn = typeof import('ai').generateText;
 export type PhaseInput = {
   runCommand: RunCommand;
   submitSelector?: string;
+  abortSignal?: AbortSignal;
   // Underscore-prefixed fields are test-only injection points; production calls leave them undefined.
   _generateText?: GenerateTextFn;
   _model?: import('ai').LanguageModel;
@@ -201,8 +202,10 @@ export async function phase3WaitForTurnstile(
   const sleep = opts._sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
 
   for (let tick = 1; tick <= maxTicks; tick++) {
+    if (input.abortSignal?.aborted) throw new Error('stopped by user');
     emit(`Waiting for security check (${(tickMs * tick) / 1000}s)`);
     await sleep(tickMs);
+    if (input.abortSignal?.aborted) throw new Error('stopped by user');
 
     const tokenRes = await input.runCommand({ action: 'evaluate', script: TOKEN_READ_SCRIPT });
     const disRes = await input.runCommand({

--- a/lib/ai/tools/enable-submit-types.ts
+++ b/lib/ai/tools/enable-submit-types.ts
@@ -1,0 +1,23 @@
+export type EnableSubmitResult =
+  | { status: 'enabled' }
+  | { status: 'enabled-via-force'; warning: string }
+  | { status: 'blocked-missing-fields'; fields: string[] }
+  | { status: 'pending-turnstile'; message: string }
+  | { status: 'blocked-unknown'; diagnostic: Record<string, unknown> }
+  | { status: 'browser-error'; error: string };
+
+export type ProgressLabel =
+  | 'Checking required fields'
+  | 'Opening sections to acknowledge'
+  | 'Trying to enable the submit button'
+  | string;
+
+export type EmitFn = (label: ProgressLabel) => void;
+
+export type EnableSubmitContext = {
+  sessionId: string;
+  userId: string;
+  submitSelector?: string;
+  abortSignal?: AbortSignal;
+  emit: EmitFn;
+};

--- a/lib/ai/tools/enable-submit.ts
+++ b/lib/ai/tools/enable-submit.ts
@@ -20,6 +20,10 @@ import {
 
 const TOOL_TIMEOUT_MS = 90_000;
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new Error('stopped by user');
+}
+
 export type OrchestratorInput = {
   runCommand: RunCommand;
   emit: EmitFn;
@@ -31,41 +35,63 @@ export type OrchestratorInput = {
 };
 
 export async function runEnableSubmit(input: OrchestratorInput): Promise<EnableSubmitResult> {
-  const { runCommand, emit, submitSelector, _generateText, _model } = input;
+  try {
+    const { runCommand, emit, submitSelector, _generateText, _model, abortSignal } = input;
 
-  const p0 = await phase0LocateButton({ runCommand, submitSelector });
-  if (p0.outcome) return p0.outcome;
-  const selector = p0.submitSelector!;
+    // Phase 0
+    throwIfAborted(abortSignal);
+    const p0 = await phase0LocateButton({ runCommand, submitSelector, abortSignal });
+    if (p0.outcome) return p0.outcome;
+    const selector = p0.submitSelector!;
 
-  emit('Checking required fields');
-  const p1 = await phase1CheckRequiredFields({ runCommand, _generateText, _model });
-  if (p1.outcome) return p1.outcome;
+    // Phase 1
+    throwIfAborted(abortSignal);
+    emit('Checking required fields');
+    const p1 = await phase1CheckRequiredFields({ runCommand, _generateText, _model, abortSignal });
+    if (p1.outcome) return p1.outcome;
 
-  emit('Opening sections to acknowledge');
-  await phase2ExpandSections({ runCommand, _generateText, _model });
+    // Phase 2
+    throwIfAborted(abortSignal);
+    emit('Opening sections to acknowledge');
+    await phase2ExpandSections({ runCommand, _generateText, _model, abortSignal });
 
-  const p3 = await phase3WaitForTurnstile(
-    { runCommand, submitSelector: selector },
-    { emit, ...(input.phase3Opts ?? {}) },
-  );
-  if (p3.outcome) return p3.outcome;
+    // Phase 3
+    throwIfAborted(abortSignal);
+    const p3 = await phase3WaitForTurnstile(
+      { runCommand, submitSelector: selector, abortSignal },
+      { emit, ...(input.phase3Opts ?? {}) },
+    );
+    if (p3.outcome) return p3.outcome;
 
-  const p4 = await phase4Verify({ runCommand, submitSelector: selector });
-  if (p4.outcome) return p4.outcome;
+    // Phase 4
+    throwIfAborted(abortSignal);
+    const p4 = await phase4Verify({ runCommand, submitSelector: selector });
+    if (p4.outcome) return p4.outcome;
 
-  const p5 = await phase5Diagnose({ runCommand });
-  if (p5.outcome) return p5.outcome;
+    // Phase 5
+    throwIfAborted(abortSignal);
+    const p5 = await phase5Diagnose({ runCommand });
+    if (p5.outcome) return p5.outcome;
 
-  emit('Trying to enable the submit button');
-  const snap = await runCommand({ action: 'snapshot', selector: 'form' });
-  const lastSnapshot = snap.output ?? '';
-  const p6 = await phase6ForceEnable({
-    runCommand,
-    submitSelector: selector,
-    tokenPresent: p5.tokenPresent,
-    lastSnapshot,
-  });
-  return p6.outcome ?? { status: 'blocked-unknown', diagnostic: { reason: 'no-result' } };
+    // Phase 6
+    throwIfAborted(abortSignal);
+    emit('Trying to enable the submit button');
+    const snap = await runCommand({ action: 'snapshot', selector: 'form' });
+    const lastSnapshot = snap.output ?? '';
+    const p6 = await phase6ForceEnable({
+      runCommand,
+      submitSelector: selector,
+      tokenPresent: p5.tokenPresent,
+      lastSnapshot,
+    });
+    return p6.outcome ?? { status: 'blocked-unknown', diagnostic: { reason: 'no-result' } };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (input.abortSignal?.aborted || message.includes('stopped by user')) {
+      return { status: 'browser-error', error: 'stopped by user' };
+    }
+    throw err;
+  }
 }
 
 export const createEnableSubmitTool = (

--- a/lib/ai/tools/enable-submit.ts
+++ b/lib/ai/tools/enable-submit.ts
@@ -1,6 +1,72 @@
 import { tool, type ToolExecutionOptions } from 'ai';
+import { nanoid } from 'nanoid';
 import { z } from 'zod';
-import type { EnableSubmitResult } from './enable-submit-types';
+import { executeCommand } from 'agent-browser/dist/actions.js';
+import type { Command } from 'agent-browser/dist/types.js';
+import { getOrCreateBrowser } from '@/lib/kernel/browser';
+import { withSessionQueue } from './browser';
+import type { EnableSubmitResult, EmitFn } from './enable-submit-types';
+import {
+  phase0LocateButton,
+  phase1CheckRequiredFields,
+  phase2ExpandSections,
+  phase3WaitForTurnstile,
+  phase4Verify,
+  phase5Diagnose,
+  phase6ForceEnable,
+  type RunCommand,
+  type Phase3Opts,
+} from './enable-submit-phases';
+
+const TOOL_TIMEOUT_MS = 90_000;
+
+export type OrchestratorInput = {
+  runCommand: RunCommand;
+  emit: EmitFn;
+  abortSignal: AbortSignal | undefined;
+  submitSelector?: string;
+  _generateText?: import('./enable-submit-phases').GenerateTextFn;
+  _model?: import('ai').LanguageModel;
+  phase3Opts?: Pick<Phase3Opts, 'tickMs' | 'maxTicks' | '_sleep'>;
+};
+
+export async function runEnableSubmit(input: OrchestratorInput): Promise<EnableSubmitResult> {
+  const { runCommand, emit, submitSelector, _generateText, _model } = input;
+
+  const p0 = await phase0LocateButton({ runCommand, submitSelector });
+  if (p0.outcome) return p0.outcome;
+  const selector = p0.submitSelector!;
+
+  emit('Checking required fields');
+  const p1 = await phase1CheckRequiredFields({ runCommand, _generateText, _model });
+  if (p1.outcome) return p1.outcome;
+
+  emit('Opening sections to acknowledge');
+  await phase2ExpandSections({ runCommand, _generateText, _model });
+
+  const p3 = await phase3WaitForTurnstile(
+    { runCommand, submitSelector: selector },
+    { emit, ...(input.phase3Opts ?? {}) },
+  );
+  if (p3.outcome) return p3.outcome;
+
+  const p4 = await phase4Verify({ runCommand, submitSelector: selector });
+  if (p4.outcome) return p4.outcome;
+
+  const p5 = await phase5Diagnose({ runCommand });
+  if (p5.outcome) return p5.outcome;
+
+  emit('Trying to enable the submit button');
+  const snap = await runCommand({ action: 'snapshot', selector: 'form' });
+  const lastSnapshot = snap.output ?? '';
+  const p6 = await phase6ForceEnable({
+    runCommand,
+    submitSelector: selector,
+    tokenPresent: p5.tokenPresent,
+    lastSnapshot,
+  });
+  return p6.outcome ?? { status: 'blocked-unknown', diagnostic: { reason: 'no-result' } };
+}
 
 export const createEnableSubmitTool = (sessionId: string, userId: string) =>
   tool({
@@ -25,10 +91,47 @@ This tool NEVER clicks the submit button. It only enables it.`,
       { submitSelector }: { submitSelector?: string },
       { abortSignal }: ToolExecutionOptions,
     ): Promise<EnableSubmitResult> => {
-      void submitSelector;
-      void abortSignal;
-      void sessionId;
-      void userId;
-      return { status: 'blocked-unknown', diagnostic: { reason: 'not-implemented' } };
+      return withSessionQueue(sessionId, async () => {
+        try {
+          const session = await getOrCreateBrowser(sessionId, userId);
+
+          const runCommand: RunCommand = async (cmd) => {
+            const command = { id: nanoid(), ...cmd } as Command;
+            const response = await executeCommand(command, session.browserManager);
+            if (response.success) {
+              const output =
+                typeof response.data === 'string'
+                  ? response.data
+                  : JSON.stringify(response.data);
+              return { success: true, output };
+            }
+            return { success: false, error: response.error ?? 'unknown' };
+          };
+
+          const emit: EmitFn = () => {
+            // Wired to dataStream in Task 10
+          };
+
+          return await Promise.race([
+            runEnableSubmit({ runCommand, emit, abortSignal, submitSelector }),
+            new Promise<EnableSubmitResult>((resolve) =>
+              setTimeout(
+                () =>
+                  resolve({
+                    status: 'blocked-unknown',
+                    diagnostic: { reason: 'timeout', timeoutMs: TOOL_TIMEOUT_MS },
+                  }),
+                TOOL_TIMEOUT_MS,
+              ),
+            ),
+          ]);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (abortSignal?.aborted || message.includes('stopped by user')) {
+            return { status: 'browser-error', error: 'stopped by user' };
+          }
+          return { status: 'browser-error', error: message };
+        }
+      });
     },
   });

--- a/lib/ai/tools/enable-submit.ts
+++ b/lib/ai/tools/enable-submit.ts
@@ -68,7 +68,11 @@ export async function runEnableSubmit(input: OrchestratorInput): Promise<EnableS
   return p6.outcome ?? { status: 'blocked-unknown', diagnostic: { reason: 'no-result' } };
 }
 
-export const createEnableSubmitTool = (sessionId: string, userId: string) =>
+export const createEnableSubmitTool = (
+  sessionId: string,
+  userId: string,
+  emitProgress?: (label: string) => void,
+) =>
   tool({
     description: `Enable the final submit button on a benefits-application form so the caseworker can review and click it.
 
@@ -108,9 +112,7 @@ This tool NEVER clicks the submit button. It only enables it.`,
             return { success: false, error: response.error ?? 'unknown' };
           };
 
-          const emit: EmitFn = () => {
-            // Wired to dataStream in Task 10
-          };
+          const emit: EmitFn = emitProgress ?? (() => {});
 
           return await Promise.race([
             runEnableSubmit({ runCommand, emit, abortSignal, submitSelector }),

--- a/lib/ai/tools/enable-submit.ts
+++ b/lib/ai/tools/enable-submit.ts
@@ -1,0 +1,34 @@
+import { tool, type ToolExecutionOptions } from 'ai';
+import { z } from 'zod';
+import type { EnableSubmitResult } from './enable-submit-types';
+
+export const createEnableSubmitTool = (sessionId: string, userId: string) =>
+  tool({
+    description: `Enable the final submit button on a benefits-application form so the caseworker can review and click it.
+
+Runs a deterministic diagnose-and-enable sequence. Returns one of:
+- "enabled": button is now enabled. Proceed to formSummary.
+- "enabled-via-force": button is enabled but Turnstile may be incomplete. Relay the warning to the caseworker.
+- "blocked-missing-fields": list of human-readable labels that need to be filled. Route through gapAnalysis.
+- "pending-turnstile": Turnstile token has not populated. Relay the message; wait and retry.
+- "blocked-unknown": could not enable. Surface the diagnostic to the caseworker.
+- "browser-error": browser command failed.
+
+This tool NEVER clicks the submit button. It only enables it.`,
+    inputSchema: z.object({
+      submitSelector: z
+        .string()
+        .optional()
+        .describe('Optional ref or CSS selector for the submit button; auto-detected if omitted.'),
+    }),
+    execute: async (
+      { submitSelector }: { submitSelector?: string },
+      { abortSignal }: ToolExecutionOptions,
+    ): Promise<EnableSubmitResult> => {
+      void submitSelector;
+      void abortSignal;
+      void sessionId;
+      void userId;
+      return { status: 'blocked-unknown', diagnostic: { reason: 'not-implemented' } };
+    },
+  });

--- a/lib/ai/tools/read-reference.ts
+++ b/lib/ai/tools/read-reference.ts
@@ -7,7 +7,7 @@ const REFERENCES_DIR = normalize(join(process.cwd(), 'lib/ai/prompts/references'
 
 export const readReference = tool({
   description:
-    'Load a reference document. Use the path the system prompt instructs you to load (e.g. "field-patterns.md", "custom-dropdowns.md", "form-submission.md", "browser-commands.md").',
+    'Load a reference document. Use the path the system prompt instructs you to load (e.g. "field-patterns.md", "custom-dropdowns.md", "browser-commands.md").',
   inputSchema: z.object({
     path: z
       .string()

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -101,10 +101,10 @@ describe('phase1CheckRequiredFields', () => {
 
   const _model = {} as any;
 
-  test('returns blocked-missing-fields when generateObject reports missing', async () => {
-    const _generateObject = vi.fn().mockResolvedValue({ object: { missing: ['First Name', 'Last Name'] } });
+  test('returns blocked-missing-fields when generateText reports missing', async () => {
+    const _generateText = vi.fn().mockResolvedValue({ output: { missing: ['First Name', 'Last Name'] } });
     const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT });
-    const result = await phase1CheckRequiredFields({ runCommand, _generateObject: _generateObject as any, _model });
+    const result = await phase1CheckRequiredFields({ runCommand, _generateText: _generateText as any, _model });
     expect(result.outcome).toEqual({
       status: 'blocked-missing-fields',
       fields: ['First Name', 'Last Name'],
@@ -112,16 +112,16 @@ describe('phase1CheckRequiredFields', () => {
   });
 
   test('returns null outcome when nothing is missing', async () => {
-    const _generateObject = vi.fn().mockResolvedValue({ object: { missing: [] } });
+    const _generateText = vi.fn().mockResolvedValue({ output: { missing: [] } });
     const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT });
-    const result = await phase1CheckRequiredFields({ runCommand, _generateObject: _generateObject as any, _model });
+    const result = await phase1CheckRequiredFields({ runCommand, _generateText: _generateText as any, _model });
     expect(result.outcome).toBeNull();
   });
 
-  test('falls back to "no missing" when generateObject throws', async () => {
-    const _generateObject = vi.fn().mockRejectedValue(new Error('model timeout'));
+  test('falls back to "no missing" when generateText throws', async () => {
+    const _generateText = vi.fn().mockRejectedValue(new Error('model timeout'));
     const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT });
-    const result = await phase1CheckRequiredFields({ runCommand, _generateObject: _generateObject as any, _model });
+    const result = await phase1CheckRequiredFields({ runCommand, _generateText: _generateText as any, _model });
     expect(result.outcome).toBeNull();
   });
 

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -7,7 +7,7 @@ vi.mock('agent-browser/dist/actions.js', () => ({
   executeCommand: vi.fn(),
 }));
 import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
-import { phase0LocateButton, phase1CheckRequiredFields, phase2ExpandSections } from '@/lib/ai/tools/enable-submit-phases';
+import { phase0LocateButton, phase1CheckRequiredFields, phase2ExpandSections, phase3WaitForTurnstile } from '@/lib/ai/tools/enable-submit-phases';
 
 describe('enableSubmit tool', () => {
   test('factory returns a tool with a description and execute fn', () => {
@@ -170,5 +170,51 @@ describe('phase2ExpandSections', () => {
     const runCommand = vi.fn().mockResolvedValue({ success: false, error: 'closed' });
     const result = await phase2ExpandSections({ runCommand });
     expect(result.outcome).toEqual({ status: 'browser-error', error: 'closed' });
+  });
+});
+
+describe('phase3WaitForTurnstile', () => {
+  test('returns enabled when disabled flips to false during polling', async () => {
+    const runCommand = vi
+      .fn()
+      // tick 1: token empty, disabled=true
+      .mockResolvedValueOnce({ success: true, output: '' })
+      .mockResolvedValueOnce({ success: true, output: 'true' })
+      // tick 2: token present, disabled=false -> exit
+      .mockResolvedValueOnce({ success: true, output: 'TOKEN_VAL' })
+      .mockResolvedValueOnce({ success: true, output: 'false' });
+    const emit = vi.fn();
+    const result = await phase3WaitForTurnstile(
+      { runCommand, submitSelector: '@e2' },
+      { tickMs: 1, maxTicks: 4, emit },
+    );
+    expect(result.outcome).toEqual({ status: 'enabled' });
+    expect(emit).toHaveBeenCalled();
+  });
+
+  test('returns null after maxTicks when still disabled', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: 'true' });
+    const emit = vi.fn();
+    const result = await phase3WaitForTurnstile(
+      { runCommand, submitSelector: '@e2' },
+      { tickMs: 1, maxTicks: 2, emit },
+    );
+    expect(result.outcome).toBeNull();
+    // emit called once per tick
+    expect(emit.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('emit receives cumulative-seconds label for each tick', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: 'true' });
+    const emit = vi.fn();
+    await phase3WaitForTurnstile(
+      { runCommand, submitSelector: '@e2' },
+      { tickMs: 2000, maxTicks: 3, emit, _sleep: async () => {} },
+    );
+    // Match labels containing "(2s)", "(4s)", "(6s)" — cumulative seconds.
+    const labels = emit.mock.calls.map((c) => c[0]);
+    expect(labels.some((l) => l.includes('(2s)'))).toBe(true);
+    expect(labels.some((l) => l.includes('(4s)'))).toBe(true);
+    expect(labels.some((l) => l.includes('(6s)'))).toBe(true);
   });
 });

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -7,7 +7,8 @@ vi.mock('agent-browser/dist/actions.js', () => ({
   executeCommand: vi.fn(),
 }));
 import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
-import { phase0LocateButton, phase1CheckRequiredFields, phase2ExpandSections, phase3WaitForTurnstile, phase4Verify, phase5Diagnose } from '@/lib/ai/tools/enable-submit-phases';
+import { phase0LocateButton, phase1CheckRequiredFields, phase2ExpandSections, phase3WaitForTurnstile, phase4Verify, phase5Diagnose, phase6ForceEnable } from '@/lib/ai/tools/enable-submit-phases';
+import { submitGates } from '@/lib/ai/tools/enable-submit-gates';
 
 describe('enableSubmit tool', () => {
   test('factory returns a tool with a description and execute fn', () => {
@@ -267,5 +268,58 @@ describe('phase5Diagnose', () => {
     // Treat browser-eval failure same as empty token — Phase 5's job is to recommend waiting, not surface evaluate failures.
     expect(result.outcome?.status).toBe('pending-turnstile');
     expect(result.tokenPresent).toBe(false);
+  });
+});
+
+describe('submitGates registry', () => {
+  test('exports at least one entry with name/match/script', () => {
+    expect(submitGates.length).toBeGreaterThan(0);
+    for (const gate of submitGates) {
+      expect(typeof gate.name).toBe('string');
+      expect(typeof gate.match).toBe('function');
+      expect(typeof gate.script).toBe('function');
+    }
+  });
+});
+
+describe('phase6ForceEnable', () => {
+  test('refuses to run when tokenPresent is false (safety guard)', async () => {
+    const runCommand = vi.fn();
+    const result = await phase6ForceEnable({
+      runCommand,
+      submitSelector: '@e2',
+      tokenPresent: false,
+      lastSnapshot: 'snap',
+    });
+    expect(result.outcome?.status).toBe('pending-turnstile');
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  test('returns enabled-via-force when a gate clears the disabled attr', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: 'ok' }) // evaluate gate script
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit Application" [ref=e2]' }); // re-snapshot enabled
+    const result = await phase6ForceEnable({
+      runCommand,
+      submitSelector: '@e2',
+      tokenPresent: true,
+      lastSnapshot: '- button "Submit Application" [ref=e2] [disabled]',
+    });
+    expect(result.outcome?.status).toBe('enabled-via-force');
+  });
+
+  test('returns blocked-unknown when no gate clears the disabled attr', async () => {
+    const runCommand = vi.fn().mockResolvedValue({
+      success: true,
+      output: '- button "Submit Application" [ref=e2] [disabled]',
+    });
+    const result = await phase6ForceEnable({
+      runCommand,
+      submitSelector: '@e2',
+      tokenPresent: true,
+      lastSnapshot: '- button "Submit Application" [ref=e2] [disabled]',
+    });
+    expect(result.outcome?.status).toBe('blocked-unknown');
   });
 });

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -8,6 +8,7 @@ vi.mock('agent-browser/dist/actions.js', () => ({
 }));
 
 import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
+import { phase0LocateButton } from '@/lib/ai/tools/enable-submit-phases';
 
 describe('enableSubmit tool', () => {
   test('factory returns a tool with a description and execute fn', () => {
@@ -15,6 +16,40 @@ describe('enableSubmit tool', () => {
     expect(tool).toBeDefined();
     expect(typeof tool.execute).toBe('function');
     expect(tool.description).toMatch(/submit/i);
+  });
+});
+
+describe('phase0LocateButton', () => {
+  const SNAPSHOT_ENABLED = `
+@e1 [textbox name="firstName"] "John"
+@e2 [button] "Submit Application"
+`.trim();
+
+  const SNAPSHOT_DISABLED = `
+@e1 [textbox name="firstName"] "John"
+@e2 [button disabled] "Submit Application"
+`.trim();
+
+  test('returns "enabled" short-circuit when button is not disabled', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT_ENABLED });
+    const result = await phase0LocateButton({ runCommand });
+    expect(result.outcome).toEqual({ status: 'enabled' });
+  });
+
+  test('returns continue + selector when button is disabled', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT_DISABLED });
+    const result = await phase0LocateButton({ runCommand });
+    expect(result.outcome).toBeNull();
+    expect(result.submitSelector).toBe('@e2');
+  });
+
+  test('respects an explicit submitSelector when passed', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: '@e1 [textbox name="firstName"] "John"' })
+      .mockResolvedValueOnce({ success: true, output: 'false' });
+    const result = await phase0LocateButton({ runCommand, submitSelector: '#mySubmit' });
+    expect(result.submitSelector).toBe('#mySubmit');
   });
 });
 

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -7,7 +7,7 @@ vi.mock('agent-browser/dist/actions.js', () => ({
   executeCommand: vi.fn(),
 }));
 import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
-import { phase0LocateButton, phase1CheckRequiredFields, phase2ExpandSections, phase3WaitForTurnstile } from '@/lib/ai/tools/enable-submit-phases';
+import { phase0LocateButton, phase1CheckRequiredFields, phase2ExpandSections, phase3WaitForTurnstile, phase4Verify, phase5Diagnose } from '@/lib/ai/tools/enable-submit-phases';
 
 describe('enableSubmit tool', () => {
   test('factory returns a tool with a description and execute fn', () => {
@@ -216,5 +216,56 @@ describe('phase3WaitForTurnstile', () => {
     expect(labels.some((l) => l.includes('(2s)'))).toBe(true);
     expect(labels.some((l) => l.includes('(4s)'))).toBe(true);
     expect(labels.some((l) => l.includes('(6s)'))).toBe(true);
+  });
+});
+
+describe('phase4Verify', () => {
+  test('returns enabled when fresh snapshot shows button not disabled', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit Application" [ref=e2]' });
+    const result = await phase4Verify({ runCommand, submitSelector: '@e2' });
+    expect(result.outcome).toEqual({ status: 'enabled' });
+  });
+
+  test('returns null when button still disabled', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit Application" [ref=e2] [disabled]' });
+    const result = await phase4Verify({ runCommand, submitSelector: '@e2' });
+    expect(result.outcome).toBeNull();
+  });
+
+  test('returns browser-error when snapshot fails', async () => {
+    const runCommand = vi.fn().mockResolvedValueOnce({ success: false, error: 'closed' });
+    const result = await phase4Verify({ runCommand, submitSelector: '@e2' });
+    expect(result.outcome).toEqual({ status: 'browser-error', error: 'closed' });
+  });
+});
+
+describe('phase5Diagnose', () => {
+  test('returns pending-turnstile when token empty', async () => {
+    const runCommand = vi.fn().mockResolvedValueOnce({ success: true, output: '' });
+    const result = await phase5Diagnose({ runCommand });
+    expect(result.outcome).toEqual({
+      status: 'pending-turnstile',
+      message: 'Turnstile token is still empty — wait ~30s and try again.',
+    });
+    expect(result.tokenPresent).toBe(false);
+  });
+
+  test('returns null outcome + tokenPresent=true when token populated', async () => {
+    const runCommand = vi.fn().mockResolvedValueOnce({ success: true, output: 'TOKEN_VALUE' });
+    const result = await phase5Diagnose({ runCommand });
+    expect(result.outcome).toBeNull();
+    expect(result.tokenPresent).toBe(true);
+  });
+
+  test('returns pending-turnstile when token read fails', async () => {
+    const runCommand = vi.fn().mockResolvedValueOnce({ success: false, error: 'eval blocked' });
+    const result = await phase5Diagnose({ runCommand });
+    // Treat browser-eval failure same as empty token — Phase 5's job is to recommend waiting, not surface evaluate failures.
+    expect(result.outcome?.status).toBe('pending-turnstile');
+    expect(result.tokenPresent).toBe(false);
   });
 });

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -6,9 +6,8 @@ vi.mock('@/lib/kernel/browser', () => ({
 vi.mock('agent-browser/dist/actions.js', () => ({
   executeCommand: vi.fn(),
 }));
-
 import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
-import { phase0LocateButton } from '@/lib/ai/tools/enable-submit-phases';
+import { phase0LocateButton, phase1CheckRequiredFields } from '@/lib/ai/tools/enable-submit-phases';
 
 describe('enableSubmit tool', () => {
   test('factory returns a tool with a description and execute fn', () => {
@@ -94,5 +93,41 @@ describe('withSessionQueue export', () => {
     });
     await Promise.all([a, b]);
     expect(events).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+});
+
+describe('phase1CheckRequiredFields', () => {
+  const SNAPSHOT = '- textbox "First Name" [ref=e1]';
+
+  const _model = {} as any;
+
+  test('returns blocked-missing-fields when generateObject reports missing', async () => {
+    const _generateObject = vi.fn().mockResolvedValue({ object: { missing: ['First Name', 'Last Name'] } });
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT });
+    const result = await phase1CheckRequiredFields({ runCommand, _generateObject: _generateObject as any, _model });
+    expect(result.outcome).toEqual({
+      status: 'blocked-missing-fields',
+      fields: ['First Name', 'Last Name'],
+    });
+  });
+
+  test('returns null outcome when nothing is missing', async () => {
+    const _generateObject = vi.fn().mockResolvedValue({ object: { missing: [] } });
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT });
+    const result = await phase1CheckRequiredFields({ runCommand, _generateObject: _generateObject as any, _model });
+    expect(result.outcome).toBeNull();
+  });
+
+  test('falls back to "no missing" when generateObject throws', async () => {
+    const _generateObject = vi.fn().mockRejectedValue(new Error('model timeout'));
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT });
+    const result = await phase1CheckRequiredFields({ runCommand, _generateObject: _generateObject as any, _model });
+    expect(result.outcome).toBeNull();
+  });
+
+  test('returns browser-error when snapshot fails', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ success: false, error: 'closed' });
+    const result = await phase1CheckRequiredFields({ runCommand });
+    expect(result.outcome).toEqual({ status: 'browser-error', error: 'closed' });
   });
 });

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -21,19 +21,26 @@ describe('enableSubmit tool', () => {
 
 describe('phase0LocateButton', () => {
   const SNAPSHOT_ENABLED = `
-@e1 [textbox name="firstName"] "John"
-@e2 [button] "Submit Application"
+- textbox "First Name" [ref=e1]
+- button "Submit Application" [ref=e2]
 `.trim();
 
   const SNAPSHOT_DISABLED = `
-@e1 [textbox name="firstName"] "John"
-@e2 [button disabled] "Submit Application"
+- textbox "First Name" [ref=e1]
+- button "Submit Application" [ref=e2] [disabled]
+`.trim();
+
+  const SNAPSHOT_MULTIPLE_BUTTONS = `
+- link "Apply now" [ref=e1]
+- button "Send message" [ref=e2]
+- button "Submit Application" [ref=e9] [disabled]
 `.trim();
 
   test('returns "enabled" short-circuit when button is not disabled', async () => {
     const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT_ENABLED });
     const result = await phase0LocateButton({ runCommand });
     expect(result.outcome).toEqual({ status: 'enabled' });
+    expect(result.submitSelector).toBe('@e2');
   });
 
   test('returns continue + selector when button is disabled', async () => {
@@ -43,12 +50,28 @@ describe('phase0LocateButton', () => {
     expect(result.submitSelector).toBe('@e2');
   });
 
-  test('respects an explicit submitSelector when passed', async () => {
-    const runCommand = vi
-      .fn()
-      .mockResolvedValueOnce({ success: true, output: '@e1 [textbox name="firstName"] "John"' })
-      .mockResolvedValueOnce({ success: true, output: 'false' });
+  test('prefers the disabled button when multiple candidates exist', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT_MULTIPLE_BUTTONS });
+    const result = await phase0LocateButton({ runCommand });
+    expect(result.submitSelector).toBe('@e9');
+    expect(result.outcome).toBeNull();
+  });
+
+  test('ignores links even when label matches', async () => {
+    const SNAPSHOT_LINK_ONLY = '- link "Apply now" [ref=e1]';
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT_LINK_ONLY });
+    const result = await phase0LocateButton({ runCommand });
+    expect(result.outcome).toEqual({
+      status: 'blocked-unknown',
+      diagnostic: { reason: 'submit-button-not-found' },
+    });
+  });
+
+  test('respects an explicit submitSelector when passed and button is enabled', async () => {
+    const SNAPSHOT_NO_BUTTON_MATCH = '- textbox "First Name" [ref=e1]';
+    const runCommand = vi.fn().mockResolvedValue({ success: true, output: SNAPSHOT_NO_BUTTON_MATCH });
     const result = await phase0LocateButton({ runCommand, submitSelector: '#mySubmit' });
+    expect(result.outcome).toEqual({ status: 'enabled' });
     expect(result.submitSelector).toBe('#mySubmit');
   });
 });

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -7,7 +7,7 @@ vi.mock('agent-browser/dist/actions.js', () => ({
   executeCommand: vi.fn(),
 }));
 import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
-import { phase0LocateButton, phase1CheckRequiredFields } from '@/lib/ai/tools/enable-submit-phases';
+import { phase0LocateButton, phase1CheckRequiredFields, phase2ExpandSections } from '@/lib/ai/tools/enable-submit-phases';
 
 describe('enableSubmit tool', () => {
   test('factory returns a tool with a description and execute fn', () => {
@@ -128,6 +128,47 @@ describe('phase1CheckRequiredFields', () => {
   test('returns browser-error when snapshot fails', async () => {
     const runCommand = vi.fn().mockResolvedValue({ success: false, error: 'closed' });
     const result = await phase1CheckRequiredFields({ runCommand });
+    expect(result.outcome).toEqual({ status: 'browser-error', error: 'closed' });
+  });
+});
+
+describe('phase2ExpandSections', () => {
+  const _model = {} as any;
+
+  test('clicks each ref returned by the LLM, then re-snapshots', async () => {
+    const _generateText = vi.fn().mockResolvedValue({ output: { refs: ['@e5', '@e7'] } });
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: '- link "+ Expand" [ref=e5]' }) // initial snapshot
+      .mockResolvedValueOnce({ success: true, output: 'ok' }) // click @e5
+      .mockResolvedValueOnce({ success: true, output: 'ok' }) // click @e7
+      .mockResolvedValueOnce({ success: true, output: 'fresh snapshot' }); // re-snapshot
+    const result = await phase2ExpandSections({ runCommand, _generateText: _generateText as any, _model });
+    expect(result.outcome).toBeNull();
+    const calls = runCommand.mock.calls.map((c) => c[0]);
+    expect(calls[1]).toEqual({ action: 'click', selector: '@e5' });
+    expect(calls[2]).toEqual({ action: 'click', selector: '@e7' });
+    expect(runCommand).toHaveBeenCalledTimes(4);
+  });
+
+  test('skips clicks and re-snapshot when LLM returns empty refs', async () => {
+    const _generateText = vi.fn().mockResolvedValue({ output: { refs: [] } });
+    const runCommand = vi.fn().mockResolvedValueOnce({ success: true, output: 'snap' });
+    const result = await phase2ExpandSections({ runCommand, _generateText: _generateText as any, _model });
+    expect(result.outcome).toBeNull();
+    expect(runCommand).toHaveBeenCalledTimes(1); // initial snapshot only
+  });
+
+  test('falls back gracefully when generateText throws', async () => {
+    const _generateText = vi.fn().mockRejectedValue(new Error('boom'));
+    const runCommand = vi.fn().mockResolvedValueOnce({ success: true, output: 'snap' });
+    const result = await phase2ExpandSections({ runCommand, _generateText: _generateText as any, _model });
+    expect(result.outcome).toBeNull();
+  });
+
+  test('returns browser-error when initial snapshot fails', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ success: false, error: 'closed' });
+    const result = await phase2ExpandSections({ runCommand });
     expect(result.outcome).toEqual({ status: 'browser-error', error: 'closed' });
   });
 });

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/lib/kernel/browser', () => ({
 vi.mock('agent-browser/dist/actions.js', () => ({
   executeCommand: vi.fn(),
 }));
-import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
+import { createEnableSubmitTool, runEnableSubmit } from '@/lib/ai/tools/enable-submit';
 import { phase0LocateButton, phase1CheckRequiredFields, phase2ExpandSections, phase3WaitForTurnstile, phase4Verify, phase5Diagnose, phase6ForceEnable } from '@/lib/ai/tools/enable-submit-phases';
 import { submitGates } from '@/lib/ai/tools/enable-submit-gates';
 
@@ -321,5 +321,83 @@ describe('phase6ForceEnable', () => {
       lastSnapshot: '- button "Submit Application" [ref=e2] [disabled]',
     });
     expect(result.outcome?.status).toBe('blocked-unknown');
+  });
+});
+
+describe('runEnableSubmit (orchestration)', () => {
+  test('phase 0 short-circuits when button already enabled', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit Application" [ref=e2]' });
+    const result = await runEnableSubmit({
+      runCommand,
+      emit: () => {},
+      abortSignal: undefined,
+    });
+    expect(result).toEqual({ status: 'enabled' });
+  });
+
+  test('phase 1 missing fields short-circuits before later phases', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2] [disabled]' }) // phase 0 snap
+      .mockResolvedValueOnce({ success: true, output: '- textbox "First Name" [ref=e1]' }); // phase 1 snap
+    const _generateText = vi.fn().mockResolvedValue({ output: { missing: ['First Name'] } });
+    const _model = {} as any;
+
+    const result = await runEnableSubmit({
+      runCommand,
+      emit: () => {},
+      abortSignal: undefined,
+      _generateText: _generateText as any,
+      _model,
+    });
+    expect(result).toEqual({ status: 'blocked-missing-fields', fields: ['First Name'] });
+  });
+
+  test('emits phase labels in order for the longer path', async () => {
+    const labels: string[] = [];
+    // Phase 0: disabled button -> continue
+    // Phase 1: no missing -> continue
+    // Phase 2: no expand sections -> continue
+    // Phase 3: still disabled after maxTicks -> continue
+    // Phase 4: still disabled -> continue
+    // Phase 5: token empty -> return pending-turnstile
+    const runCommand = vi
+      .fn()
+      // phase 0 snap
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2] [disabled]' })
+      // phase 1 snap
+      .mockResolvedValueOnce({ success: true, output: '- textbox "OK" [ref=e1]' })
+      // phase 2 snap
+      .mockResolvedValueOnce({ success: true, output: '- textbox "OK" [ref=e1]' })
+      // phase 3 polling (2 ticks × 2 evals each = 4): token eval + disabled eval per tick
+      .mockResolvedValueOnce({ success: true, output: 'TOKEN' })   // tick 1 token
+      .mockResolvedValueOnce({ success: true, output: 'true' })    // tick 1 disabled
+      .mockResolvedValueOnce({ success: true, output: 'TOKEN' })   // tick 2 token
+      .mockResolvedValueOnce({ success: true, output: 'true' })    // tick 2 disabled
+      // phase 4 snap: still disabled
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2] [disabled]' })
+      // phase 5 token eval: empty -> pending-turnstile
+      .mockResolvedValueOnce({ success: true, output: '' });
+    const _generateText = vi
+      .fn()
+      .mockResolvedValueOnce({ output: { missing: [] } }) // phase 1
+      .mockResolvedValueOnce({ output: { refs: [] } }); // phase 2
+
+    const result = await runEnableSubmit({
+      runCommand,
+      emit: (l) => labels.push(l),
+      abortSignal: undefined,
+      _generateText: _generateText as any,
+      _model: {} as any,
+      phase3Opts: { tickMs: 1, maxTicks: 2 },
+    });
+
+    expect(labels).toContain('Checking required fields');
+    expect(labels).toContain('Opening sections to acknowledge');
+    expect(labels.some((l) => l.startsWith('Waiting for security check'))).toBe(true);
+    // Token empty → pending-turnstile
+    expect(result.status).toBe('pending-turnstile');
   });
 });

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -401,3 +401,21 @@ describe('runEnableSubmit (orchestration)', () => {
     expect(result.status).toBe('pending-turnstile');
   });
 });
+
+describe('createEnableSubmitTool emit wiring', () => {
+  test('passes emit callback through to runEnableSubmit', async () => {
+    // We can't easily test the real browser path, but we can verify the factory
+    // exposes an emitProgress parameter and accepts a callback.
+    const calls: string[] = [];
+    const myTool = createEnableSubmitTool('chat-1', 'user-1', (label) => calls.push(label));
+    expect(myTool).toBeDefined();
+    expect(typeof myTool.execute).toBe('function');
+    // No assertion about calls until a real run; the factory accepting the param is enough.
+  });
+
+  test('factory works without emit callback (backward compat)', () => {
+    const myTool = createEnableSubmitTool('chat-1', 'user-1');
+    expect(myTool).toBeDefined();
+    expect(typeof myTool.execute).toBe('function');
+  });
+});

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -402,6 +402,40 @@ describe('runEnableSubmit (orchestration)', () => {
   });
 });
 
+describe('runEnableSubmit abort behavior', () => {
+  test('aborts during Phase 3 polling when signal fires', async () => {
+    const runCommand = vi
+      .fn()
+      // Phase 0: button is disabled, continue
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2] [disabled]' })
+      // Phase 1 snapshot
+      .mockResolvedValueOnce({ success: true, output: '- textbox "OK" [ref=e1]' })
+      // Phase 2 snapshot
+      .mockResolvedValueOnce({ success: true, output: '- textbox "OK" [ref=e1]' })
+      // Phase 3 polling stays disabled
+      .mockResolvedValue({ success: true, output: 'true' });
+    const _generateText = vi
+      .fn()
+      .mockResolvedValueOnce({ output: { missing: [] } })
+      .mockResolvedValueOnce({ output: { refs: [] } });
+
+    const ctrl = new AbortController();
+    // Abort after ~5ms — Phase 3 will be in its first tick
+    setTimeout(() => ctrl.abort(), 5);
+
+    const result = await runEnableSubmit({
+      runCommand,
+      emit: () => {},
+      abortSignal: ctrl.signal,
+      _generateText: _generateText as any,
+      _model: {} as any,
+      phase3Opts: { tickMs: 50, maxTicks: 4 },
+    });
+    expect(result.status).toBe('browser-error');
+    expect((result as any).error).toMatch(/stop|abort/i);
+  });
+});
+
 describe('createEnableSubmitTool emit wiring', () => {
   test('passes emit callback through to runEnableSubmit', async () => {
     // We can't easily test the real browser path, but we can verify the factory

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@/lib/kernel/browser', () => ({
+  getOrCreateBrowser: vi.fn(),
+}));
+vi.mock('agent-browser/dist/actions.js', () => ({
+  executeCommand: vi.fn(),
+}));
+
+import { createEnableSubmitTool } from '@/lib/ai/tools/enable-submit';
+
+describe('enableSubmit tool', () => {
+  test('factory returns a tool with a description and execute fn', () => {
+    const tool = createEnableSubmitTool('chat-1', 'user-1');
+    expect(tool).toBeDefined();
+    expect(typeof tool.execute).toBe('function');
+    expect(tool.description).toMatch(/submit/i);
+  });
+});

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -453,3 +453,106 @@ describe('createEnableSubmitTool emit wiring', () => {
     expect(typeof myTool.execute).toBe('function');
   });
 });
+
+describe('integration replays', () => {
+  test('scenario A: missing field blocks early', async () => {
+    const runCommand = vi
+      .fn()
+      // phase 0 snapshot: disabled button
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit Application" [ref=e2] [disabled]' })
+      // phase 1 snapshot
+      .mockResolvedValueOnce({ success: true, output: '- textbox "Email" [ref=e1]' });
+    const _generateText = vi.fn().mockResolvedValueOnce({ output: { missing: ['Email'] } });
+
+    const result = await runEnableSubmit({
+      runCommand,
+      emit: () => {},
+      abortSignal: undefined,
+      _generateText: _generateText as any,
+      _model: {} as any,
+    });
+    expect(result).toEqual({ status: 'blocked-missing-fields', fields: ['Email'] });
+  });
+
+  test('scenario B: turnstile resolves during polling -> enabled', async () => {
+    const runCommand = vi
+      .fn()
+      // phase 0
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2] [disabled]' })
+      // phase 1 snapshot
+      .mockResolvedValueOnce({ success: true, output: '- textbox "OK" [ref=e1]' })
+      // phase 2 snapshot
+      .mockResolvedValueOnce({ success: true, output: '- textbox "OK" [ref=e1]' })
+      // phase 3 tick 1: token empty, disabled true
+      .mockResolvedValueOnce({ success: true, output: '' })
+      .mockResolvedValueOnce({ success: true, output: 'true' })
+      // phase 3 tick 2: token present, disabled false -> exits
+      .mockResolvedValueOnce({ success: true, output: 'TOK' })
+      .mockResolvedValueOnce({ success: true, output: 'false' });
+    const _generateText = vi
+      .fn()
+      .mockResolvedValueOnce({ output: { missing: [] } })
+      .mockResolvedValueOnce({ output: { refs: [] } });
+
+    const result = await runEnableSubmit({
+      runCommand,
+      emit: () => {},
+      abortSignal: undefined,
+      _generateText: _generateText as any,
+      _model: {} as any,
+      phase3Opts: { tickMs: 1, maxTicks: 4 },
+    });
+    expect(result).toEqual({ status: 'enabled' });
+  });
+
+  test('scenario C: token resolved but still disabled -> force-enable success', async () => {
+    const runCommand = vi
+      .fn()
+      // phase 0
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2] [disabled]' })
+      // phase 1 snapshot
+      .mockResolvedValueOnce({ success: true, output: '- textbox "OK" [ref=e1]' })
+      // phase 2 snapshot
+      .mockResolvedValueOnce({ success: true, output: '- textbox "OK" [ref=e1]' })
+      // phase 3: token+disabled reads, NOT a snapshot. 2 ticks × 2 reads = 4 calls. Always token present, disabled true.
+      .mockResolvedValueOnce({ success: true, output: 'TOK' })
+      .mockResolvedValueOnce({ success: true, output: 'true' })
+      .mockResolvedValueOnce({ success: true, output: 'TOK' })
+      .mockResolvedValueOnce({ success: true, output: 'true' })
+      // phase 4 snapshot: still disabled
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2] [disabled]' })
+      // phase 5: read token (evaluate)
+      .mockResolvedValueOnce({ success: true, output: 'TOK' })
+      // phase 6: orchestrator takes lastSnapshot
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2] [disabled]' })
+      // phase 6 gate iteration: evaluate, then re-snapshot now shows not-disabled
+      .mockResolvedValueOnce({ success: true, output: 'ok' })
+      .mockResolvedValueOnce({ success: true, output: '- button "Submit" [ref=e2]' });
+    const _generateText = vi
+      .fn()
+      .mockResolvedValueOnce({ output: { missing: [] } })
+      .mockResolvedValueOnce({ output: { refs: [] } });
+
+    const result = await runEnableSubmit({
+      runCommand,
+      emit: () => {},
+      abortSignal: undefined,
+      _generateText: _generateText as any,
+      _model: {} as any,
+      phase3Opts: { tickMs: 1, maxTicks: 2 },
+    });
+    expect(result.status).toBe('enabled-via-force');
+  });
+
+  test('scenario D: initial snapshot fails (modal-blocked-like) returns browser-error', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ success: false, error: 'snapshot returned empty' });
+    const result = await runEnableSubmit({
+      runCommand,
+      emit: () => {},
+      abortSignal: undefined,
+    });
+    expect(result.status).toBe('browser-error');
+  });
+});

--- a/tests/client/enable-submit.test.ts
+++ b/tests/client/enable-submit.test.ts
@@ -17,3 +17,24 @@ describe('enableSubmit tool', () => {
     expect(tool.description).toMatch(/submit/i);
   });
 });
+
+import { withSessionQueue } from '@/lib/ai/tools/browser';
+
+describe('withSessionQueue export', () => {
+  test('serializes calls per session id', async () => {
+    const events: string[] = [];
+    const a = withSessionQueue('s1', async () => {
+      events.push('a-start');
+      await new Promise((r) => setTimeout(r, 20));
+      events.push('a-end');
+      return 'a';
+    });
+    const b = withSessionQueue('s1', async () => {
+      events.push('b-start');
+      events.push('b-end');
+      return 'b';
+    });
+    await Promise.all([a, b]);
+    expect(events).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -9,6 +9,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, './'),
     },
   },
+  optimizeDeps: {
+    exclude: ['playwright-core', 'chromium-bidi'],
+  },
   test: {
     browser: {
       enabled: true,

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -9,9 +9,6 @@ export default defineConfig({
       '@': path.resolve(__dirname, './'),
     },
   },
-  optimizeDeps: {
-    exclude: ['playwright-core', 'chromium-bidi'],
-  },
   test: {
     browser: {
       enabled: true,


### PR DESCRIPTION
## Checklist

- [ ] Update PR Title to follow this pattern: `[INTENT]:[MESSAGE]`
  > The title will become a one-line commit message in the git log, so be as concise and specific as possible -- refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/). Prepend [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) intent (`fix:`, `feat:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`).

## Ticket

Resolves #{TICKET NUMBER or URL or description} or Adds {new capability or feature}

## Changes

  - New tool lib/ai/tools/enable-submit.ts + 3 supporting files (-types, -phases, -gates), with 7 deterministic phases.
  - "Never click submit" enforced structurally — no code path in the new tool constructs a submit-click.               
  - System prompt collapsed from 20-line protocol to 6 lines pointing at the tool.                      
  - Registered in the chat route with a dataStream.write callback for data-submit-progress events.
  - Final reviewer's pre-merge nits addressed in d86a643 (third-person warning, catch-all-last comment, dropped orphan reference).                                                                
                                                                                                                                   

## Testing

> What was tested? How did you test it? Add unit tests for new functions, integration tests for API/database interactions, and E2E tests for critical user flows.
> * https://martinfowler.com/articles/practical-test-pyramid.html
> * https://blog.logrocket.com/javascript-testing-best-practices/
> * https://www.testim.io/blog/typescript-unit-testing-101/

## Context for reviewers

> Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.
> Add comments to your code under the "Files Changed" tab to explain complex logic or code
> * https://betterprogramming.pub/how-to-make-a-perfect-pull-request-3578fb4c112 