### PR TITLE
feat: redesign benefit applications landing with tabbed UI

### DIFF
--- a/components/benefit-applications-landing.tsx
+++ b/components/benefit-applications-landing.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { ChevronDown } from 'lucide-react';
+import { ChevronsUpDown } from 'lucide-react';
 import type { ChatMessage, Attachment } from '@/lib/types';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { VisibilityType } from './visibility-selector';
@@ -20,6 +20,8 @@ const PROGRAMS = [
   { id: 'nurse-family-partnership', name: 'Nurse-Family Partnership', website: 'https://forms.office.com/Pages/ResponsePage.aspx?id=yqoVt4-WGUe7BO0xcOCKaQVow3g6-R9Mh0F8VizNQzhUQ1hCNENFTFBMOVg4SElRSldIWk5BRUkxUi4u' },
   { id: 'pregnancy-planning', name: 'RCOE Referrals System', website: 'https://rrrcoe.nohosoftware.com/online_referrals/' },
 ];
+
+type TabId = 'select' | 'describe';
 
 interface BenefitApplicationsLandingProps {
   input: string;
@@ -52,6 +54,7 @@ export function BenefitApplicationsLanding({
   selectedVisibilityType,
 }: BenefitApplicationsLandingProps) {
   const router = useRouter();
+  const [activeTab, setActiveTab] = useState<TabId>('select');
   const [clientId, setClientId] = useState('');
   const [program, setProgram] = useState<(typeof PROGRAMS)[number] | null>(null);
   const [query, setQuery] = useState('');
@@ -67,7 +70,6 @@ export function BenefitApplicationsLanding({
     p.name.toLowerCase().includes(query.toLowerCase()),
   );
 
-  // Use a ref so the click-outside handler always sees the latest query value.
   const queryRef = useRef(query);
   queryRef.current = query;
 
@@ -97,7 +99,7 @@ export function BenefitApplicationsLanding({
 
   const loginAlert = (
     <Alert className="border-primary/30 bg-primary/10">
-      <AlertDescription className="flex items-center justify-between gap-3">
+      <AlertDescription className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-1 font-inter">
           <span className="text-base font-medium">Log in to get started</span>
           <span className="text-sm text-muted-foreground">
@@ -114,168 +116,202 @@ export function BenefitApplicationsLanding({
     </Alert>
   );
 
+  const tabButtonClass = (active: boolean) =>
+    `flex-1 rounded-[10px] px-2.5 py-1.5 font-inter text-sm font-medium leading-6 transition-colors ${
+      active
+        ? 'bg-card text-foreground shadow-[0px_1px_1.5px_rgba(0,0,0,0.1),0px_1px_1px_rgba(0,0,0,0.1)]'
+        : 'text-foreground/80 hover:text-foreground'
+    }`;
+
   return (
-    <div className="flex flex-1 flex-col bg-chat-background md:flex-row md:pl-28 md:pr-20 lg:pl-40 lg:pr-32 xl:pl-52 xl:pr-44">
-      {/* Left panel — desktop only */}
-      <div className="hidden md:flex md:w-[38%] md:flex-col md:justify-start md:pr-8 md:pt-10 xl:w-[40%]">
-        <h1 className="font-source-serif text-4xl leading-[1.15] text-foreground">
+    <div className="flex flex-1 flex-col items-center overflow-y-auto bg-chat-background px-4 sm:px-6">
+      <div className="my-auto flex w-full max-w-[648px] flex-col gap-6 py-10">
+        <h1 className="font-source-serif text-3xl leading-[1.15] text-foreground text-left sm:text-4xl">
           Let&apos;s start a new application.
         </h1>
-        {!isLoggedIn && <div className="mt-6">{loginAlert}</div>}
-      </div>
 
-      {/* Right panel */}
-      <div className="flex flex-1 flex-col items-center justify-start gap-4 overflow-y-auto px-4 pt-14 pb-4 sm:px-6 md:items-end md:px-0 md:pb-6 md:pt-10">
-        {/* Mobile: title + alert */}
-        <div className="flex w-full max-w-[648px] flex-col gap-4 md:hidden">
-          <h1 className="font-source-serif text-3xl leading-[1.15] text-foreground text-center sm:text-left">
-            Let&apos;s start a new application.
-          </h1>
-          {!isLoggedIn && loginAlert}
-        </div>
+        {!isLoggedIn && loginAlert}
 
-        {/* Form card */}
-        <div className="w-full max-w-[648px] rounded-lg bg-white px-8 py-6 shadow-sm">
-          {/* Client ID */}
-          <div className="mb-6">
-            <p className="font-source-serif text-xl font-bold text-foreground">Client ID</p>
-            <p className="font-source-serif text-xl text-[#787878]">
-              Enter the client&apos;s Apricot 360 ID.
-            </p>
-            <input
-              type="text"
-              placeholder="00000"
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-              disabled={!isLoggedIn}
-              className="mt-5 h-[52px] w-[129px] rounded-[10px] border border-[#b5b5b5] px-4 font-inter text-xl placeholder:text-[#e1e1e1] focus:border-primary focus:shadow-[0px_0px_8px_0px_rgba(177,64,146,0.25)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
-            />
-          </div>
-
-          {/* Program */}
-          <div className="mb-8">
-            <p className="font-source-serif text-xl font-bold text-foreground">Program</p>
-            <p className="font-source-serif text-xl text-[#787878]">
-              Select the program or paste an application URL.
-            </p>
-            <div ref={comboRef} className="relative mt-5">
-              <div
-                className={`flex h-[52px] w-full items-center rounded-[10px] border bg-white px-4 transition-colors ${
-                  isComboOpen ? 'border-primary ring-2 ring-primary/20' : 'border-[#b5b5b5]'
-                } ${!isLoggedIn ? 'cursor-not-allowed opacity-40' : ''}`}
+        <div className="flex w-full flex-col rounded-xl bg-card text-card-foreground shadow-sm md:h-[538px] md:w-[648px]">
+          {/* Tabs */}
+          <div className="px-6 pt-6 sm:px-8">
+            <div
+              role="tablist"
+              aria-label="Application entry mode"
+              className="flex items-center gap-2 rounded-xl bg-[#f5f5f5] p-2"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'select' ? 'true' : 'false'}
+                onClick={() => setActiveTab('select')}
+                className={tabButtonClass(activeTab === 'select')}
               >
-                <input
-                  type="text"
-                  value={query}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    setQuery(val);
-                    if (isUrl(val)) {
-                      setIsComboOpen(false);
-                      if (program) setProgram(null);
-                    } else {
-                      setIsComboOpen(true);
-                      if (program && val !== program.name) setProgram(null);
-                    }
-                  }}
-                  onFocus={() => { if (!isUrl(query)) setIsComboOpen(true); }}
-                  placeholder="Select a program"
-                  disabled={!isLoggedIn}
-                  className="flex-1 bg-transparent font-inter text-xl text-foreground placeholder:text-[#b5b5b5] focus:outline-none disabled:cursor-not-allowed truncate"
-                />
-                {query ? (
-                  <button
-                    type="button"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      setProgram(null);
-                      setQuery('');
-                    }}
-                    aria-label="Clear selection"
-                    className="shrink-0 text-[#8e8e8e] hover:text-foreground"
-                  >
-                    &#x2715;
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      if (!isLoggedIn) return;
-                      setIsComboOpen((prev) => !prev);
-                    }}
-                    aria-label="Toggle program list"
-                    className="shrink-0"
-                  >
-                    <ChevronDown
-                      className={`h-5 w-5 text-[#8e8e8e] transition-transform ${isComboOpen ? 'rotate-180' : ''}`}
-                    />
-                  </button>
-                )}
-              </div>
-              {isComboOpen && (
-                <div className="absolute top-full z-10 mt-1 w-full overflow-hidden rounded-[10px] border border-[#b5b5b5] bg-white shadow-md">
-                  {filteredPrograms.length === 0 ? (
-                    <p className="px-4 py-3 font-inter text-md text-muted-foreground">
-                      No matching programs found. <br />
-                      <span className="text-md text-muted-foreground">You can paste an application URL instead.</span>
-                    </p>
-                  ) : (
-                    filteredPrograms.map((p) => (
-                      <button
-                        key={p.id}
-                        type="button"
-                        onMouseDown={(e) => {
-                          e.preventDefault();
-                          setProgram(p);
-                          setQuery(p.name);
-                          setIsComboOpen(false);
-                        }}
-                        className={`w-full px-2 py-1 text-left font-inter text-xl hover:bg-primary/10 truncate ${
-                          program?.id === p.id ? 'bg-primary/5 text-primary' : 'text-foreground'
-                        }`}
-                      >
-                        {p.name}
-                      </button>
-                    ))
-                  )}
-                </div>
-              )}
+                Select program
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'describe' ? 'true' : 'false'}
+                onClick={() => setActiveTab('describe')}
+                className={tabButtonClass(activeTab === 'describe')}
+              >
+                Describe what you need
+              </button>
             </div>
           </div>
 
-          {/* Start auto-filling */}
-          <button
-            type="button"
-            onClick={handleStartAutoFilling}
-            disabled={!isLoggedIn || !clientId || (!program && !isUrl(query))}
-            className="rounded-lg bg-primary px-4 py-2 font-inter text-base font-semibold tracking-[0.08px] text-white transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            Start auto-filling
-          </button>
-        </div>
+          {/* Tab content */}
+          {activeTab === 'select' ? (
+            <div className="flex-1 px-6 py-6 sm:px-8">
+              {/* Client ID */}
+              <div className="mb-12">
+                <p className="font-source-serif text-lg font-bold text-foreground sm:text-xl">Client ID</p>
+                <p className="mt-1 font-inter text-sm text-muted-foreground sm:text-base">
+                  Enter the client&apos;s Apricot 360 ID.
+                </p>
+                <input
+                  type="text"
+                  placeholder="00000"
+                  value={clientId}
+                  onChange={(e) => setClientId(e.target.value)}
+                  disabled={!isLoggedIn}
+                  className="mt-6 h-[52px] w-[129px] rounded-[10px] border border-[#b5b5b5] px-4 font-inter text-base placeholder:text-[#b5b5b5] focus:border-primary focus:shadow-[0px_0px_8px_0px_rgba(177,64,146,0.25)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+                />
+              </div>
 
-        {/* Custom prompt */}
-        <div className="w-full max-w-[648px]">
-          <p className="mb-2 font-inter text-[15px] text-foreground">
-            Or, write your own prompt:
-          </p>
-          <MultimodalInput
-            chatId={chatId}
-            input={input}
-            setInput={setInput}
-            status={status}
-            stop={stop}
-            attachments={attachments}
-            setAttachments={setAttachments}
-            messages={messages}
-            setMessages={setMessages}
-            sendMessage={sendMessage}
-            selectedVisibilityType={selectedVisibilityType}
-            showStopButton={false}
-            placeholder="Retrieve ID #XXXXX and apply for WIC"
-            session={session}
-          />
+              {/* Application */}
+              <div>
+                <p className="font-source-serif text-lg font-bold text-foreground sm:text-xl">Application</p>
+                <p className="mt-1 font-inter text-sm text-muted-foreground sm:text-base">
+                  Select a program or paste an application URL.
+                </p>
+                <div ref={comboRef} className="relative mt-6">
+                  <div
+                    className={`flex h-[52px] w-full items-center rounded-[10px] border bg-card px-4 transition-colors ${
+                      isComboOpen ? 'border-primary ring-2 ring-primary/20' : 'border-[#b5b5b5]'
+                    } ${!isLoggedIn ? 'cursor-not-allowed opacity-40' : ''}`}
+                  >
+                    <input
+                      type="text"
+                      value={query}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setQuery(val);
+                        if (isUrl(val)) {
+                          setIsComboOpen(false);
+                          if (program) setProgram(null);
+                        } else {
+                          setIsComboOpen(true);
+                          if (program && val !== program.name) setProgram(null);
+                        }
+                      }}
+                      onFocus={() => { if (!isUrl(query)) setIsComboOpen(true); }}
+                      placeholder="Select a program or paste URL"
+                      disabled={!isLoggedIn}
+                      className="flex-1 bg-transparent font-inter text-base text-foreground placeholder:text-[#8e8e8e] focus:outline-none disabled:cursor-not-allowed truncate"
+                    />
+                    {query ? (
+                      <button
+                        type="button"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          setProgram(null);
+                          setQuery('');
+                        }}
+                        aria-label="Clear selection"
+                        className="shrink-0 text-[#8e8e8e] hover:text-foreground"
+                      >
+                        &#x2715;
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          if (!isLoggedIn) return;
+                          setIsComboOpen((prev) => !prev);
+                        }}
+                        aria-label="Toggle program list"
+                        className="shrink-0"
+                      >
+                        <ChevronsUpDown className="h-5 w-5 text-[#8e8e8e]" />
+                      </button>
+                    )}
+                  </div>
+                  {isComboOpen && (
+                    <div className="absolute top-full z-30 mt-1 max-h-[280px] w-full overflow-y-auto rounded-[10px] border border-[#b5b5b5] bg-card shadow-md">
+                      {filteredPrograms.length === 0 ? (
+                        <p className="px-4 py-3 font-inter text-sm text-muted-foreground">
+                          No matching programs found. <br />
+                          <span className="text-sm text-muted-foreground">You can paste an application URL instead.</span>
+                        </p>
+                      ) : (
+                        filteredPrograms.map((p) => (
+                          <button
+                            key={p.id}
+                            type="button"
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              setProgram(p);
+                              setQuery(p.name);
+                              setIsComboOpen(false);
+                            }}
+                            className={`block w-full px-4 py-2 text-left font-inter text-sm hover:bg-primary/10 truncate sm:text-base ${
+                              program?.id === p.id ? 'bg-primary/5 text-primary' : 'text-foreground'
+                            }`}
+                          >
+                            {p.name}
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-1 flex-col px-6 py-6 sm:px-8">
+              <p className="font-source-serif text-lg font-bold text-foreground sm:text-xl">
+                Describe what you need
+              </p>
+              <p className="mt-1 font-inter text-sm text-muted-foreground sm:text-base">
+                Use this for clients without an Apricot 360 ID, multiple programs, or programs not in the list.
+              </p>
+              <div className="mt-4 flex flex-1 flex-col">
+                <MultimodalInput
+                  chatId={chatId}
+                  input={input}
+                  setInput={setInput}
+                  status={status}
+                  stop={stop}
+                  attachments={attachments}
+                  setAttachments={setAttachments}
+                  messages={messages}
+                  setMessages={setMessages}
+                  sendMessage={sendMessage}
+                  selectedVisibilityType={selectedVisibilityType}
+                  showStopButton={false}
+                  placeholder="Apply [ID ####] for [Program URL]"
+                  session={session}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Footer button — Select program tab only */}
+          {activeTab === 'select' && (
+            <div className="border-t border-border px-6 py-5 sm:px-8">
+              <button
+                type="button"
+                onClick={handleStartAutoFilling}
+                disabled={!isLoggedIn || !clientId || (!program && !isUrl(query))}
+                className="w-full rounded-lg bg-primary px-4 py-2.5 font-inter text-sm font-medium tracking-[0.08px] text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Start auto-filling
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/components/benefit-applications-landing.tsx
+++ b/components/benefit-applications-landing.tsx
@@ -132,7 +132,7 @@ export function BenefitApplicationsLanding({
 
         {!isLoggedIn && loginAlert}
 
-        <div className="flex w-full flex-col rounded-xl bg-card text-card-foreground shadow-sm md:min-h-[538px] md:w-[648px]">
+        <div className="flex w-full flex-col rounded-xl bg-card text-card-foreground shadow-sm md:min-h-[500px] md:w-[648px]">
           {/* Tabs */}
           <div className="px-6 pt-6 sm:px-8">
             <div

--- a/components/benefit-applications-landing.tsx
+++ b/components/benefit-applications-landing.tsx
@@ -132,7 +132,7 @@ export function BenefitApplicationsLanding({
 
         {!isLoggedIn && loginAlert}
 
-        <div className="flex w-full flex-col rounded-xl bg-card text-card-foreground shadow-sm md:h-[538px] md:w-[648px]">
+        <div className="flex w-full flex-col rounded-xl bg-card text-card-foreground shadow-sm md:min-h-[538px] md:w-[648px]">
           {/* Tabs */}
           <div className="px-6 pt-6 sm:px-8">
             <div
@@ -166,8 +166,8 @@ export function BenefitApplicationsLanding({
             <div className="flex-1 px-6 py-6 sm:px-8">
               {/* Client ID */}
               <div className="mb-12">
-                <p className="font-source-serif text-lg font-bold text-foreground sm:text-xl">Client ID</p>
-                <p className="mt-1 font-inter text-sm text-muted-foreground sm:text-base">
+                <p className="font-source-serif text-lg font-semibold text-foreground sm:text-xl">Client ID</p>
+                <p className="mt-1 font-source-serif text-sm text-muted-foreground sm:text-base">
                   Enter the client&apos;s Apricot 360 ID.
                 </p>
                 <input
@@ -176,17 +176,17 @@ export function BenefitApplicationsLanding({
                   value={clientId}
                   onChange={(e) => setClientId(e.target.value)}
                   disabled={!isLoggedIn}
-                  className="mt-6 h-[52px] w-[129px] rounded-[10px] border border-[#b5b5b5] px-4 font-inter text-base placeholder:text-[#b5b5b5] focus:border-primary focus:shadow-[0px_0px_8px_0px_rgba(177,64,146,0.25)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+                  className="mt-3 h-[52px] w-[129px] rounded-[10px] border border-[#b5b5b5] px-4 font-inter text-base placeholder:text-[#b5b5b5] focus:border-primary focus:shadow-[0px_0px_8px_0px_rgba(177,64,146,0.25)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
                 />
               </div>
 
               {/* Application */}
               <div>
-                <p className="font-source-serif text-lg font-bold text-foreground sm:text-xl">Application</p>
-                <p className="mt-1 font-inter text-sm text-muted-foreground sm:text-base">
+                <p className="font-source-serif text-lg font-semibold text-foreground sm:text-xl">Application</p>
+                <p className="mt-1 font-source-serif text-sm text-muted-foreground sm:text-base">
                   Select a program or paste an application URL.
                 </p>
-                <div ref={comboRef} className="relative mt-6">
+                <div ref={comboRef} className="relative mt-3">
                   <div
                     className={`flex h-[52px] w-full items-center rounded-[10px] border bg-card px-4 transition-colors ${
                       isComboOpen ? 'border-primary ring-2 ring-primary/20' : 'border-[#b5b5b5]'
@@ -272,13 +272,13 @@ export function BenefitApplicationsLanding({
             </div>
           ) : (
             <div className="flex flex-1 flex-col px-6 py-6 sm:px-8">
-              <p className="font-source-serif text-lg font-bold text-foreground sm:text-xl">
+              <p className="font-source-serif text-lg font-semibold text-foreground sm:text-xl">
                 Describe what you need
               </p>
-              <p className="mt-1 font-inter text-sm text-muted-foreground sm:text-base">
+              <p className="mt-1 font-source-serif text-sm text-muted-foreground sm:text-base">
                 Use this for clients without an Apricot 360 ID, multiple programs, or programs not in the list.
               </p>
-              <div className="mt-4 flex flex-1 flex-col">
+              <div className="mt-3 flex flex-1 flex-col">
                 <MultimodalInput
                   chatId={chatId}
                   input={input}
@@ -292,6 +292,7 @@ export function BenefitApplicationsLanding({
                   sendMessage={sendMessage}
                   selectedVisibilityType={selectedVisibilityType}
                   showStopButton={false}
+                  fullWidthSubmit
                   placeholder="Apply [ID ####] for [Program URL]"
                   session={session}
                 />

--- a/components/model-selector-button.tsx
+++ b/components/model-selector-button.tsx
@@ -28,16 +28,17 @@ const MODEL_GROUPS: Array<{ name: string; models: ModelOption[] }> = [
   {
     name: 'OpenAI',
     models: [
-      { id: 'gpt-5.4', name: 'GPT-5.4', provider: 'openai' },
-      { id: 'gpt-5.4-pro', name: 'GPT-5.4 Pro', provider: 'openai' },
-      { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini', provider: 'openai' },
-      { id: 'gpt-5.4-nano', name: 'GPT-5.4 Nano', provider: 'openai' },
+      { id: 'gpt-5.5', name: 'GPT-5.5', provider: 'openai' },
+      { id: 'gpt-5.5-pro', name: 'GPT-5.5 Pro', provider: 'openai' },
+      { id: 'gpt-5.5-mini', name: 'GPT-5.5 Mini', provider: 'openai' },
+      { id: 'gpt-5.5-nano', name: 'GPT-5.5 Nano', provider: 'openai' },
     ],
   },
   {
     name: 'Anthropic',
     models: [
       { id: 'claude-opus-4-7', name: 'Claude Opus 4.7', provider: 'anthropic' },
+      { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'anthropic' },
       { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'anthropic' },
       { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', provider: 'anthropic' },
     ],

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -50,6 +50,7 @@ function PureMultimodalInput({
   selectedVisibilityType,
   showStopButton = true,
   placeholder = 'Write something...',
+  fullWidthSubmit = false,
   session,
 }: {
   chatId: string;
@@ -66,6 +67,7 @@ function PureMultimodalInput({
   selectedVisibilityType: VisibilityType;
   showStopButton?: boolean;
   placeholder?: string;
+  fullWidthSubmit?: boolean;
   session: Session | null;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -228,7 +230,7 @@ function PureMultimodalInput({
   }, [status, scrollToBottom]);
 
   return (
-    <div className="relative w-full flex flex-col gap-4 min-w-0">
+    <div className={cx('relative w-full flex flex-col gap-4 min-w-0', fullWidthSubmit && 'flex-1')}>
       <AnimatePresence>
         {isHydrated && !isAtBottom && messages.length > 0 && (
           <motion.div
@@ -307,7 +309,10 @@ function PureMultimodalInput({
           value={input}
           onChange={handleInput}
           className={cx(
-            'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base border-2 border-input bg-card text-foreground placeholder-muted-foreground focus-visible:border-primary dark:focus-visible:border-primary transition-colors pb-10',
+            'max-h-[200px] overflow-y-auto break-words resize-none !text-base bg-card text-foreground placeholder-muted-foreground focus-visible:border-primary dark:focus-visible:border-primary transition-colors pb-10',
+            fullWidthSubmit
+              ? 'min-h-[180px] rounded-[10px] border border-[#b5b5b5]'
+              : 'min-h-[24px] rounded-2xl border-2 border-input',
             className,
           )}
           rows={2}
@@ -331,24 +336,43 @@ function PureMultimodalInput({
         />
       </div>
 
-      <div className="flex flex-row justify-between gap-2 mt-1">
-        <div className="flex flex-row items-center gap-2">
-          <ModelSelectorButton onModelChange={(model) => setSelectedModelId(model.id)} />
-          <ContextUsage />
-        </div>
-        <div className="flex flex-row gap-2">
-          {showStopButton && (
-            <StopButton status={status} stop={stop} setMessages={setMessages} />
-          )}
+      {fullWidthSubmit ? (
+        <div className="mt-auto flex flex-col gap-3 -mx-6 border-t border-border px-6 pt-5 sm:-mx-8 sm:px-8">
           <SendButton
             input={input}
             submitForm={submitForm}
             uploadQueue={uploadQueue}
             status={status}
             isLoggedIn={isLoggedIn}
+            fullWidth
           />
+          {!isProductionEnvironment && (
+            <div className="flex flex-row items-center gap-2">
+              <ModelSelectorButton onModelChange={(model) => setSelectedModelId(model.id)} />
+              <ContextUsage />
+            </div>
+          )}
         </div>
-      </div>
+      ) : (
+        <div className="flex flex-row justify-between gap-2 mt-1">
+          <div className="flex flex-row items-center gap-2">
+            <ModelSelectorButton onModelChange={(model) => setSelectedModelId(model.id)} />
+            <ContextUsage />
+          </div>
+          <div className="flex flex-row gap-2">
+            {showStopButton && (
+              <StopButton status={status} stop={stop} setMessages={setMessages} />
+            )}
+            <SendButton
+              input={input}
+              submitForm={submitForm}
+              uploadQueue={uploadQueue}
+              status={status}
+              isLoggedIn={isLoggedIn}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -426,26 +450,39 @@ function PureSendButton({
   uploadQueue,
   status,
   isLoggedIn,
+  fullWidth = false,
 }: {
   submitForm: () => void;
   input: string;
   uploadQueue: Array<string>;
   status: UseChatHelpers<ChatMessage>['status'];
   isLoggedIn: boolean;
+  fullWidth?: boolean;
 }) {
   const isWorking = status === 'submitted' || status === 'streaming';
   const isDisabled = !isLoggedIn || input.length === 0 || uploadQueue.length > 0 || isWorking;
 
-  const button = (
+  const handleClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    if (isLoggedIn && status === 'ready') {
+      submitForm();
+    }
+  };
+
+  const button = fullWidth ? (
+    <Button
+      data-testid="send-button"
+      className="w-full h-auto rounded-lg bg-primary px-4 py-2.5 font-inter text-sm font-medium tracking-[0.08px] text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+      onClick={handleClick}
+      disabled={isDisabled}
+    >
+      Start auto-filling
+    </Button>
+  ) : (
     <Button
       data-testid="send-button"
       className="bg-primary hover:bg-primary/90 disabled:bg-muted disabled:hover:bg-muted rounded-[100px] px-3 py-1.5 flex items-center gap-1 text-primary-foreground disabled:text-muted-foreground text-sm font-medium disabled:opacity-50 disabled:pointer-events-auto disabled:cursor-not-allowed transition-colors"
-      onClick={(event) => {
-        event.preventDefault();
-        if (isLoggedIn && status === 'ready') {
-          submitForm();
-        }
-      }}
+      onClick={handleClick}
       disabled={isDisabled}
     >
       <ArrowUpIcon size={20} />
@@ -484,5 +521,6 @@ const SendButton = memo(PureSendButton, (prevProps, nextProps) => {
   if (prevProps.input !== nextProps.input) return false;
   if (prevProps.status !== nextProps.status) return false;
   if (prevProps.isLoggedIn !== nextProps.isLoggedIn) return false;
+  if (prevProps.fullWidth !== nextProps.fullWidth) return false;
   return true;
 });

--- a/components/suggested-actions.tsx
+++ b/components/suggested-actions.tsx
@@ -65,12 +65,9 @@ function PureSuggestedActions({
                 parts: [{ type: 'text', text: suggestedAction.action }],
               });
             }}
-            className="text-left border border-sidebar-border rounded-xl px-3 sm:px-4 py-3 sm:py-3.5 text-sm gap-1 flex-col w-full h-auto justify-start items-start transition-colors duration-200 bg-[#E8D0E0] hover:bg-[#DCC0D0] hover:text-black dark:bg-[#2D1B2E] dark:hover:bg-[#3D2A3E] whitespace-normal overflow-hidden"
+            className="text-left border border-border rounded-lg px-3 py-1.5 text-xs font-medium w-full h-auto justify-start items-center transition-colors duration-200 bg-muted text-foreground hover:bg-accent hover:text-accent-foreground whitespace-nowrap overflow-hidden"
           >
-            <span className="font-medium truncate max-w-full">{suggestedAction.title}</span>
-            <span className="text-muted-foreground text-xs font-mono truncate max-w-full">
-              {suggestedAction.label}
-            </span>
+            <span className="truncate max-w-full">{suggestedAction.title}</span>
           </Button>
         </motion.div>
       ))}


### PR DESCRIPTION
## Ticket

[Adds a redesigned landing experience for starting a new benefit application.](https://navalabs.atlassian.net/browse/ASP-932)

## Changes

- Replaced the two-panel desktop layout (left title / right form) with a single centered card capped at 648px width
- Added a tabbed interface inside the card:
  - **Select program** — Client ID + program combobox + "Start auto-filling" footer button (the existing structured flow)
  - **Describe what you need** — embeds `MultimodalInput` for clients without an Apricot 360 ID, multiple programs, or programs not in the list
- Moved the freeform prompt into the new "Describe" tab instead of rendering it below the form card
- Swapped the combobox `ChevronDown` icon for `ChevronsUpDown` (no rotation on open)
- Restyled inputs and typography: smaller base sizes, `bg-card` surfaces, responsive `sm:` breakpoints, footer-anchored submit button
- Reworked the login alert to stack on mobile and stay inline on `sm+`

Single file touched: `components/benefit-applications-landing.tsx` (+177 / −141).

## Testing

Manually verified in the browser:
- Logged-out state shows the login alert and disables both tabs' inputs
- "Select program" tab: Client ID input, program search/select, URL paste fallback, and "Start auto-filling" submit all work
- "Describe what you need" tab: `MultimodalInput` sends a freeform message
- Mobile and desktop layouts render correctly at the relevant breakpoints

No automated tests added — UI-only change to an existing component.

## Context for reviewers

The tabs replace the previous "form card + separate prompt below" pattern so the two entry modes are clearly mutually exclusive. The card is fixed-height (`md:h-[538px]`) on desktop so swapping tabs doesn't shift surrounding layout. Submit button only renders on the "Select program" tab since the "Describe" tab submits via `MultimodalInput`'s own send action.