### PR TITLE
fix: clarify DOB verification and applicant identity in agent prompts

### DIFF
--- a/lib/ai/prompts/application-protocol.ts
+++ b/lib/ai/prompts/application-protocol.ts
@@ -13,6 +13,21 @@ When given participant data:
 5. If the participant ID does not return a user, inform the caseworker.
 6. Navigate to the appropriate website (research if URL unknown).
 
+<example>
+**Correct verification of a child's date of birth (avoids mistaking "Date created" for DOB):**
+
+Carlos Flores's date of birth came from the Apricot record I pulled for him.
+
+- Record ID: 339704 (linked from Rosa's Family Profile, record 339703)
+- Field: field_1935
+- Label: "Date of birth" (confirmed via the Participant Profile form fields, form 99)
+- Value: "2024-12-01"
+
+That record also shows his name as "Carlos Flores", participant type "Child", and age 5 in field_2310 ("Age at File open date") — though based on the DOB of 2024-12-01 and today's date, his actual current age is about 1 year and 5 months.
+
+The key step is calling \`getApricotFormFields\` for form 99 to confirm that field_1935 is "Date of birth" — not the record's created-at timestamp, not field_2310 ("Age at File open date"), and not any other date-shaped value on the record. Without that label confirmation, a date like "2019-..." (the record's creation date) could be mistaken for the DOB and make a 1-year-old look 7.
+</example>
+
 ## Autofilled Field Detection
 
 On your first snapshot of each form page, check whether any fields are already populated (e.g., autofilled by the site from a prior session, account profile, or URL parameters). Compare the pre-filled values against the participant data from the database. If a field already contains the correct value, do NOT re-fill it — skip it and move on. Only fill fields that are empty or contain an incorrect value. Note any pre-filled fields in your gap analysis so the caseworker knows which values were kept as-is.

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -13,11 +13,15 @@ You are an expert web automation specialist who intelligently does web searches,
 
 ## IMPORTANT — Applicant Identity
 
-The caseworker is filling out the participant's application.
+**The participant whose ID the caseworker provides in the initial prompt IS the applicant/recipient — always.** This holds regardless of whether other family members appear in the database (e.g., the parent's Family Profile linking to children, or a child's record linking to a parent). Do not switch the applicant based on which program you're applying to or which family member "seems more typical" for that program. If the prompt names Rosa's ID, Rosa is the applicant — even for a child-focused program like WIC, where you would instead expect Carlos's ID. If the prompt names Carlos's ID, Carlos is the recipient and Rosa is the representative — even though Carlos is a child.
 
-- **Adult (18+)**: Select "Applying for myself" / "Self". Never select "on behalf of someone else."
-- **Child (under 18)**: The parent/guardian applies on the child's behalf. Select "Parent/Guardian" / "On behalf of someone else." Fill the child's info in recipient fields and the parent/guardian's info in representative fields. If the parent/guardian's info isn't in the database, include it in the gap analysis.
-- **Age unknown**: Check the database for date of birth. If still unknown, clarify with the caseworker.
+Once the applicant is fixed by the prompt, use their age to pick the correct "applying for whom" option:
+
+- **Applicant is an adult (18+)**: Select "Applying for myself" / "Self". Never select "on behalf of someone else." Other household members are NOT the applicant, even if they're children and the program (e.g., WIC) typically serves children.
+- **Applicant is a child (under 18)**: The parent/guardian applies on the child's behalf. Select "Parent/Guardian" / "On behalf of someone else." Fill the child's info in recipient fields and the parent/guardian's info in representative fields. If the parent/guardian's info isn't in the database, include it in the gap analysis.
+- **Applicant's age unknown**: Check the database for date of birth (confirm the field via \`getApricotFormFields\` — see Data Provenance). If still unknown, clarify with the caseworker before choosing an option.
+
+If the caseworker's prompt is genuinely ambiguous about whose ID was provided (e.g., two IDs, or no ID at all), stop and ask — do not pick an applicant on your own.
 
 ## Core Approach
 1. AUTONOMOUS: Take decisive action without asking for permission, except for the last submission step.


### PR DESCRIPTION
## Ticket

- Resolves [ASP-923](https://navalabs.atlassian.net/browse/ASP-923)
- Resolves [ASP-913](https://navalabs.atlassian.net/browse/ASP-913)

Addresses two recurring agent failure modes observed during WIC application sessions:

1. The agent inconsistently calls `getApricotFormFields`, leading it to guess that a record's "Date created" is the child's DOB (e.g., Carlos Flores rendered as 7 years old instead of 1).
2. The agent gets confused about whether the adult or the child is the applicant when both appear in the participant data — even when the caseworker explicitly provided the adult's ID.

## Changes

- `lib/ai/prompts/application-protocol.ts` — Added a worked `<example>` under **Database Retrieval & Verification** showing the correct DOB verification path: record ID → `field_1935` → label confirmed as "Date of birth" via `getApricotFormFields` on form 99 → value. Explicitly calls out why this matters (without label confirmation, a creation-date or `field_2310` "Age at File open date" can be mistaken for DOB).
- `lib/ai/prompts/web-automation.ts` — Reworked the **IMPORTANT — Applicant Identity** section:
  - Led with an unambiguous rule: the participant whose ID is in the initial prompt **is** the applicant/recipient, regardless of program.
  - Called out the specific WIC failure mode (Rosa's ID → Rosa applies, not Carlos, even though WIC typically serves children).
  - Kept the adult-vs-child branch, but framed it as "given the applicant fixed by the prompt, pick the right 'applying for whom' option" rather than as the primary decision.
  - Added a fallback for genuinely ambiguous prompts (two IDs / no ID): stop and ask, don't guess.

## Testing

Prompt-only change — no code paths modified, no tests added. Will be validated against the WIC scenarios that surfaced both bugs (Rosa + Carlos household, adult-applicant and child-applicant variants) once merged into the eval/test environment.

## Context for reviewers

Both edits are additive clarifications to existing rules, not new behavior. The DOB example mirrors the exact (correct) output the agent produced when it *did* call \`getApricotFormFields\`, so it serves as a positive demonstration of the workflow already required by rule #2 in that section. The applicant-identity rewrite specifically targets the WIC case where the agent over-indexed on "WIC is for children" and overrode the explicit ID in the prompt.