### PR TITLE
fix: project next-step tokens so compaction fires before context overflow

### DIFF
--- a/lib/ai/context-compression.ts
+++ b/lib/ai/context-compression.ts
@@ -208,7 +208,9 @@ function buildSummaryMessage(summary: string): ModelMessage {
  * original messages that were summarized) and re-apply it on every
  * subsequent prepareStep call.
  */
-export function createMessageCompressor() {
+export function createMessageCompressor(
+  summarize: typeof summarizeMessages = summarizeMessages,
+) {
   let justCompacted = false;
 
   // Persisted compaction state — survives across prepareStep calls
@@ -253,28 +255,31 @@ export function createMessageCompressor() {
       return { messages: prepend(pruned), compacted: false };
     }
 
-    const usedPct = lastInputTokens / MODEL_CONTEXT_WINDOW;
+    const headroomTokens = maxRecentToolResultTokens(effectiveMessages);
+    const projectedTokens = lastInputTokens + headroomTokens;
+    const projectedPct = projectedTokens / MODEL_CONTEXT_WINDOW;
 
     if (justCompacted) {
       justCompacted = false;
       log(
-        `skip — stale inputTokens after compaction, ${effectiveMessages.length} msgs, ${(usedPct * 100).toFixed(1)}% (stale)`
+        `skip — stale inputTokens after compaction, ${effectiveMessages.length} msgs, ` +
+        `${((lastInputTokens / MODEL_CONTEXT_WINDOW) * 100).toFixed(1)}% (stale)`
       );
       return { messages: prepend(effectiveMessages), compacted: false };
     }
 
     log(
       `step check — ${effectiveMessages.length} msgs (raw ${stepMessages.length}${wm ? ', +WM' : ''}), ` +
-      `inputTokens=${lastInputTokens ?? 'n/a'}, ` +
-      `${(usedPct * 100).toFixed(1)}% of ${MODEL_CONTEXT_WINDOW} context window, ` +
+      `inputTokens=${lastInputTokens}, headroom=${headroomTokens}, ` +
+      `projected=${projectedTokens} (${(projectedPct * 100).toFixed(1)}%), ` +
       `threshold=${(COMPACT_THRESHOLD_PCT * 100).toFixed(0)}%`
     );
 
-    if (usedPct < COMPACT_THRESHOLD_PCT) {
+    if (projectedPct < COMPACT_THRESHOLD_PCT) {
       return { messages: prepend(effectiveMessages), compacted: false };
     }
 
-    const result = await summarizeMessages(effectiveMessages, '', onCompacting);
+    const result = await summarize(effectiveMessages, '', onCompacting);
     if (!result) {
       justCompacted = true;
       return { messages: prepend(effectiveMessages), compacted: false };

--- a/lib/ai/context-compression.ts
+++ b/lib/ai/context-compression.ts
@@ -6,8 +6,21 @@ import { updateWorkingMemory } from '@/lib/ai/tools/working-memory';
 const MODEL_CONTEXT_WINDOW = 200_000; // claude-sonnet-4-6
 const COMPACT_THRESHOLD_PCT = 0.75;
 const KEEP_RECENT = 8;                // keep last N messages after compaction
+const TOOL_RESULT_WINDOW = 5;
 
 const SUMMARY_PREFIX = '[Session summary — earlier context compacted]';
+
+function estimateMessageTokens(m: ModelMessage): number {
+  return Math.ceil(JSON.stringify(m.content).length / 4);
+}
+
+function maxRecentToolResultTokens(messages: ModelMessage[]): number {
+  const toolMessages = messages
+    .filter((m) => m.role === 'tool')
+    .slice(-TOOL_RESULT_WINDOW);
+  if (toolMessages.length === 0) return 0;
+  return Math.max(...toolMessages.map(estimateMessageTokens));
+}
 
 const COMPACTION_SYSTEM_PROMPT =
   'You are creating a session handoff document for a benefits form-filling agent. ' +
@@ -289,3 +302,5 @@ export function createMessageCompressor() {
     return { messages: prepend([newSummaryMessage, ...result.recentMessages]), compacted: true, summary: result.summary };
   };
 }
+
+export const __test__ = { estimateMessageTokens, maxRecentToolResultTokens };

--- a/lib/ai/context-compression.ts
+++ b/lib/ai/context-compression.ts
@@ -5,7 +5,7 @@ import { updateWorkingMemory } from '@/lib/ai/tools/working-memory';
 
 const MODEL_CONTEXT_WINDOW = 200_000; // claude-sonnet-4-6
 const COMPACT_THRESHOLD_PCT = 0.75;
-const KEEP_RECENT = 8;                // keep last N messages after compaction
+const KEEP_RECENT = 16;               // keep last N messages after compaction
 const TOOL_RESULT_WINDOW = 5;
 
 const SUMMARY_PREFIX = '[Session summary — earlier context compacted]';

--- a/lib/ai/prompts/web-automation.ts
+++ b/lib/ai/prompts/web-automation.ts
@@ -52,6 +52,12 @@ This section applies ONLY when there is an in-progress application from a prior 
 
 When resuming: the browser is still on the last page and mid-form. Call \`url\` and \`snapshot\` to confirm state, then continue filling from where you stopped. NEVER call \`navigate\`, \`back\`, or \`reload\` as a recovery move — they wipe form state. NEVER restart the application from scratch unless the caseworker explicitly asks. If you can't tell where you are, stop and report to the caseworker; do not re-navigate.
 
+## Session Summary Messages
+
+If you see an assistant message starting with \`[Session summary — earlier context compacted]\`, treat its contents as **authoritative ground truth** for work already completed in this session. Do not redo completed steps. Do not call \`formSummary\` unless the summary explicitly confirms you reached a review page. If the summary lists a form as filled, it was filled — even if you do not see the individual tool calls in this view.
+
+If the summary contradicts what the most recent tool results suggest, prefer the summary for completed-work claims and the tool results for current page state.
+
 ## Action Labeling
 Before each logical group of related browser actions, call \`actionLabel\` ONCE with the best-fit \`category\`: \`fill\`, \`navigate\`, \`interact\`, \`read\`, \`search\`, or \`misc\`.
 

--- a/tests/lib/ai/context-compression.test.ts
+++ b/tests/lib/ai/context-compression.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest';
+import type { ModelMessage } from 'ai';
+import { __test__ } from '@/lib/ai/context-compression';
+
+const { maxRecentToolResultTokens, estimateMessageTokens } = __test__;
+
+function toolMsg(payload: unknown): ModelMessage {
+  return {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'tc_test',
+        toolName: 'browser',
+        output: { type: 'json', value: payload },
+      },
+    ],
+  } as ModelMessage;
+}
+
+function userMsg(text: string): ModelMessage {
+  return { role: 'user', content: text } as ModelMessage;
+}
+
+describe('estimateMessageTokens', () => {
+  test('returns ceil(content-chars / 4) for a tool message', () => {
+    const m = toolMsg({ data: 'a'.repeat(400) });
+    const result = estimateMessageTokens(m);
+    // Payload is ~500 chars after JSON wrapping: { data: "aaa...400" } plus
+    // tool-result envelope. Expect ~125 tokens; bounds catch off-by-4x errors
+    // in either direction.
+    expect(result).toBeGreaterThanOrEqual(120);
+    expect(result).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('maxRecentToolResultTokens', () => {
+  test('returns 0 when there are no tool-role messages', () => {
+    expect(maxRecentToolResultTokens([userMsg('hi'), userMsg('there')])).toBe(0);
+  });
+
+  test('returns the max estimated size among the last 5 tool messages', () => {
+    const big = toolMsg({ snapshot: 'x'.repeat(60_000 * 4) }); // ~60K tokens
+    const small = toolMsg({ ok: true });
+    const messages = [userMsg('start'), big, small, small, small, small];
+    const result = maxRecentToolResultTokens(messages);
+    expect(result).toBeGreaterThan(50_000);
+  });
+
+  test('window of 5 means an older big result falls out', () => {
+    const big = toolMsg({ snapshot: 'x'.repeat(60_000 * 4) });
+    const small = toolMsg({ ok: true });
+    const messages = [big, small, small, small, small, small];
+    const result = maxRecentToolResultTokens(messages);
+    expect(result).toBeLessThan(1_000);
+  });
+
+  test('window counts tool-role messages only, not all messages', () => {
+    const big = toolMsg({ snapshot: 'x'.repeat(60_000 * 4) });
+    const small = toolMsg({ ok: true });
+    // 6 tool messages total. If implementation correctly filters first then takes
+    // the last 5 tool messages, `big` is among them (positions 2-6 of the tool
+    // messages) and the max is large. If implementation incorrectly slices first
+    // (last 5 of all 11 messages), `big` would fall outside the slice and the
+    // max would be small.
+    const messages = [
+      small,
+      userMsg('u1'),
+      big,
+      userMsg('u2'),
+      small,
+      userMsg('u3'),
+      small,
+      userMsg('u4'),
+      small,
+      userMsg('u5'),
+      small,
+    ];
+    const result = maxRecentToolResultTokens(messages);
+    expect(result).toBeGreaterThan(50_000);
+  });
+});

--- a/tests/lib/ai/context-compression.test.ts
+++ b/tests/lib/ai/context-compression.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import type { ModelMessage } from 'ai';
-import { __test__ } from '@/lib/ai/context-compression';
+import { __test__, createMessageCompressor } from '@/lib/ai/context-compression';
 
 const { maxRecentToolResultTokens, estimateMessageTokens } = __test__;
 
@@ -20,6 +20,10 @@ function toolMsg(payload: unknown): ModelMessage {
 
 function userMsg(text: string): ModelMessage {
   return { role: 'user', content: text } as ModelMessage;
+}
+
+function assistantMsg(text: string): ModelMessage {
+  return { role: 'assistant', content: text } as ModelMessage;
 }
 
 describe('estimateMessageTokens', () => {
@@ -79,4 +83,89 @@ describe('maxRecentToolResultTokens', () => {
     const result = maxRecentToolResultTokens(messages);
     expect(result).toBeGreaterThan(50_000);
   });
+});
+
+// 200K window; 75% threshold = 150K
+const UNDER_THRESHOLD_TOKENS = 130_000;
+const ABOVE_THRESHOLD_TOKENS = 160_000;
+
+const hasApi =
+  !!process.env.ANTHROPIC_API_KEY ||
+  !!process.env.GOOGLE_VERTEX_PROJECT ||
+  !!process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+describe('createMessageCompressor — proactive projection', () => {
+  test('does NOT compact when projection stays under threshold', async () => {
+    const compressor = createMessageCompressor();
+    const small = toolMsg({ ok: true });
+    const filler: ModelMessage[] = Array.from({ length: 20 }, (_, i) =>
+      i % 2 === 0 ? userMsg(`u${i}`) : assistantMsg(`a${i}`),
+    );
+    const messages = [...filler, small, small, small, small, small];
+
+    // 130K + ~1K headroom = ~131K → below 150K threshold, no compaction.
+    const result = await compressor(messages, UNDER_THRESHOLD_TOKENS);
+
+    expect(result.compacted).toBe(false);
+  });
+
+  test('projection triggers compaction without a Haiku call', async () => {
+    const stubSummary = {
+      summary: 'test summary',
+      workingMemory: null,
+      recentMessages: [] as ModelMessage[],
+      splitAt: 5,
+    };
+    const summarizeSpy = vi.fn().mockResolvedValue(stubSummary);
+    const compressor = createMessageCompressor(summarizeSpy);
+    const big = toolMsg({ snapshot: 'x'.repeat(60_000 * 4) }); // ~60K headroom
+    const filler: ModelMessage[] = Array.from({ length: 20 }, (_, i) =>
+      i % 2 === 0 ? userMsg(`u${i}`) : assistantMsg(`a${i}`),
+    );
+    const messages = [...filler, big];
+
+    // 130K (65% — under reactive threshold) + 60K headroom = 190K projected (95%)
+    // → projection trigger fires. With the old reactive logic this would NOT have
+    // compacted.
+    const result = await compressor(messages, UNDER_THRESHOLD_TOKENS);
+
+    expect(summarizeSpy).toHaveBeenCalledTimes(1);
+    expect(result.compacted).toBe(true);
+    expect(result.summary).toBe('test summary');
+  });
+
+  test.skipIf(!hasApi)(
+    'compacts when lastInputTokens + headroom crosses threshold',
+    async () => {
+      const compressor = createMessageCompressor();
+      const big = toolMsg({ snapshot: 'x'.repeat(60_000 * 4) }); // ~60K tokens
+      const filler: ModelMessage[] = Array.from({ length: 20 }, (_, i) =>
+        i % 2 === 0 ? userMsg(`u${i}`) : assistantMsg(`a${i}`),
+      );
+      const messages = [...filler, big];
+
+      // 130K + 60K headroom = 190K (95%) → compaction triggers even though
+      // lastInputTokens alone (130K = 65%) was below the 75% threshold.
+      const result = await compressor(messages, UNDER_THRESHOLD_TOKENS);
+
+      expect(result.compacted).toBe(true);
+      expect(result.messages.length).toBeLessThan(messages.length);
+    },
+    60_000,
+  );
+
+  test.skipIf(!hasApi)(
+    'still compacts when lastInputTokens alone crosses threshold',
+    async () => {
+      const compressor = createMessageCompressor();
+      const filler: ModelMessage[] = Array.from({ length: 20 }, (_, i) =>
+        i % 2 === 0 ? userMsg(`u${i}`) : assistantMsg(`a${i}`),
+      );
+
+      const result = await compressor(filler, ABOVE_THRESHOLD_TOKENS);
+
+      expect(result.compacted).toBe(true);
+    },
+    60_000,
+  );
 });


### PR DESCRIPTION
## Ticket

Resolves ASP-945 and the conversational-checkpoint regressions flagged in the May 28 PR 370 eval (`eval_comparison_PR_370_2026-05-28.docx`).

## Changes

- **`lib/ai/context-compression.ts`** — added a stateless `maxRecentToolResultTokens(messages)` helper that scans the last 5 tool-role messages and returns the max estimated token size. The threshold check inside `createMessageCompressor` now projects `lastInputTokens + headroomTokens` instead of just `lastInputTokens`, so compaction fires *before* a large browser snapshot pushes context past 100%.
- **`lib/ai/context-compression.ts`** — bumped `KEEP_RECENT` from 8 to 16. A typical form-page fill cycle is 6–10 tool calls; 8 was too small to preserve a just-completed page across a compaction.
- **`lib/ai/prompts/web-automation.ts`** — added a `## Session Summary Messages` section instructing the agent to treat `[Session summary — earlier context compacted]` messages as authoritative ground truth for completed work, and not to call `formSummary` unless the summary explicitly confirms a review page.
- **`lib/ai/context-compression.ts`** — `createMessageCompressor` now takes an optional `summarize` parameter (default = real implementation) to enable offline unit tests of the projection trigger. No production caller changes.
- **`tests/lib/ai/context-compression.test.ts`** *(new file)* — 9 vitest unit tests covering the helper and the projection trigger; 7 unconditional + 2 API-gated (`skipIf` no `ANTHROPIC_API_KEY` / `GOOGLE_VERTEX_PROJECT` / `GOOGLE_APPLICATION_CREDENTIALS`).

## Testing

- New unit tests: `tests/lib/ai/context-compression.test.ts` — run with `pnpm test tests/lib/ai/context-compression.test.ts` (or `npx vitest run --browser.enabled=false tests/lib/ai/context-compression.test.ts` if the global browser-mode config hangs locally). 7 pass + 2 skipped offline; 9/9 pass with creds.
- The key discriminating test (`projection triggers compaction without a Haiku call`) uses a `vi.fn()` stub for `summarizeMessages` and asserts compaction fires at 130K \`lastInputTokens\` + 60K headroom (projected 190K) — a case the old reactive logic would NOT have caught at 130K alone.
- A second discriminating test verifies filter-then-slice semantics in `maxRecentToolResultTokens` (would fail under a slice-then-filter implementation).
- Manual eval verification recommended before merging: re-run BenefitsCal Step 26 and IHSS Step 12 traces on dev to confirm checkpoints fire earlier than the page boundaries and the agent does not call `formSummary` mid-flow.

## Context for reviewers

### Why this surfaced now

The "Conversational Checkpoint" UI shows context compaction events. The compaction system has existed for a while; PR #370 added the UI cards (\`3ff025b\`, \`1eca389\`), making the (preexisting) compactions visible. The eval then flagged what the compactions were doing to agent behavior:

- **Checkpoints at 95% and 102%** — the threshold check in `prepareStep` used the *previous* step's `inputTokens`, so a single browser snapshot adding 30–60K tokens could push a 65% step to 95% before the next prepareStep had a chance to compact. (102% values are a secondary artifact of the Anthropic SDK adapter summing `input_tokens` across iterations; proactive prediction makes this moot.)
- **IHSS amnesia (Step 12)** — after a compaction, the agent only sees the Haiku summary + last 8 messages + working memory. With \`KEEP_RECENT = 8\` and 6–10 tool calls per form page, the just-filled IHSS page was getting folded entirely into the summary.
- **ASP-945 (premature \`formSummary\`)** — after a compaction mid-BenefitsCal, the agent had no instruction to treat the summary as authoritative for completed work, so it would emit the Review/Submit card thinking it was at the end of the form.

I verified prompt caching (PR #233) is **not** the direct cause: \`usage.inputTokens.total\` in the AI SDK = \`input_tokens + cache_creation + cache_read\` (\`@ai-sdk/anthropic/dist/index.js:1627\`), so cached tokens are correctly counted toward the threshold.

### Approach

Three coordinated, small changes attacking the three failure modes — kept the changes minimal on purpose. \`COMPACT_THRESHOLD_PCT\` stays at \`0.75\`; we're projecting overshoot, not lowering the gate.

### Out of scope (intentionally)

- The 3-breakpoint cache layout from unmerged \`8640fbc\` — separate decision.
- Replacing the Haiku summary with structured tool-call extraction — iterate later if the prompt block isn't enough.
- Patching the SDK adapter's iterations sum — downstream; projection makes it irrelevant for our threshold math.

### Files / lines

3 files, +205 / −8 lines. Per-task review history is in the commits:

\`\`\`
60d7ad9 fix(prompt): teach agent to trust [Session summary] messages
dd41df0 fix(compaction): keep last 16 messages after compaction (was 8)
47027da fix(compaction): project next-step tokens with tool-result headroom
ce76fee feat(compaction): add maxRecentToolResultTokens helper
\`\`\`

A final reviewer flagged two post-ship cleanup items (hoist the \`justCompacted\` guard above the projection computation; tighten one test's token bounds). Both are micro; happy to address in a follow-up if reviewers prefer.