### PR TITLE
ci: add AI test classifier workflow (p0 observe-only)

### DIFF
--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -1,0 +1,12 @@
+name: AI test classifier
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  classify:
+    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@test-classifier-v0
+    with:
+      tool: claude
+      mode: p0
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Adds `.github/workflows/ai-test-classifier.yml`, which calls the classifier's reusable workflow pinned to `@test-classifier-v0` on PR open/synchronize/reopen.

- **Mode:** `p0` (observe-only) — records an `ai-test-classification` artifact on the PR's Actions run, posts no comment.
- Per install doc: do not enable `p1`/gating yet; flip later once P0 looks trustworthy.

Manual prerequisites (done by maintainer): `ANTHROPIC_API_KEY` secret set, and org access enabled on the source repo.