### PR TITLE
feat(test-classifier): add AI test classifier caller workflow

### DIFF
--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -1,11 +1,35 @@
 name: AI test classifier
+#
+# Lifecycle-aware caller for the AI test classifier reusable workflow.
+#
+# This runs AFTER your test workflow finishes, so the classifier can read your
+# REAL test results (OBSERVED mode) instead of only guessing from the diff.
+#
+# ── IMPORTANT: set this to YOUR test workflow's name ────────────────────────
+# `workflow_run.workflows` must list the `name:` of the workflow that runs your
+# test suite — exactly as it appears at the top of that workflow file (the
+# `name:` field, NOT the filename). The convention names below cover the common
+# cases ("Test" / "CI" / "Tests"); edit this list so it contains your suite's
+# actual workflow name. If none match, this caller will silently never fire.
+#
+# NOTE: GitHub reads `workflow_run` triggers from the workflow file on your
+# repo's DEFAULT branch. The trigger will not fire while this file lives only on
+# a feature branch — merge it to the default branch to activate it. Forked-PR
+# runs also won't carry your secrets; that is a GitHub platform constraint.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["Test", "CI", "Tests"]   # ← your test workflow's name(s)
+    types: [completed]
+
 jobs:
   classify:
     uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@pilot
     with:
       tool: claude
+      # Name of the artifact your test workflow uploads with its results
+      # (JUnit XML and/or a captured run log). Defaults to 'ai-test-results'.
+      # Have your test job upload results under this name to unlock OBSERVED mode;
+      # without it, the classifier still runs in INFERRED/diff-only mode.
+      test-results-artifact: ai-test-results
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -4,14 +4,14 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   classify:
-    # Pinned to PR #22 (navapbc/ai-transformation-delivery-systems@c159a2a,
+    # Pinned to PR #22 (navapbc/ai-transformation-delivery-systems@76f91c8,
     # branch classifier-agent-runs-suite) — the design where the agent runs the
     # repo's suite itself for OBSERVED verdicts. NOT @pilot (older design).
     # Both refs are pinned: the `uses:` ref selects the reusable workflow YAML,
     # and `ref:` selects the bundle scripts/SKILL.md it checks out.
-    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@c159a2ac5c7ea469a1ffe19ed992cc1d05a78969
+    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@76f91c87c100b0b605780c7ed84fbfdbfdba6b36
     with:
       tool: claude
-      ref: c159a2ac5c7ea469a1ffe19ed992cc1d05a78969
+      ref: 76f91c87c100b0b605780c7ed84fbfdbfdba6b36
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -1,35 +1,17 @@
 name: AI test classifier
-#
-# Lifecycle-aware caller for the AI test classifier reusable workflow.
-#
-# This runs AFTER your test workflow finishes, so the classifier can read your
-# REAL test results (OBSERVED mode) instead of only guessing from the diff.
-#
-# ── IMPORTANT: set this to YOUR test workflow's name ────────────────────────
-# `workflow_run.workflows` must list the `name:` of the workflow that runs your
-# test suite — exactly as it appears at the top of that workflow file (the
-# `name:` field, NOT the filename). The convention names below cover the common
-# cases ("Test" / "CI" / "Tests"); edit this list so it contains your suite's
-# actual workflow name. If none match, this caller will silently never fire.
-#
-# NOTE: GitHub reads `workflow_run` triggers from the workflow file on your
-# repo's DEFAULT branch. The trigger will not fire while this file lives only on
-# a feature branch — merge it to the default branch to activate it. Forked-PR
-# runs also won't carry your secrets; that is a GitHub platform constraint.
 on:
-  workflow_run:
-    workflows: ["Test", "CI", "Tests"]   # ← your test workflow's name(s)
-    types: [completed]
-
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   classify:
-    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@pilot
+    # Pinned to PR #22 (navapbc/ai-transformation-delivery-systems@c159a2a,
+    # branch classifier-agent-runs-suite) — the design where the agent runs the
+    # repo's suite itself for OBSERVED verdicts. NOT @pilot (older design).
+    # Both refs are pinned: the `uses:` ref selects the reusable workflow YAML,
+    # and `ref:` selects the bundle scripts/SKILL.md it checks out.
+    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@c159a2ac5c7ea469a1ffe19ed992cc1d05a78969
     with:
       tool: claude
-      # Name of the artifact your test workflow uploads with its results
-      # (JUnit XML and/or a captured run log). Defaults to 'ai-test-results'.
-      # Have your test job upload results under this name to unlock OBSERVED mode;
-      # without it, the classifier still runs in INFERRED/diff-only mode.
-      test-results-artifact: ai-test-results
+      ref: c159a2ac5c7ea469a1ffe19ed992cc1d05a78969
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -1,0 +1,11 @@
+name: AI test classifier
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  classify:
+    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@pilot
+    with:
+      tool: claude
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -4,14 +4,15 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   classify:
-    # Pinned to PR #22 (navapbc/ai-transformation-delivery-systems@76f91c8,
+    # Pinned to PR #22 head (navapbc/ai-transformation-delivery-systems@a8cfe78,
     # branch classifier-agent-runs-suite) — the design where the agent runs the
-    # repo's suite itself for OBSERVED verdicts. NOT @pilot (older design).
+    # repo's suite itself for OBSERVED verdicts. NOT @pilot: the pilot tag is
+    # currently the PR #21 revert (older diff-only design); PR #22 is unmerged.
     # Both refs are pinned: the `uses:` ref selects the reusable workflow YAML,
     # and `ref:` selects the bundle scripts/SKILL.md it checks out.
-    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@76f91c87c100b0b605780c7ed84fbfdbfdba6b36
+    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@a8cfe78f6bc24e3f028f2a72b5ce7e6e54f30acb
     with:
       tool: claude
-      ref: 76f91c87c100b0b605780c7ed84fbfdbfdba6b36
+      ref: a8cfe78f6bc24e3f028f2a72b5ce7e6e54f30acb
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           mkdir -p test-results
           set -o pipefail
-          pnpm test --run \
+          pnpm exec vitest run \
             --reporter=default --reporter=junit \
             --outputFile.junit=test-results/junit.xml \
             2>&1 | tee test-results/test-log.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,17 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
       - name: Run tests
-        run: pnpm test --run
+        run: |
+          mkdir -p test-results
+          set -o pipefail
+          pnpm test --run \
+            --reporter=default --reporter=junit \
+            --outputFile.junit=test-results/junit.xml \
+            2>&1 | tee test-results/test-log.txt
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-test-results
+          path: test-results/
+          if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run tests
+        run: pnpm test --run

--- a/tests/client/consent-modal-actions.test.tsx
+++ b/tests/client/consent-modal-actions.test.tsx
@@ -1,0 +1,15 @@
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { ConsentModal } from '@/components/consent-modal';
+
+test('ConsentModal shows the confirm action label', async () => {
+  const { getByText } = render(
+    <ConsentModal
+      open={true}
+      onOpenChange={vi.fn()}
+      onContinue={vi.fn()}
+    />,
+  );
+
+  await expect.element(getByText('Confirm')).toBeInTheDocument();
+});


### PR DESCRIPTION
Adds the AI test-failure classifier from [navapbc/ai-transformation-delivery-systems](https://github.com/navapbc/ai-transformation-delivery-systems) as a single caller workflow, per its `AGENT_INSTALL.md` (Path A — reusable workflow, pinned to `@pilot`).

## What it does
On each PR (`opened`/`synchronize`/`reopened`), it triages the failing tests your CI **already** produces — classifying each as `APPLICATION_BUG` / `TEST_BUG` / `FLAKY_FAILURE` / `ENVIRONMENT_ISSUE` — and posts **one** non-blocking PR comment with the verdicts and a 👍/👎 ask. The full report is also uploaded as an `ai-test-classification` CI artifact.

It does **not** run the test suite, and gating is **not** enabled (out of scope).

## Required manual step
Set the Anthropic API key secret on this repo (key from <https://console.anthropic.com/settings/keys>):

```
gh secret set ANTHROPIC_API_KEY -R navapbc/ai-chatbot
```

The source repo is public, so no org-access setting is needed.