### PR TITLE
feat: add AI test classifier workflow and pagination test

### DIFF
--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -1,0 +1,11 @@
+name: AI test classifier
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  classify:
+    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@pilot
+    with:
+      tool: claude
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9.12.3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+    - name: Install dependencies
+      run: pnpm install
+    - name: Install Playwright browsers
+      run: pnpm exec playwright install --with-deps chromium
+    - name: Run tests
+      run: pnpm exec vitest run

--- a/tests/client/form-cards-pagination.test.ts
+++ b/tests/client/form-cards-pagination.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { adaptGapSections, adaptReviewSections } from '@/lib/types/form-cards';
+
+describe('form-cards pagination', () => {
+  test('keeps a six-field gap list on a single page', () => {
+    const fields = Array.from({ length: 6 }, (_, i) => ({ field: `f${i + 1}` }));
+    const pages = adaptGapSections({ missingFields: fields });
+    expect(pages).toHaveLength(1);
+    expect(pages[0].fields).toEqual(fields);
+  });
+
+  test('keeps a six-field review list on a single page', () => {
+    const fields = Array.from({ length: 6 }, (_, i) => ({
+      field: `r${i + 1}`,
+      source: 'database' as const,
+    }));
+    const pages = adaptReviewSections({ fields });
+    expect(pages).toHaveLength(1);
+    expect(pages[0].fields).toEqual(fields);
+  });
+});


### PR DESCRIPTION
## What

- Adds `.github/workflows/ai-test-classifier.yml` — the reusable AI test-classifier caller workflow, pinned to `@pilot`. On each PR it triages failing tests and posts one comment with a 👍/👎 ask (non-blocking).
- Adds `tests/client/form-cards-pagination.test.ts` — pagination coverage for `adaptGapSections` / `adaptReviewSections`.

This PR doubles as the first live run of the classifier.