### PR TITLE
fix: microcopy improvements and dynamic sidebar toggle

### DIFF
--- a/components/ai-elements/form-summary-card.tsx
+++ b/components/ai-elements/form-summary-card.tsx
@@ -269,7 +269,7 @@ export function FormSummaryCard({
           <div className="font-source-serif text-[14px]">
             <div className="flex items-center gap-2 mb-2">
               <Info size={14} className="text-primary flex-shrink-0" />
-              <p className="font-bold">{hasIssues ? 'Ready to review' : 'Ready to submit'}</p>
+              <p className="font-bold">Ready for review</p>
             </div>
             <p className="mb-4">
               Confirm each field is accurate. You&rsquo;ll see how each one was filled.
@@ -292,11 +292,11 @@ export function FormSummaryCard({
           <div className="flex items-center gap-2 mb-2">
             <Info size={14} className="text-primary flex-shrink-0" />
             <p className="font-source-serif text-[14px] font-bold">
-              {hasIssues ? 'Ready to review' : 'Ready to submit'}
+              Ready for review
             </p>
           </div>
           <p className="font-source-serif text-[14px] mb-4">
-            Confirm each field is accurate before submitting. You&rsquo;ll see how each one was filled.
+            Confirm each field is accurate. You&rsquo;ll see how each one was filled.
           </p>
           <div className="flex gap-2">
             <button

--- a/components/ai-elements/form-summary-card.tsx
+++ b/components/ai-elements/form-summary-card.tsx
@@ -272,7 +272,7 @@ export function FormSummaryCard({
               <p className="font-bold">{hasIssues ? 'Ready to review' : 'Ready to submit'}</p>
             </div>
             <p className="mb-4">
-              Confirm each field is accurate before submitting. You&rsquo;ll see how each one was filled.
+              Confirm each field is accurate. You&rsquo;ll see how each one was filled.
             </p>
           </div>
           <button
@@ -305,7 +305,7 @@ export function FormSummaryCard({
               disabled={interactionDisabled || sections.length === 0}
               className="bg-primary text-white text-sm font-medium px-4 py-2 rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {hasIssues ? 'Start review' : 'Review & submit'}
+              {hasIssues ? 'Start review' : 'Review fields'}
             </button>
             <button
               type="button"

--- a/components/ai-elements/gap-analysis-card.tsx
+++ b/components/ai-elements/gap-analysis-card.tsx
@@ -387,7 +387,7 @@ export function GapAnalysisCard({
                 onClick={handleSubmit}
                 className="text-[14px] font-semibold px-5 py-2.5 rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
               >
-                Submit
+                Update and continue
               </button>
             )
           }

--- a/components/ai-elements/user-action-confirmation.tsx
+++ b/components/ai-elements/user-action-confirmation.tsx
@@ -26,7 +26,7 @@ interface UserActionConfirmationProps {
 export function UserActionConfirmation({
   approval,
   state = 'approval-requested',
-  requestTitle = 'Action required',
+  requestTitle = 'Your turn to submit',
   requestMessage,
   acceptedMessage = 'You approved this action',
   rejectedMessage = 'You rejected this action',

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -82,7 +82,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                 >
                   <PlusIcon size={16} />
                   <span className="text-[14px] font-medium text-sidebar-foreground leading-[24px] not-italic font-inter">
-                    New chat
+                    New application
                   </span>
                 </Button>
               </div>

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -42,10 +42,10 @@ function PureChatHeader({
               }}
             >
               <PlusIcon />
-              <span className="md:sr-only">New Chat</span>
+              <span className="md:sr-only">New application</span>
             </Button>
           </TooltipTrigger>
-          <TooltipContent>New Chat</TooltipContent>
+          <TooltipContent>New application</TooltipContent>
         </Tooltip>
       )}
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -83,6 +83,12 @@ export function Chat({
   const stoppedRef = useRef(false);
 
   const [selectedModelId] = useLocalStorage<string>('selected-chat-model-id', '');
+  // useChat captures the transport (and its prepareSendMessagesRequest closure)
+  // once at first render, so reading selectedModelId directly there would freeze
+  // it at the initial value. Route reads through a ref updated every render so
+  // each send picks up the current model selection.
+  const selectedModelIdRef = useRef(selectedModelId);
+  selectedModelIdRef.current = selectedModelId;
 
   const {
     messages,
@@ -108,8 +114,8 @@ export function Chat({
           message: messages.at(-1),
           selectedChatModel: initialChatModel,
           selectedVisibilityType: visibilityType,
-          ...(!isProductionEnvironment && selectedModelId
-            ? { modelOverride: selectedModelId }
+          ...(!isProductionEnvironment && selectedModelIdRef.current
+            ? { modelOverride: selectedModelIdRef.current }
             : {}),
           ...body,
         },

--- a/components/layout-header.tsx
+++ b/components/layout-header.tsx
@@ -56,7 +56,7 @@ export function LayoutHeader() {
             </Button>
           </TooltipTrigger>
           <TooltipContent align="start" side="right" sideOffset={8}>
-            New Chat
+            New application
           </TooltipContent>
         </Tooltip>
       </div>

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -314,7 +314,7 @@ const PurePreviewMessage = ({
                         <UserActionConfirmation
                           approval={{ id: `action-${message.id}`, approved: undefined }}
                           state="approval-requested"
-                          requestMessage='Manual action required to proceed.'
+                          requestMessage='Open the application and press submit.'
                           onApprove={(approvalId) => {
                             // Trigger browser control switch to user mode
                             const event = new CustomEvent('switch-browser-control', { 
@@ -616,7 +616,7 @@ const PurePreviewMessage = ({
               <div className="flex items-center gap-2 p-3 border-0 rounded-md">
                 <div className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground flex items-center gap-2">
                   <Spinner className="size-3 shrink-0 text-primary" />
-                  {isCompacting ? 'Summarizing the conversation...' : 'Processing...'}
+                  {isCompacting ? 'Still processing, may take a moment...' : 'Processing...'}
                 </div>
               </div>
             )}

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -50,7 +50,7 @@ function PureMultimodalInput({
   className,
   selectedVisibilityType,
   showStopButton = true,
-  placeholder = 'Write something...',
+  placeholder = 'Add information or give direction...',
   fullWidthSubmit = false,
   stackToolbar = false,
   session,

--- a/components/sidebar-toggle.tsx
+++ b/components/sidebar-toggle.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-import { SidebarLeftIcon } from './icons';
+import { CrossIcon, MenuIcon } from './icons';
 import { Button } from './ui/button';
 import { useArtifact } from '@/hooks/use-artifact';
 import { cn } from '@/lib/utils';
@@ -15,8 +15,10 @@ import { cn } from '@/lib/utils';
 export function SidebarToggle({
   className,
 }: ComponentProps<typeof SidebarTrigger>) {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, state } = useSidebar();
   const { metadata, artifact } = useArtifact();
+
+  const isExpanded = state === 'expanded';
   
   // Check if browser artifact sheet is open
   const isSheetOpen = artifact.kind === 'browser' && metadata?.isSheetOpen;
@@ -33,11 +35,11 @@ export function SidebarToggle({
             isSheetOpen && "opacity-30 cursor-not-allowed pointer-events-auto bg-gray-100 dark:bg-gray-800"
           )}
         >
-          <SidebarLeftIcon size={16} />
+          {isExpanded ? <CrossIcon size={16} /> : <MenuIcon size={16} />}
         </Button>
       </TooltipTrigger>
       <TooltipContent align="start" side="bottom" sideOffset={8}>
-        Toggle sidebar
+        {isExpanded ? 'Close' : 'Menu'}
       </TooltipContent>
     </Tooltip>
   );

--- a/tests/client/user-action-confirmation.test.tsx
+++ b/tests/client/user-action-confirmation.test.tsx
@@ -15,7 +15,7 @@ test('UserActionConfirmation renders with proper content in approval-requested s
     />
   );
 
-  await expect.element(getByText('Action required')).toBeInTheDocument();
+  await expect.element(getByText('Your turn to submit')).toBeInTheDocument();
   await expect.element(getByText('Complete the CAPTCHA and submit the application.')).toBeInTheDocument();
   await expect.element(getByText('Take control')).toBeInTheDocument();
   await expect.element(getByText('Skip for now')).toBeInTheDocument();


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/ASP-926

## Changes

**Microcopy**
- Reframed "New Chat" → "New application" across sidebar, chat header, and layout header
- Form summary card: simplified the review blurb and changed the CTA from "Review & submit" → "Review fields"
- Gap analysis card: button "Submit" → "Update and continue"
- User action confirmation: default title "Action required" → "Your turn to submit"
- Message: clearer manual-action prompt ("Open the application and press submit.") and a friendlier long-running state ("Still processing, may take a moment...")
- Multimodal input placeholder → "Add information or give direction..."

**Sidebar toggle (`components/sidebar-toggle.tsx`)**
- Toggle now reflects sidebar state: hamburger (`MenuIcon`) + "Menu" tooltip when collapsed, close (`CrossIcon`) + "Close" tooltip when expanded

**Fix: stale model override (`components/chat.tsx`)**
- `useChat` captures the transport closure once at first render, freezing `selectedModelId` at its initial value. Routed the read through a ref updated each render so every send picks up the current model selection

## Testing

- Updated `tests/client/user-action-confirmation.test.tsx` to assert the new "Your turn to submit" default title
- Manually verified the sidebar toggle icon/tooltip swap between collapsed and expanded states

## Context for reviewers

Mostly low-risk copy changes. The one behavioral fix is in `chat.tsx`: reading `selectedModelId` directly inside `prepareSendMessagesRequest` froze it at the first-render value because `useChat` only captures the transport once. The ref keeps `modelOverride` in sync with the current selection on each send. Note this override only applies in non-production environments.