### PR TITLE
feat: declutter agent tool calls behind a QA-toggleable feature flag

### DIFF
--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -397,6 +397,7 @@ function PureArtifact({
                       setMessages={setMessages}
                       selectedVisibilityType={selectedVisibilityType}
                       session={session ?? null}
+                      stackToolbar
                     />
 
                   </form>

--- a/components/feature-flags-menu.tsx
+++ b/components/feature-flags-menu.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { FlaskConical } from 'lucide-react';
+import { Button } from './ui/button';
+import { Switch } from './ui/switch';
+import { Label } from './ui/label';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu';
+import {
+  FEATURE_FLAGS,
+  setFlagOverride,
+  type FeatureFlagKey,
+} from '@/lib/feature-flags';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { isProductionEnvironment } from '@/lib/constants';
+
+function FlagRow({ flagKey }: { flagKey: FeatureFlagKey }) {
+  const def = FEATURE_FLAGS[flagKey];
+  const enabled = useFeatureFlag(flagKey);
+  const id = `ff-${flagKey}`;
+
+  return (
+    <div className="flex items-start justify-between gap-3 px-2 py-1.5">
+      <div className="flex flex-col gap-0.5">
+        <Label htmlFor={id} className="text-xs font-medium">
+          {def.label}
+        </Label>
+        <span className="text-[10px] leading-snug text-muted-foreground">
+          {def.description}
+        </span>
+      </div>
+      <Switch
+        id={id}
+        checked={enabled}
+        onCheckedChange={(checked) => setFlagOverride(flagKey, checked)}
+      />
+    </div>
+  );
+}
+
+// Dev-only menu for toggling feature flags. QA can flip features on/off in
+// dev/preview without a redeploy; overrides persist via localStorage. Hidden
+// in production.
+export function FeatureFlagsMenu() {
+  if (isProductionEnvironment) return null;
+
+  const keys = Object.keys(FEATURE_FLAGS) as FeatureFlagKey[];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className="flex items-center gap-1.5 h-fit px-2 py-1.5 text-xs text-muted-foreground rounded-md hover:bg-accent hover:text-foreground transition-colors"
+        >
+          <FlaskConical className="size-3" />
+          <span>Flags</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-72">
+        <DropdownMenuLabel>Feature flags (dev)</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {keys.map((key) => (
+          <FlagRow key={key} flagKey={key} />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -34,6 +34,7 @@ import { useRouter } from 'next/navigation';
 import { isProductionEnvironment } from '@/lib/constants';
 import { ModelSelectorButton } from './model-selector-button';
 import { ContextUsage } from './context-usage';
+import { FeatureFlagsMenu } from './feature-flags-menu';
 
 function PureMultimodalInput({
   chatId,
@@ -350,6 +351,7 @@ function PureMultimodalInput({
             <div className="flex flex-row items-center gap-2">
               <ModelSelectorButton onModelChange={(model) => setSelectedModelId(model.id)} />
               <ContextUsage />
+              <FeatureFlagsMenu />
             </div>
           )}
         </div>
@@ -358,6 +360,7 @@ function PureMultimodalInput({
           <div className="flex flex-row items-center gap-2">
             <ModelSelectorButton onModelChange={(model) => setSelectedModelId(model.id)} />
             <ContextUsage />
+            <FeatureFlagsMenu />
           </div>
           <div className="flex flex-row gap-2">
             {showStopButton && (

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -52,6 +52,7 @@ function PureMultimodalInput({
   showStopButton = true,
   placeholder = 'Write something...',
   fullWidthSubmit = false,
+  stackToolbar = false,
   session,
 }: {
   chatId: string;
@@ -69,6 +70,7 @@ function PureMultimodalInput({
   showStopButton?: boolean;
   placeholder?: string;
   fullWidthSubmit?: boolean;
+  stackToolbar?: boolean;
   session: Session | null;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -354,6 +356,26 @@ function PureMultimodalInput({
               <FeatureFlagsMenu />
             </div>
           )}
+        </div>
+      ) : stackToolbar ? (
+        <div className="flex flex-col gap-2 mt-1">
+          <div className="flex flex-row justify-end gap-2">
+            {showStopButton && (
+              <StopButton status={status} stop={stop} setMessages={setMessages} />
+            )}
+            <SendButton
+              input={input}
+              submitForm={submitForm}
+              uploadQueue={uploadQueue}
+              status={status}
+              isLoggedIn={isLoggedIn}
+            />
+          </div>
+          <div className="flex flex-row flex-wrap items-center gap-2">
+            <ModelSelectorButton onModelChange={(model) => setSelectedModelId(model.id)} />
+            <ContextUsage />
+            <FeatureFlagsMenu />
+          </div>
         </div>
       ) : (
         <div className="flex flex-row justify-between gap-2 mt-1">

--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/collapsible';
 import { getToolDisplayInfo, isSpecificToolAction } from './tool-icon';
 import { cn } from '@/lib/utils';
-import { isProductionEnvironment } from '@/lib/constants';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { Shimmer } from '@/components/ai-elements/shimmer';
 
 // --- Types ---
@@ -281,6 +281,8 @@ export function ToolCallGroup({
   isStreaming = false,
 }: ToolCallGroupProps) {
   const [open, setOpen] = useState(false);
+  // When enabled, hide generic actions and show only value-bearing tool calls.
+  const declutter = useFeatureFlag('declutterToolCalls');
 
   // Deduplicate: keep only the latest state per toolCallId
   const deduped = deduplicateParts(parts);
@@ -290,26 +292,24 @@ export function ToolCallGroup({
   const completedParts = deduped.filter((p) => p.state === 'output-available' && !LABEL_TOOL_TYPES.has(p.type));
   const candidateParts = (isInProgress ? completedParts : deduped).filter((p) => !LABEL_TOOL_TYPES.has(p.type));
 
-  // In production, hide generic actions — show only value-bearing tool calls.
-  // Dev/preview keeps everything.
-  const visibleParts = isProductionEnvironment
+  const visibleParts = declutter
     ? candidateParts.filter((p) => isSpecificToolAction(p.type, p.input))
     : candidateParts;
 
   const { label, Icon: TitleIcon } = getGroupTitle(deduped, isInProgress);
 
-  // Single part → render the bare line when it's shown; in production a lone
-  // generic action collapses to the summary line instead.
+  // Single part → render the bare line when it's shown; when decluttering, a
+  // lone generic action collapses to the summary line instead.
   if (deduped.length === 1) {
     const part = deduped[0];
-    if (!isProductionEnvironment || isSpecificToolAction(part.type, part.input)) {
+    if (!declutter || isSpecificToolAction(part.type, part.input)) {
       return <SingleToolLine part={part} />;
     }
     return <GroupSummaryCard label={label} Icon={TitleIcon} isInProgress={isInProgress} />;
   }
 
-  // Nothing specific to show (production) → summary line, no expander.
-  if (isProductionEnvironment && visibleParts.length === 0) {
+  // Nothing specific to show (decluttered) → summary line, no expander.
+  if (declutter && visibleParts.length === 0) {
     return <GroupSummaryCard label={label} Icon={TitleIcon} isInProgress={isInProgress} />;
   }
 

--- a/components/tool-call-group.tsx
+++ b/components/tool-call-group.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { CheckIcon, ChevronDown, Globe, Layers, Monitor, MousePointer, Pencil, Search } from 'lucide-react';
+import { CheckIcon, ChevronDown, Globe, Monitor, MousePointer, Pencil, Search } from 'lucide-react';
 
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
@@ -9,8 +9,9 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
-import { getToolDisplayInfo } from './tool-icon';
+import { getToolDisplayInfo, isSpecificToolAction } from './tool-icon';
 import { cn } from '@/lib/utils';
+import { isProductionEnvironment } from '@/lib/constants';
 import { Shimmer } from '@/components/ai-elements/shimmer';
 
 // --- Types ---
@@ -253,7 +254,7 @@ const GROUP_TITLE_MAP: Record<string, {
   interact: { inProgress: 'Interacting with page', done: 'Interacted with page', icon: MousePointer },
   read:     { inProgress: 'Reading page',          done: 'Read page',            icon: Monitor },
   search:   { inProgress: 'Searching',             done: 'Search complete',      icon: Search },
-  misc:     { inProgress: 'Working on page',       done: 'Completed actions',    icon: Layers },
+  misc:     { inProgress: 'Working on page',       done: 'Completed actions',    icon: Pencil },
 };
 
 function getGroupTitle(
@@ -284,17 +285,33 @@ export function ToolCallGroup({
   // Deduplicate: keep only the latest state per toolCallId
   const deduped = deduplicateParts(parts);
 
-  // Single part → render as-is (no card wrapper)
-  if (deduped.length === 1) {
-    return <SingleToolLine part={deduped[0]} />;
-  }
-
   // Group is "in progress" while the parent signals the agent is still streaming this group.
   const isInProgress = isStreaming;
   const completedParts = deduped.filter((p) => p.state === 'output-available' && !LABEL_TOOL_TYPES.has(p.type));
-  const displayParts = (isInProgress ? completedParts : deduped).filter((p) => !LABEL_TOOL_TYPES.has(p.type));
+  const candidateParts = (isInProgress ? completedParts : deduped).filter((p) => !LABEL_TOOL_TYPES.has(p.type));
+
+  // In production, hide generic actions — show only value-bearing tool calls.
+  // Dev/preview keeps everything.
+  const visibleParts = isProductionEnvironment
+    ? candidateParts.filter((p) => isSpecificToolAction(p.type, p.input))
+    : candidateParts;
 
   const { label, Icon: TitleIcon } = getGroupTitle(deduped, isInProgress);
+
+  // Single part → render the bare line when it's shown; in production a lone
+  // generic action collapses to the summary line instead.
+  if (deduped.length === 1) {
+    const part = deduped[0];
+    if (!isProductionEnvironment || isSpecificToolAction(part.type, part.input)) {
+      return <SingleToolLine part={part} />;
+    }
+    return <GroupSummaryCard label={label} Icon={TitleIcon} isInProgress={isInProgress} />;
+  }
+
+  // Nothing specific to show (production) → summary line, no expander.
+  if (isProductionEnvironment && visibleParts.length === 0) {
+    return <GroupSummaryCard label={label} Icon={TitleIcon} isInProgress={isInProgress} />;
+  }
 
   return (
     <Alert className="rounded-xl border-accent bg-background p-3">
@@ -302,22 +319,7 @@ export function ToolCallGroup({
         <Collapsible open={open} onOpenChange={setOpen}>
           {/* Summary line — always visible, clickable to expand */}
           <CollapsibleTrigger className="flex items-center justify-between w-full cursor-pointer gap-2">
-            <div className="flex items-center gap-2 min-w-0">
-              <TitleIcon size={12} className="text-gray-500 shrink-0" />
-              {isInProgress ? (
-                <Shimmer
-                  as="span"
-                  className="text-[10px] leading-[150%] font-ibm-plex-mono"
-                  duration={1.5}
-                >
-                  {label}
-                </Shimmer>
-              ) : (
-                <span className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground">
-                  {label}
-                </span>
-              )}
-            </div>
+            <GroupSummaryLine label={label} Icon={TitleIcon} isInProgress={isInProgress} />
             <span className="inline-flex items-center justify-center p-1 h-auto text-muted-foreground">
               <ChevronDown
                 size={14}
@@ -330,10 +332,10 @@ export function ToolCallGroup({
             </span>
           </CollapsibleTrigger>
 
-          {/* Expanded: show completed tools (or all when done) */}
+          {/* Expanded: show the visible tools */}
           <CollapsibleContent>
             <div className="flex flex-col gap-0 mt-2 border-t border-border pt-1">
-              {displayParts.map((part) => (
+              {visibleParts.map((part) => (
                 <SingleToolLine
                   key={part.toolCallId}
                   part={part}
@@ -343,6 +345,57 @@ export function ToolCallGroup({
             </div>
           </CollapsibleContent>
         </Collapsible>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+// Summary line content (icon + label) shared by the collapsible trigger and
+// the expander-less summary card.
+function GroupSummaryLine({
+  label,
+  Icon,
+  isInProgress,
+}: {
+  label: string;
+  Icon: React.ComponentType<any>;
+  isInProgress: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <Icon size={12} className="text-gray-500 shrink-0" />
+      {isInProgress ? (
+        <Shimmer
+          as="span"
+          className="text-[10px] leading-[150%] font-ibm-plex-mono"
+          duration={1.5}
+        >
+          {label}
+        </Shimmer>
+      ) : (
+        <span className="text-[10px] leading-[150%] font-ibm-plex-mono text-muted-foreground">
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Summary line in a card with no expander — used when there are no specific
+// tool calls worth listing.
+function GroupSummaryCard({
+  label,
+  Icon,
+  isInProgress,
+}: {
+  label: string;
+  Icon: React.ComponentType<any>;
+  isInProgress: boolean;
+}) {
+  return (
+    <Alert className="rounded-xl border-accent bg-background p-3">
+      <AlertDescription>
+        <GroupSummaryLine label={label} Icon={Icon} isInProgress={isInProgress} />
       </AlertDescription>
     </Alert>
   );

--- a/components/tool-icon.tsx
+++ b/components/tool-icon.tsx
@@ -201,6 +201,37 @@ const parseBrowserAction = (input?: Record<string, any>): { text: string; icon: 
   return { text: mapping.verb, icon: mapping.icon };
 };
 
+const hasValue = (v: any): boolean =>
+  Array.isArray(v) ? v.length > 0 : v != null && String(v).length > 0;
+
+// A tool call is "specific" when it carries a concrete user-visible value
+// (a typed value, a chosen option, a destination URL) rather than a generic
+// navigation/inspection action (click, snapshot, scroll, wait, ...).
+export const isSpecificToolAction = (toolName: string, input?: any): boolean => {
+  const cleanToolName = toolName.replace('tool-', '');
+
+  if (cleanToolName === 'browser') {
+    const action = input?.action ? String(input.action).toLowerCase() : '';
+    switch (action) {
+      case 'fill': return hasValue(input?.value);
+      case 'type': return hasValue(input?.text);
+      case 'select': return hasValue(input?.values);
+      case 'navigate': return hasValue(input?.url);
+      case 'getbylabel': return input?.subaction === 'fill';
+      default: return false;
+    }
+  }
+
+  // Legacy browser_* / playwright_browser_* tool formats
+  const base = cleanToolName.replace(/^playwright_/, '');
+  switch (base) {
+    case 'browser_type': return hasValue(input?.text);
+    case 'browser_select_option': return hasValue(input?.values);
+    case 'browser_navigate': return hasValue(input?.url);
+    default: return false;
+  }
+};
+
 // Helper function to get tool display name with icon
 export const getToolDisplayInfo = (toolName: string, input?: any): { text: string; icon: React.ComponentType<any> } => {
   // Handle AI SDK browser tool (agent-browser)

--- a/hooks/use-feature-flag.ts
+++ b/hooks/use-feature-flag.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import {
+  FEATURE_FLAGS,
+  getFlagOverride,
+  subscribeToFlags,
+  type FeatureFlagKey,
+} from '@/lib/feature-flags';
+
+// Reactive read of a feature flag. Re-renders when the flag's localStorage
+// override changes (via the dev-only feature-flags menu or another tab).
+export function useFeatureFlag(key: FeatureFlagKey): boolean {
+  const defaultValue = FEATURE_FLAGS[key].defaultValue;
+  return useSyncExternalStore(
+    subscribeToFlags,
+    () => getFlagOverride(key) ?? defaultValue,
+    () => defaultValue,
+  );
+}

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,57 @@
+import { isProductionEnvironment } from './constants';
+
+// Feature flags for individual features. Each flag ships with an
+// environment-aware default and can be overridden per-browser via localStorage
+// (flipped by the dev-only feature-flags menu) so QA can preview features in
+// dev/preview without a redeploy.
+export type FeatureFlagKey = 'declutterToolCalls';
+
+export interface FeatureFlagDef {
+  key: FeatureFlagKey;
+  label: string;
+  description: string;
+  defaultValue: boolean;
+}
+
+export const FEATURE_FLAGS: Record<FeatureFlagKey, FeatureFlagDef> = {
+  declutterToolCalls: {
+    key: 'declutterToolCalls',
+    label: 'Declutter tool calls',
+    description: 'Show only value-bearing tool calls (production behavior).',
+    defaultValue: isProductionEnvironment,
+  },
+};
+
+const STORAGE_PREFIX = 'ff:';
+const CHANGE_EVENT = 'feature-flag-change';
+
+export function getFlagOverride(key: FeatureFlagKey): boolean | null {
+  if (typeof window === 'undefined') return null;
+  const raw = window.localStorage.getItem(STORAGE_PREFIX + key);
+  if (raw === null) return null;
+  return raw === 'true';
+}
+
+export function setFlagOverride(key: FeatureFlagKey, value: boolean | null): void {
+  if (typeof window === 'undefined') return;
+  if (value === null) {
+    window.localStorage.removeItem(STORAGE_PREFIX + key);
+  } else {
+    window.localStorage.setItem(STORAGE_PREFIX + key, String(value));
+  }
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: { key } }));
+}
+
+export function subscribeToFlags(callback: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener(CHANGE_EVENT, callback);
+  window.addEventListener('storage', callback);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, callback);
+    window.removeEventListener('storage', callback);
+  };
+}
+
+export function isFeatureEnabled(key: FeatureFlagKey): boolean {
+  return getFlagOverride(key) ?? FEATURE_FLAGS[key].defaultValue;
+}

--- a/tests/client/feature-flags-menu.test.tsx
+++ b/tests/client/feature-flags-menu.test.tsx
@@ -1,0 +1,24 @@
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { FeatureFlagsMenu } from '@/components/feature-flags-menu';
+import { isFeatureEnabled, setFlagOverride } from '@/lib/feature-flags';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  setFlagOverride('declutterToolCalls', null);
+  window.localStorage.clear();
+});
+
+test('toggling the switch flips the feature flag', async () => {
+  expect(isFeatureEnabled('declutterToolCalls')).toBe(false);
+
+  const { getByRole } = render(<FeatureFlagsMenu />);
+
+  await getByRole('button', { name: /flags/i }).click();
+  await getByRole('switch', { name: /declutter tool calls/i }).click();
+
+  expect(isFeatureEnabled('declutterToolCalls')).toBe(true);
+});

--- a/tests/client/feature-flags.test.ts
+++ b/tests/client/feature-flags.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  FEATURE_FLAGS,
+  getFlagOverride,
+  isFeatureEnabled,
+  setFlagOverride,
+  subscribeToFlags,
+} from '@/lib/feature-flags';
+
+const KEY = 'declutterToolCalls';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('flag overrides', () => {
+  test('getFlagOverride returns null when unset', () => {
+    expect(getFlagOverride(KEY)).toBeNull();
+  });
+
+  test('setFlagOverride(true) then getFlagOverride returns true', () => {
+    setFlagOverride(KEY, true);
+    expect(getFlagOverride(KEY)).toBe(true);
+  });
+
+  test('setFlagOverride(false) then getFlagOverride returns false', () => {
+    setFlagOverride(KEY, false);
+    expect(getFlagOverride(KEY)).toBe(false);
+  });
+
+  test('setFlagOverride(null) clears the override', () => {
+    setFlagOverride(KEY, true);
+    setFlagOverride(KEY, null);
+    expect(getFlagOverride(KEY)).toBeNull();
+  });
+});
+
+describe('isFeatureEnabled', () => {
+  test('falls back to the registry default when no override (dev default is off)', () => {
+    expect(isFeatureEnabled(KEY)).toBe(FEATURE_FLAGS[KEY].defaultValue);
+  });
+
+  test('honors an override over the default', () => {
+    setFlagOverride(KEY, true);
+    expect(isFeatureEnabled(KEY)).toBe(true);
+    setFlagOverride(KEY, false);
+    expect(isFeatureEnabled(KEY)).toBe(false);
+  });
+});
+
+describe('subscribeToFlags', () => {
+  test('notifies subscribers when a flag changes and stops after unsubscribe', () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeToFlags(cb);
+
+    setFlagOverride(KEY, true);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    setFlagOverride(KEY, false);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/client/tool-call-group.test.tsx
+++ b/tests/client/tool-call-group.test.tsx
@@ -1,0 +1,61 @@
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+// Force the production path so the filtering behavior is exercised.
+vi.mock('@/lib/constants', () => ({
+  isProductionEnvironment: true,
+  isDevelopmentEnvironment: false,
+  isTestEnvironment: false,
+  DUMMY_PASSWORD: 'test',
+}));
+
+import { ToolCallGroup } from '@/components/tool-call-group';
+
+const part = (toolCallId: string, input: Record<string, unknown>) => ({
+  type: 'tool-browser',
+  toolCallId,
+  state: 'output-available',
+  input,
+});
+
+test('production: a group shows only specific tool calls when expanded', async () => {
+  const { getByRole, getByText } = render(
+    <ToolCallGroup
+      parts={[
+        part('1', { action: 'click' }),
+        part('2', { action: 'fill', value: '05/05/2026' }),
+        part('3', { action: 'snapshot' }),
+        part('4', { action: 'select', values: ['Female'] }),
+      ]}
+    />,
+  );
+
+  // Expand the accordion.
+  await getByRole('button').click();
+
+  await expect.element(getByText(/Filling "05\/05\/2026"/)).toBeVisible();
+  await expect.element(getByText(/Selecting "Female"/)).toBeVisible();
+  await expect.element(getByText(/Clicking/)).not.toBeInTheDocument();
+  await expect.element(getByText(/Reading page/)).not.toBeInTheDocument();
+});
+
+test('production: a group with only generic actions shows a summary line and no expander', async () => {
+  const { getByText, getByRole } = render(
+    <ToolCallGroup
+      parts={[part('1', { action: 'click' }), part('2', { action: 'snapshot' })]}
+    />,
+  );
+
+  await expect.element(getByText('Completed actions')).toBeVisible();
+  // No expander button to open into an empty list.
+  await expect.element(getByRole('button')).not.toBeInTheDocument();
+});
+
+test('production: a single generic action collapses to the summary line', async () => {
+  const { getByText, getByRole } = render(
+    <ToolCallGroup parts={[part('1', { action: 'click' })]} />,
+  );
+
+  await expect.element(getByText('Completed actions')).toBeVisible();
+  await expect.element(getByRole('button')).not.toBeInTheDocument();
+});

--- a/tests/client/tool-call-group.test.tsx
+++ b/tests/client/tool-call-group.test.tsx
@@ -1,15 +1,16 @@
-import { expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test } from 'vitest';
 import { render } from 'vitest-browser-react';
-
-// Force the production path so the filtering behavior is exercised.
-vi.mock('@/lib/constants', () => ({
-  isProductionEnvironment: true,
-  isDevelopmentEnvironment: false,
-  isTestEnvironment: false,
-  DUMMY_PASSWORD: 'test',
-}));
-
+import { setFlagOverride } from '@/lib/feature-flags';
 import { ToolCallGroup } from '@/components/tool-call-group';
+
+// Enable the declutter flag so the filtering behavior is exercised in dev tests.
+beforeEach(() => {
+  setFlagOverride('declutterToolCalls', true);
+});
+
+afterEach(() => {
+  setFlagOverride('declutterToolCalls', null);
+});
 
 const part = (toolCallId: string, input: Record<string, unknown>) => ({
   type: 'tool-browser',
@@ -18,7 +19,7 @@ const part = (toolCallId: string, input: Record<string, unknown>) => ({
   input,
 });
 
-test('production: a group shows only specific tool calls when expanded', async () => {
+test('decluttered: a group shows only specific tool calls when expanded', async () => {
   const { getByRole, getByText } = render(
     <ToolCallGroup
       parts={[
@@ -39,7 +40,7 @@ test('production: a group shows only specific tool calls when expanded', async (
   await expect.element(getByText(/Reading page/)).not.toBeInTheDocument();
 });
 
-test('production: a group with only generic actions shows a summary line and no expander', async () => {
+test('decluttered: a group with only generic actions shows a summary line and no expander', async () => {
   const { getByText, getByRole } = render(
     <ToolCallGroup
       parts={[part('1', { action: 'click' }), part('2', { action: 'snapshot' })]}
@@ -51,11 +52,27 @@ test('production: a group with only generic actions shows a summary line and no 
   await expect.element(getByRole('button')).not.toBeInTheDocument();
 });
 
-test('production: a single generic action collapses to the summary line', async () => {
+test('decluttered: a single generic action collapses to the summary line', async () => {
   const { getByText, getByRole } = render(
     <ToolCallGroup parts={[part('1', { action: 'click' })]} />,
   );
 
   await expect.element(getByText('Completed actions')).toBeVisible();
   await expect.element(getByRole('button')).not.toBeInTheDocument();
+});
+
+test('flag off: all tool calls remain visible (dev default)', async () => {
+  setFlagOverride('declutterToolCalls', false);
+  const { getByRole, getByText } = render(
+    <ToolCallGroup
+      parts={[
+        part('1', { action: 'click' }),
+        part('2', { action: 'fill', value: '05/05/2026' }),
+      ]}
+    />,
+  );
+
+  await getByRole('button').click();
+  await expect.element(getByText(/Clicking/)).toBeVisible();
+  await expect.element(getByText(/Filling "05\/05\/2026"/)).toBeVisible();
 });

--- a/tests/client/tool-icon.test.ts
+++ b/tests/client/tool-icon.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+import { isSpecificToolAction } from '@/components/tool-icon';
+
+describe('isSpecificToolAction (browser tool)', () => {
+  test('fill with a value is specific', () => {
+    expect(isSpecificToolAction('tool-browser', { action: 'fill', value: '05/05/2026' })).toBe(true);
+  });
+
+  test('fill without a value is generic', () => {
+    expect(isSpecificToolAction('tool-browser', { action: 'fill' })).toBe(false);
+  });
+
+  test('type with text is specific', () => {
+    expect(isSpecificToolAction('tool-browser', { action: 'type', text: '432433425' })).toBe(true);
+  });
+
+  test('select with values is specific', () => {
+    expect(isSpecificToolAction('tool-browser', { action: 'select', values: ['Female'] })).toBe(true);
+  });
+
+  test('navigate with a url is specific', () => {
+    expect(isSpecificToolAction('tool-browser', { action: 'navigate', url: 'https://example.com' })).toBe(true);
+  });
+
+  test('navigate without a url is generic', () => {
+    expect(isSpecificToolAction('tool-browser', { action: 'navigate' })).toBe(false);
+  });
+
+  test('getbylabel with subaction fill is specific', () => {
+    expect(isSpecificToolAction('tool-browser', { action: 'getbylabel', label: 'Date of birth', subaction: 'fill' })).toBe(true);
+  });
+
+  test('getbylabel with subaction click is generic', () => {
+    expect(isSpecificToolAction('tool-browser', { action: 'getbylabel', label: 'Submit', subaction: 'click' })).toBe(false);
+  });
+
+  test.each(['click', 'snapshot', 'screenshot', 'scroll', 'wait', 'hover', 'press', 'back', 'reload'])(
+    '%s is generic',
+    (action) => {
+      expect(isSpecificToolAction('tool-browser', { action })).toBe(false);
+    },
+  );
+
+  test('missing input is generic', () => {
+    expect(isSpecificToolAction('tool-browser', undefined)).toBe(false);
+  });
+});
+
+describe('isSpecificToolAction (legacy browser_* / playwright_browser_* tools)', () => {
+  test('browser_type with text is specific', () => {
+    expect(isSpecificToolAction('tool-browser_type', { text: 'hello' })).toBe(true);
+  });
+
+  test('browser_type without text is generic', () => {
+    expect(isSpecificToolAction('tool-browser_type', {})).toBe(false);
+  });
+
+  test('browser_select_option with values is specific', () => {
+    expect(isSpecificToolAction('tool-browser_select_option', { values: ['Female'] })).toBe(true);
+  });
+
+  test('browser_navigate with url is specific', () => {
+    expect(isSpecificToolAction('tool-playwright_browser_navigate', { url: 'https://example.com' })).toBe(true);
+  });
+
+  test('browser_click is generic', () => {
+    expect(isSpecificToolAction('tool-browser_click', { element: 'button' })).toBe(false);
+  });
+
+  test('browser_snapshot is generic', () => {
+    expect(isSpecificToolAction('tool-playwright_browser_snapshot', {})).toBe(false);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,6 @@
+// The vitest browser environment has no Node `process` global, but some app
+// modules (e.g. lib/constants.ts) read `process.env.*` at import time. Provide
+// a minimal shim so those modules load in tests.
+(globalThis as unknown as { process?: { env: Record<string, string | undefined> } }).process ??= {
+  env: {},
+};

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -9,6 +9,25 @@ export default defineConfig({
       '@': path.resolve(__dirname, './'),
     },
   },
+  // Pre-bundle UI deps so the optimizer doesn't discover them mid-run and force
+  // a reload (which nulls React and breaks Radix-based component tests).
+  optimizeDeps: {
+    include: [
+      'react',
+      'react-dom',
+      'react/jsx-dev-runtime',
+      '@radix-ui/react-alert-dialog',
+      '@radix-ui/react-checkbox',
+      '@radix-ui/react-collapsible',
+      '@radix-ui/react-dialog',
+      '@radix-ui/react-dropdown-menu',
+      '@radix-ui/react-label',
+      '@radix-ui/react-radio-group',
+      '@radix-ui/react-select',
+      '@radix-ui/react-switch',
+      '@radix-ui/react-tooltip',
+    ],
+  },
   test: {
     browser: {
       enabled: true,
@@ -18,6 +37,7 @@ export default defineConfig({
       ],
     },
     globals: true,
+    setupFiles: ['./tests/setup.ts'],
     exclude: [
       '**/node_modules/**',
       '**/dist/**',


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/ASP-927

## Changes

**Tool-call decluttering** (`components/tool-icon.tsx`, `components/tool-call-group.tsx`)
- Added `isSpecificToolAction()` — classifies a tool call as "specific" (value-bearing: fill/type/select with a value, navigate with a URL) vs generic (click, snapshot, scroll, wait, …).
- When decluttering is on, the accordion shows only specific calls; groups (or single calls) with nothing specific collapse to a summary line with no expander.
- Changed the generic "Working on page…" group icon from the stack/`Layers` icon to `Pencil`.

**Feature-flag system** (`lib/feature-flags.ts`, `hooks/use-feature-flag.ts`, `components/feature-flags-menu.tsx`)
- `FEATURE_FLAGS` registry with localStorage overrides + change events; `useFeatureFlag()` reactive hook.
- Dev-only "Flags" menu (hidden in production) mounted in the composer control row; iterates the registry so future flags just get an entry.
- `tool-call-group` now reads `useFeatureFlag('declutterToolCalls')` (default = `isProductionEnvironment`) instead of the raw constant.

**Composer layout** (`components/multimodal-input.tsx`, `components/artifact.tsx`)
- Added `stackToolbar` prop; in the narrow artifact panel the bottom controls stack into two rows (Stop/Send above, model · context · Flags below) so the Send button is no longer clipped. Main chat is unchanged.

**Test infra** (`tests/setup.ts`, `vitest.config.mjs`)
- `process` shim so the real `constants.ts` loads in browser tests (removes the need to mock it).
- `optimizeDeps.include` for React + Radix deps to stop the dep-optimizer reload that was nulling React in component tests.

## Testing

- Unit/component tests (run with `CI=true pnpm exec vitest run tests/client`):
  - `tests/client/tool-icon.test.ts` (24) — `isSpecificToolAction` across browser/legacy tool shapes.
  - `tests/client/feature-flags.test.ts` (7) — override get/set/clear, `isFeatureEnabled` resolution, subscriptions.
  - `tests/client/feature-flags-menu.test.tsx` — toggling the switch flips the flag.
  - `tests/client/tool-call-group.test.tsx` — decluttered rendering (specific-only, summary-line fallback) and flag-off (everything visible).
- Full client suite passes except 2 pre-existing `form-summary-card` timeouts that fail on `develop` independently of this work.
- Composer layout change is type/lint-verified; visual confirmation requires an open artifact (live agent session).

## Context for reviewers

- The decluttering defaults to `isProductionEnvironment`, so production ships the clean view while dev/preview keeps everything visible by default; QA flips it live via the dev-only Flags menu (persists in localStorage). A general feature-flag system was chosen over a one-off "prod view" so future features can register their own flags.
- Diff is ~580 lines but roughly half is tests; the test-infra changes (`tests/setup.ts`, `optimizeDeps.include`) are isolated and also stabilize the broader browser-test suite.