### PR TITLE
chore: upgrade @onkernel/sdk 0.28.0 → 0.62.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.35.3",
     "@google-cloud/storage": "^7.17.0",
-    "@onkernel/sdk": "^0.28.0",
+    "@onkernel/sdk": "^0.62.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.200.0",
     "@radix-ui/react-alert-dialog": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^7.17.0
         version: 7.17.0
       '@onkernel/sdk':
-        specifier: ^0.28.0
-        version: 0.28.0
+        specifier: ^0.62.0
+        version: 0.62.0
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -1487,8 +1487,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@onkernel/sdk@0.28.0':
-    resolution: {integrity: sha512-0m6ReJxXtGKIj4BJgbPGsS4amF3KsnSgCYADjPkH+Tqre9pYH/muku5pFQ4dOAybNkVxJ+UEUo9B5i+aMgG6sw==}
+  '@onkernel/sdk@0.62.0':
+    resolution: {integrity: sha512-EubnlM6xRHZKziN48cMa0Zl6SBWF4C+5NWTDjiVz0TBT2nd2nXI54io9IAIRhTpqK1/3q2bxM7YFrqgu+bVNaA==}
 
   '@opentelemetry/api-logs@0.200.0':
     resolution: {integrity: sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==}
@@ -5718,7 +5718,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@onkernel/sdk@0.28.0': {}
+  '@onkernel/sdk@0.62.0': {}
 
   '@opentelemetry/api-logs@0.200.0':
     dependencies:


### PR DESCRIPTION
## What

Bumps `@onkernel/sdk` from `^0.28.0` to `^0.62.0` (latest on npm). Deps-only change — `package.json` + `pnpm-lock.yaml`, no source edits.

## Why

We were pinned ~34 minor versions behind. The modern Kernel lifecycle model (profile-backed persistence + scale-to-zero **standby** + 72h cap) is only properly expressed in newer SDKs — `persistence`/`persistent_id` was already `@deprecated` in 0.28 and is **fully removed** in 0.62. This upgrade is a prerequisite for the upcoming idle-timeout / session-lifecycle work (standby = "no cost while idle, state preserved").

Also brings 34 releases of fixes plus new resources (`browsers.curl`/`browsers.fetch`, `computer`/`process`/`fs`/`playwright`/`telemetry`).

## Blast radius

Our entire SDK footprint is **4 call sites in 1 file** (`lib/kernel/browser.ts`):

| Call site | 0.28 -> 0.62 |
|---|---|
| `new Kernel()` | identical (default export, still CommonJS) |
| `browsers.create({ viewport, timeout_seconds, kiosk_mode, stealth })` | params + response fields (`session_id`, `cdp_ws_url`, `browser_live_view_url`) unchanged |
| `browsers.replays.start(id)` -> `.replay_id` | identical signature |
| `browsers.replays.stop(replayId, { id })` | identical signature |
| `browsers.replays.list(id)` | identical signature |

- We never used the removed `persistence` field, so its removal doesn't affect us.
- `agent-browser` (our CDP layer) does **not** depend on the SDK -> zero transitive coupling.
- No `engines`/`peerDependencies` constraints introduced.

## Verification

- `pnpm install` clean; only the `@onkernel/sdk` lockfile entry changed (`0.62.0`).
- `tsc --noEmit` introduces **zero new type errors**. (7 pre-existing errors remain in `tests/client/consent-page.test.tsx` and `tests/e2e/session.test.ts` — unrelated to this change; present on `develop`.)

## Needs a runtime smoke test before merge

Type defs match, but server-side semantics *could* have drifted across 34 releases — this is the only real risk and **could not be verified locally** (`KERNEL_API_KEY` not available in my env). Please run, with the key set, against the four call sites:

1. Create a browser -> confirm live-view URL renders + CDP connects
2. Start a replay
3. Stop a replay
4. Delete the browser

Easiest path: run the app, open a chat that spins up the embedded browser, confirm it connects and tears down cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)