### PR TITLE
feat: map PostHog session to chat + kernel session/replay

### DIFF
--- a/app/api/session-mapping/route.ts
+++ b/app/api/session-mapping/route.ts
@@ -1,0 +1,45 @@
+import { auth } from '@/app/(auth)/auth';
+import { getChatById, upsertSessionMapping } from '@/lib/db/queries';
+
+// Receives the PostHog session id from the client (the only place it is
+// knowable) and records it against the chat. The kernel session/replay ids are
+// filled in server-side when the browser is created — see lib/kernel/browser.ts.
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+
+  try {
+    const { chatId, posthogSessionId } = await request.json();
+
+    if (!chatId || !posthogSessionId) {
+      return Response.json(
+        { error: 'chatId and posthogSessionId are required' },
+        { status: 400 },
+      );
+    }
+
+    // Ownership check: the chat must exist and belong to the caller. This also
+    // guarantees the chatId FK is satisfiable before we insert the mapping.
+    const chat = await getChatById({ id: chatId });
+    if (!chat || chat.userId !== userId) {
+      return Response.json(
+        { error: 'Forbidden: chat does not belong to user' },
+        { status: 403 },
+      );
+    }
+
+    await upsertSessionMapping({ chatId, userId, posthogSessionId });
+
+    return Response.json({ success: true });
+  } catch (error) {
+    console.error('Session mapping API error:', error);
+    return Response.json(
+      { error: 'Failed to record session mapping' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/session-mapping/route.ts
+++ b/app/api/session-mapping/route.ts
@@ -1,9 +1,25 @@
 import { auth } from '@/app/(auth)/auth';
 import { getChatById, upsertSessionMapping } from '@/lib/db/queries';
 
+// Build the PostHog-hosted replay deep-link for a session. PostHog has no video
+// export, so we store the link rather than re-recording. Requires the numeric
+// project id; returns undefined if it isn't configured so we still record the id.
+function buildPosthogReplayUrl(posthogSessionId: string): string | undefined {
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  if (!projectId) return undefined;
+
+  // App-facing host (us.posthog.com), distinct from the ingest host
+  // (us.i.posthog.com) used by NEXT_PUBLIC_POSTHOG_HOST.
+  const host = (
+    process.env.POSTHOG_APP_HOST || 'https://us.posthog.com'
+  ).replace(/\/$/, '');
+  return `${host}/project/${projectId}/replay/${posthogSessionId}`;
+}
+
 // Receives the PostHog session id from the client (the only place it is
-// knowable) and records it against the chat. The kernel session/replay ids are
-// filled in server-side when the browser is created — see lib/kernel/browser.ts.
+// knowable) and records it — plus a derived replay deep-link — against the
+// chat. The kernel session/replay ids and video are filled in server-side when
+// the browser is created/torn down — see lib/kernel/browser.ts.
 export async function POST(request: Request) {
   const session = await auth();
   if (!session?.user) {
@@ -32,7 +48,12 @@ export async function POST(request: Request) {
       );
     }
 
-    await upsertSessionMapping({ chatId, userId, posthogSessionId });
+    await upsertSessionMapping({
+      chatId,
+      userId,
+      posthogSessionId,
+      posthogReplayUrl: buildPosthogReplayUrl(posthogSessionId),
+    });
 
     return Response.json({ success: true });
   } catch (error) {

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from 'ai';
 import { useChat } from '@ai-sdk/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSWRConfig } from 'swr';
@@ -23,8 +26,13 @@ import type { Attachment, ChatMessage } from '@/lib/types';
 import { useDataStream } from './data-stream-provider';
 import { BenefitApplicationsLanding } from './benefit-applications-landing';
 import { TokenUsageProvider } from '@/hooks/use-token-usage';
+import { useSessionMapping } from '@/hooks/use-session-mapping';
 
-export type CheckpointData = { messageId: string; stepNumber: number; summary: string };
+export type CheckpointData = {
+  messageId: string;
+  stepNumber: number;
+  summary: string;
+};
 
 export function Chat({
   id,
@@ -62,14 +70,17 @@ export function Chat({
     outputTokens: number;
     cachedInputTokens: number;
     currentInputTokens: number;
-  }>({ inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, currentInputTokens: 0 });
+  }>({
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedInputTokens: 0,
+    currentInputTokens: 0,
+  });
 
   // Track compaction checkpoints. Each entry records the message ID,
   // the number of parts that message had at checkpoint time, and the summary.
   // This lets us render the card between parts at the right position.
-  const [checkpoints, setCheckpoints] = useState<CheckpointData[]>(
-    []
-  );
+  const [checkpoints, setCheckpoints] = useState<CheckpointData[]>([]);
   // True while the compressor is running the Sonnet summary call
   const [isCompacting, setIsCompacting] = useState(false);
   // Ref to always have the latest messages in the onData closure
@@ -104,7 +115,8 @@ export function Chat({
     experimental_throttle: 100,
     generateId: generateUUID,
     sendAutomaticallyWhen: ({ messages }) =>
-      !stoppedRef.current && lastAssistantMessageIsCompleteWithToolCalls({ messages }),
+      !stoppedRef.current &&
+      lastAssistantMessageIsCompleteWithToolCalls({ messages }),
     transport: new DefaultChatTransport({
       api: '/api/chat',
       fetch: fetchWithErrorHandlers,
@@ -187,6 +199,15 @@ export function Chat({
   // Keep ref in sync so onData closure always has latest messages
   messagesRef.current = messages;
 
+  // Report the PostHog session id for this chat once the chat is persisted.
+  // An assistant message only exists after the server's POST handler ran,
+  // which creates the chat row before streaming — so this guarantees the
+  // ownership check in /api/session-mapping will find the chat.
+  useSessionMapping({
+    chatId: id,
+    ready: messages.some((m) => m.role === 'assistant'),
+  });
+
   const stop = async () => {
     stoppedRef.current = true;
     // Explicit server-side cancel. Cloud Run over HTTP/1.1 does not
@@ -233,7 +254,8 @@ export function Chat({
   const [attachments, setAttachments] = useState<Array<Attachment>>([]);
   const isArtifactVisible = useArtifactSelector((state) => state.isVisible);
   const { setArtifact, artifact } = useArtifact();
-  const [browserArtifactDismissed, setBrowserArtifactDismissed] = useState(false);
+  const [browserArtifactDismissed, setBrowserArtifactDismissed] =
+    useState(false);
 
   // Derive once — whether any message contains a browser tool call
   const hasBrowserToolCall = useMemo(
@@ -270,8 +292,10 @@ export function Chat({
     if (status !== 'streaming') return;
 
     if (hasBrowserToolCall && !isArtifactVisible && !browserArtifactDismissed) {
-      const userMessage = messages.find(msg => msg.role === 'user');
-      const messageText = userMessage?.parts.find(part => part.type === 'text')?.text || 'Web Automation';
+      const userMessage = messages.find((msg) => msg.role === 'user');
+      const messageText =
+        userMessage?.parts.find((part) => part.type === 'text')?.text ||
+        'Web Automation';
       const title = `Browser: ${messageText}`;
 
       setArtifact({
@@ -289,14 +313,31 @@ export function Chat({
         },
       });
     }
-  }, [hasBrowserToolCall, isArtifactVisible, browserArtifactDismissed, status, messages, setArtifact]);
+  }, [
+    hasBrowserToolCall,
+    isArtifactVisible,
+    browserArtifactDismissed,
+    status,
+    messages,
+    setArtifact,
+  ]);
 
   // Track when user manually closes the browser artifact
   useEffect(() => {
-    if (!isArtifactVisible && !browserArtifactDismissed && hasBrowserToolCall && initialChatModel === 'web-automation-model') {
+    if (
+      !isArtifactVisible &&
+      !browserArtifactDismissed &&
+      hasBrowserToolCall &&
+      initialChatModel === 'web-automation-model'
+    ) {
       setBrowserArtifactDismissed(true);
     }
-  }, [isArtifactVisible, browserArtifactDismissed, hasBrowserToolCall, initialChatModel]);
+  }, [
+    isArtifactVisible,
+    browserArtifactDismissed,
+    hasBrowserToolCall,
+    initialChatModel,
+  ]);
 
   // Reset dismissed state when a new user message arrives
   useEffect(() => {
@@ -381,7 +422,7 @@ export function Chat({
               checkpoints={checkpoints}
               isCompacting={isCompacting}
             />
-  
+
             <div className="shrink-0 mx-auto px-4 pt-6 bg-chat-background pb-4 md:pb-6 w-full">
               {!isReadonly && (
                 <form className="flex gap-2 w-full md:max-w-3xl mx-auto">

--- a/hooks/use-browser-session-exit.ts
+++ b/hooks/use-browser-session-exit.ts
@@ -25,27 +25,51 @@ export function useBrowserSessionExit() {
    * @param action - The navigation action to perform after confirmation
    * @returns boolean - true if navigation should proceed immediately, false if intercepted
    */
-  const interceptNavigation = useCallback((action: () => void) => {
-    if (hasActiveBrowserSession()) {
-      setPendingAction(() => action);
-      setShowExitWarning(true);
-      return false;
-    }
-    // No active session, proceed immediately
-    action();
-    return true;
-  }, [hasActiveBrowserSession]);
+  const interceptNavigation = useCallback(
+    (action: () => void) => {
+      if (hasActiveBrowserSession()) {
+        setPendingAction(() => action);
+        setShowExitWarning(true);
+        return false;
+      }
+      // No active session, proceed immediately
+      action();
+      return true;
+    },
+    [hasActiveBrowserSession],
+  );
 
   /**
-   * Handle user confirming they want to leave the session
+   * Handle user confirming they want to leave the session.
+   *
+   * Leaving is an explicit teardown: tell the server to delete the browser,
+   * which stops the replay recording and archives the video to storage before
+   * the Kernel session is destroyed. Without this, navigating away would just
+   * abandon the session — it would idle into standby (delayed) or be reaped by
+   * Kernel's timeout with no video written. Fire-and-forget via sendBeacon so
+   * it survives the navigation that runs immediately after.
    */
   const handleConfirmLeave = useCallback(() => {
     setShowExitWarning(false);
+
+    const sessionId = metadata?.sessionId;
+    if (sessionId) {
+      try {
+        const payload = JSON.stringify({ action: 'delete', sessionId });
+        navigator.sendBeacon(
+          '/api/kernel-browser',
+          new Blob([payload], { type: 'application/json' }),
+        );
+      } catch {
+        // Best-effort — don't block leaving on cleanup.
+      }
+    }
+
     if (pendingAction) {
       pendingAction();
       setPendingAction(null);
     }
-  }, [pendingAction]);
+  }, [pendingAction, metadata?.sessionId]);
 
   /**
    * Handle user canceling the exit
@@ -64,4 +88,3 @@ export function useBrowserSessionExit() {
     handleCancelLeave,
   };
 }
-

--- a/hooks/use-session-mapping.ts
+++ b/hooks/use-session-mapping.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePostHog } from 'posthog-js/react';
+
+/**
+ * Reports the current PostHog session id to the server so it can be correlated
+ * with the chat (and, server-side, with the Kernel browser session/replay) in
+ * the SessionMapping table.
+ *
+ * The PostHog session id is only knowable in the browser, so the client is the
+ * only place that can supply it. We wait until `ready` is true — i.e. the chat
+ * row exists in the DB — because the server route enforces a chat-ownership
+ * check before inserting (the chat is created lazily on the first message).
+ *
+ * Re-reports whenever PostHog rotates the session id (its 30-min idle / 24-h
+ * cap), keyed so we POST at most once per (chatId, sessionId) pair.
+ */
+export function useSessionMapping({
+  chatId,
+  ready,
+}: {
+  chatId: string;
+  ready: boolean;
+}) {
+  const posthog = usePostHog();
+  const reportedKey = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!ready || !posthog) return;
+
+    const posthogSessionId = posthog.get_session_id?.();
+    if (!posthogSessionId) return;
+
+    const key = `${chatId}:${posthogSessionId}`;
+    if (reportedKey.current === key) return;
+    reportedKey.current = key;
+
+    fetch('/api/session-mapping', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chatId, posthogSessionId }),
+    }).catch((error) => {
+      // Best-effort telemetry — don't surface to the user, but allow a retry.
+      console.error('Failed to report session mapping:', error);
+      reportedKey.current = null;
+    });
+  }, [chatId, ready, posthog]);
+}

--- a/lib/db/migrations/0005_ambitious_lorna_dane.sql
+++ b/lib/db/migrations/0005_ambitious_lorna_dane.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "SessionMapping" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chatId" uuid NOT NULL,
+	"userId" uuid NOT NULL,
+	"posthogSessionId" text,
+	"kernelSessionId" text,
+	"kernelReplayId" text,
+	"createdAt" timestamp NOT NULL,
+	"updatedAt" timestamp NOT NULL,
+	CONSTRAINT "SessionMapping_chatId_unique" UNIQUE("chatId")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "SessionMapping" ADD CONSTRAINT "SessionMapping_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "SessionMapping" ADD CONSTRAINT "SessionMapping_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/lib/db/migrations/0006_greedy_william_stryker.sql
+++ b/lib/db/migrations/0006_greedy_william_stryker.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "SessionMapping" ADD COLUMN "posthogReplayUrl" text;--> statement-breakpoint
+ALTER TABLE "SessionMapping" ADD COLUMN "kernelReplayUrl" text;

--- a/lib/db/migrations/meta/0005_snapshot.json
+++ b/lib/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,683 @@
+{
+  "id": "7946bf92-09b2-4854-b8b1-09cbd61d157a",
+  "prevId": "a55b828b-7064-46d6-b1d8-56ed79677d3c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "mastraThreadId": {
+          "name": "mastraThreadId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.SessionMapping": {
+      "name": "SessionMapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posthogSessionId": {
+          "name": "posthogSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernelSessionId": {
+          "name": "kernelSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernelReplayId": {
+          "name": "kernelReplayId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "SessionMapping_chatId_Chat_id_fk": {
+          "name": "SessionMapping_chatId_Chat_id_fk",
+          "tableFrom": "SessionMapping",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "SessionMapping_userId_User_id_fk": {
+          "name": "SessionMapping_userId_User_id_fk",
+          "tableFrom": "SessionMapping",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "SessionMapping_chatId_unique": {
+          "name": "SessionMapping_chatId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chatId"
+          ]
+        }
+      }
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/0006_snapshot.json
+++ b/lib/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,695 @@
+{
+  "id": "f22722ed-be0a-41f5-b8d3-03bbc7d99805",
+  "prevId": "7946bf92-09b2-4854-b8b1-09cbd61d157a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "mastraThreadId": {
+          "name": "mastraThreadId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.SessionMapping": {
+      "name": "SessionMapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posthogSessionId": {
+          "name": "posthogSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posthogReplayUrl": {
+          "name": "posthogReplayUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernelSessionId": {
+          "name": "kernelSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernelReplayId": {
+          "name": "kernelReplayId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernelReplayUrl": {
+          "name": "kernelReplayUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "SessionMapping_chatId_Chat_id_fk": {
+          "name": "SessionMapping_chatId_Chat_id_fk",
+          "tableFrom": "SessionMapping",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "SessionMapping_userId_User_id_fk": {
+          "name": "SessionMapping_userId_User_id_fk",
+          "tableFrom": "SessionMapping",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "SessionMapping_chatId_unique": {
+          "name": "SessionMapping_chatId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chatId"
+          ]
+        }
+      }
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1761006937695,
       "tag": "0004_common_dragon_man",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1781197631020,
+      "tag": "0005_ambitious_lorna_dane",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781197631020,
       "tag": "0005_ambitious_lorna_dane",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1781282233474,
+      "tag": "0006_greedy_william_stryker",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -27,6 +27,7 @@ import {
   type DBMessage,
   type Chat,
   stream,
+  sessionMapping,
 } from './schema';
 import type { ArtifactKind } from '@/components/artifact';
 import { generateUUID } from '../utils';
@@ -53,7 +54,9 @@ export async function getUser(email: string): Promise<Array<User>> {
   }
 }
 
-export async function getUserById({ id }: { id: string }): Promise<User | null> {
+export async function getUserById({
+  id,
+}: { id: string }): Promise<User | null> {
   try {
     const result = await db.select().from(user).where(eq(user.id, id));
     return result[0] || null;
@@ -62,7 +65,10 @@ export async function getUserById({ id }: { id: string }): Promise<User | null> 
   }
 }
 
-export async function ensureUserExists({ id, email }: { id: string; email: string }): Promise<User> {
+export async function ensureUserExists({
+  id,
+  email,
+}: { id: string; email: string }): Promise<User> {
   const existingUser = await getUserById({ id });
   if (existingUser) {
     return existingUser;
@@ -71,17 +77,17 @@ export async function ensureUserExists({ id, email }: { id: string; email: strin
   const password = generateHashedPassword(generateUUID());
 
   try {
-    const result = await db.insert(user).values({
-      id,
-      email,
-      password
-    }).returning();
+    const result = await db
+      .insert(user)
+      .values({
+        id,
+        email,
+        password,
+      })
+      .returning();
     return result[0];
   } catch (error) {
-    throw new ChatSDKError(
-      'bad_request:database',
-      'Failed to create user',
-    );
+    throw new ChatSDKError('bad_request:database', 'Failed to create user');
   }
 }
 
@@ -114,7 +120,7 @@ export async function upsertOAuthUser({
         .set({
           name: name ?? existingUser.name,
           image: image ?? existingUser.image,
-          emailVerified: new Date()
+          emailVerified: new Date(),
         })
         .where(eq(user.email, email))
         .returning();
@@ -122,21 +128,28 @@ export async function upsertOAuthUser({
     }
 
     // Create new OAuth user (no password)
-    const [newUser] = await db.insert(user).values({
-      email,
-      name,
-      image,
-      password: null, // OAuth users don't have passwords
-      emailVerified: new Date(),
-    }).returning();
+    const [newUser] = await db
+      .insert(user)
+      .values({
+        email,
+        name,
+        image,
+        password: null, // OAuth users don't have passwords
+        emailVerified: new Date(),
+      })
+      .returning();
 
     return newUser;
   } catch (error) {
     console.error('OAUTH_UPSERT_ERROR:', error);
-    console.error('OAUTH_USER_DATA:', { email, name, imageLength: image?.length });
+    console.error('OAUTH_USER_DATA:', {
+      email,
+      name,
+      imageLength: image?.length,
+    });
     throw new ChatSDKError(
       'bad_request:database',
-      'Failed to upsert OAuth user'
+      'Failed to upsert OAuth user',
     );
   }
 }
@@ -367,7 +380,10 @@ export async function saveDocument({
   } catch (error) {
     console.error('Database error saving document:', error);
     console.error('Error details:', JSON.stringify(error, null, 2));
-    throw new ChatSDKError('bad_request:database', `Failed to save document: ${error instanceof Error ? error.message : String(error)}`);
+    throw new ChatSDKError(
+      'bad_request:database',
+      `Failed to save document: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 
@@ -597,6 +613,61 @@ export async function getStreamIdsByChatId({ chatId }: { chatId: string }) {
     throw new ChatSDKError(
       'bad_request:database',
       'Failed to get stream ids by chat id',
+    );
+  }
+}
+
+/**
+ * Upsert the session mapping for a chat. Populated from two directions:
+ * the client sends posthogSessionId, the server sends kernelSessionId/
+ * kernelReplayId. One row per chat (unique on chatId) — only the provided,
+ * non-undefined id fields are written, so neither side clobbers the other's.
+ */
+export async function upsertSessionMapping({
+  chatId,
+  userId,
+  posthogSessionId,
+  kernelSessionId,
+  kernelReplayId,
+}: {
+  chatId: string;
+  userId: string;
+  posthogSessionId?: string;
+  kernelSessionId?: string;
+  kernelReplayId?: string;
+}) {
+  try {
+    const now = new Date();
+
+    // Only the fields actually provided are updated on conflict, so a later
+    // write from one source never nulls out a value set by the other.
+    const setOnConflict: Record<string, unknown> = { updatedAt: now };
+    if (posthogSessionId !== undefined)
+      setOnConflict.posthogSessionId = posthogSessionId;
+    if (kernelSessionId !== undefined)
+      setOnConflict.kernelSessionId = kernelSessionId;
+    if (kernelReplayId !== undefined)
+      setOnConflict.kernelReplayId = kernelReplayId;
+
+    return await db
+      .insert(sessionMapping)
+      .values({
+        chatId,
+        userId,
+        posthogSessionId,
+        kernelSessionId,
+        kernelReplayId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: sessionMapping.chatId,
+        set: setOnConflict,
+      });
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to upsert session mapping',
     );
   }
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -627,14 +627,18 @@ export async function upsertSessionMapping({
   chatId,
   userId,
   posthogSessionId,
+  posthogReplayUrl,
   kernelSessionId,
   kernelReplayId,
+  kernelReplayUrl,
 }: {
   chatId: string;
   userId: string;
   posthogSessionId?: string;
+  posthogReplayUrl?: string;
   kernelSessionId?: string;
   kernelReplayId?: string;
+  kernelReplayUrl?: string;
 }) {
   try {
     const now = new Date();
@@ -644,10 +648,14 @@ export async function upsertSessionMapping({
     const setOnConflict: Record<string, unknown> = { updatedAt: now };
     if (posthogSessionId !== undefined)
       setOnConflict.posthogSessionId = posthogSessionId;
+    if (posthogReplayUrl !== undefined)
+      setOnConflict.posthogReplayUrl = posthogReplayUrl;
     if (kernelSessionId !== undefined)
       setOnConflict.kernelSessionId = kernelSessionId;
     if (kernelReplayId !== undefined)
       setOnConflict.kernelReplayId = kernelReplayId;
+    if (kernelReplayUrl !== undefined)
+      setOnConflict.kernelReplayUrl = kernelReplayUrl;
 
     return await db
       .insert(sessionMapping)
@@ -655,8 +663,10 @@ export async function upsertSessionMapping({
         chatId,
         userId,
         posthogSessionId,
+        posthogReplayUrl,
         kernelSessionId,
         kernelReplayId,
+        kernelReplayUrl,
         createdAt: now,
         updatedAt: now,
       })

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -192,8 +192,15 @@ export const sessionMapping = pgTable(
       .notNull()
       .references(() => user.id),
     posthogSessionId: text('posthogSessionId'),
+    // Deep-link to the PostHog-hosted session replay. PostHog has no video
+    // export, so we keep the link rather than re-storing the recording.
+    posthogReplayUrl: text('posthogReplayUrl'),
     kernelSessionId: text('kernelSessionId'),
     kernelReplayId: text('kernelReplayId'),
+    // Stored location of the kernel browser video, downloaded from Kernel and
+    // uploaded to object storage on browser teardown. Null until the video
+    // lands. Storage-agnostic (currently a GCS URL).
+    kernelReplayUrl: text('kernelReplayUrl'),
     createdAt: timestamp('createdAt').notNull(),
     updatedAt: timestamp('updatedAt').notNull(),
   },

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,6 +9,7 @@ import {
   primaryKey,
   foreignKey,
   boolean,
+  unique,
 } from 'drizzle-orm/pg-core';
 
 export const user = pgTable('User', {
@@ -113,7 +114,9 @@ export const document = pgTable(
     createdAt: timestamp('createdAt').notNull(),
     title: text('title').notNull(),
     content: text('content'),
-    kind: varchar('text', { enum: ['text', 'code', 'image', 'sheet', 'browser'] })
+    kind: varchar('text', {
+      enum: ['text', 'code', 'image', 'sheet', 'browser'],
+    })
       .notNull()
       .default('text'),
     userId: uuid('userId')
@@ -172,3 +175,31 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+// Mapping table correlating a chat with its PostHog session and Kernel browser
+// session/replay. Populated from two directions: the client supplies the
+// PostHog session id (only knowable in the browser), the server supplies the
+// Kernel session/replay ids (only knowable when the browser is created). One
+// row per chat — fields fill in as each id materializes (upsert on chatId).
+export const sessionMapping = pgTable(
+  'SessionMapping',
+  {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    chatId: uuid('chatId')
+      .notNull()
+      .references(() => chat.id),
+    userId: uuid('userId')
+      .notNull()
+      .references(() => user.id),
+    posthogSessionId: text('posthogSessionId'),
+    kernelSessionId: text('kernelSessionId'),
+    kernelReplayId: text('kernelReplayId'),
+    createdAt: timestamp('createdAt').notNull(),
+    updatedAt: timestamp('updatedAt').notNull(),
+  },
+  (table) => ({
+    chatUnique: unique('SessionMapping_chatId_unique').on(table.chatId),
+  }),
+);
+
+export type SessionMapping = InferSelectModel<typeof sessionMapping>;

--- a/lib/kernel/browser.ts
+++ b/lib/kernel/browser.ts
@@ -1,6 +1,7 @@
 import Kernel from '@onkernel/sdk';
 import { BrowserManager } from 'agent-browser/dist/browser.js';
 import { upsertSessionMapping } from '@/lib/db/queries';
+import { uploadReplayVideo } from '@/lib/storage/gcs';
 import { KERNEL_TIMEOUT_SECONDS } from './session-config';
 import {
   buildSessionStatus,
@@ -396,15 +397,42 @@ export async function deleteBrowser(
   // Remove from cache first
   sessions.delete(key);
 
-  // Stop replay recording and log the view URL
+  // Stop the replay recording, then download the finished video and archive it
+  // to object storage. Stopping first ensures the recording is complete before
+  // we download it. All best-effort — teardown must not fail on archival.
   if (session.replayId) {
     try {
       await kernel.browsers.replays.stop(session.replayId, {
         id: session.kernelSessionId,
       });
-      await kernel.browsers.replays.list(session.kernelSessionId);
+
+      const chatId = sessionId.endsWith(`-${userId}`)
+        ? sessionId.slice(0, -(userId.length + 1))
+        : null;
+
+      if (chatId) {
+        try {
+          const videoResponse = await kernel.browsers.replays.download(
+            session.replayId,
+            { id: session.kernelSessionId },
+          );
+          const videoBuffer = await videoResponse.arrayBuffer();
+          const url = await uploadReplayVideo(
+            chatId,
+            session.kernelSessionId,
+            videoBuffer,
+          );
+          await upsertSessionMapping({
+            chatId,
+            userId,
+            kernelReplayUrl: url,
+          });
+        } catch (err) {
+          console.error('[Kernel] Failed to archive replay video:', err);
+        }
+      }
     } catch (err) {
-      console.error('[Kernel] Failed to stop/list replays:', err);
+      console.error('[Kernel] Failed to stop replay:', err);
     }
   }
 

--- a/lib/kernel/browser.ts
+++ b/lib/kernel/browser.ts
@@ -14,6 +14,52 @@ import {
 const kernel = new Kernel();
 
 // =============================================================================
+// Replay archival
+// =============================================================================
+
+/**
+ * Recover the chatId from a sessionId. sessionId is `${chatId}-${userId}`, so
+ * the chatId is everything before the trailing `-${userId}`. Returns null if
+ * the suffix doesn't match (defensive — callers skip archival when null).
+ */
+function chatIdFromSessionId(sessionId: string, userId: string): string | null {
+  return sessionId.endsWith(`-${userId}`)
+    ? sessionId.slice(0, -(userId.length + 1))
+    : null;
+}
+
+/**
+ * Download the current replay video from Kernel and archive it to object
+ * storage, recording the URL on the session mapping. Kernel supports
+ * downloading in-progress replays, so this is safe to call at standby (the
+ * recording keeps running) as well as on teardown.
+ *
+ * Deterministic GCS path (keyed by chatId + kernelSessionId) means repeated
+ * calls overwrite with an increasingly complete video rather than duplicating.
+ * Best-effort: callers must not let archival failures break their flow.
+ */
+async function archiveReplayVideo(
+  sessionId: string,
+  userId: string,
+  kernelSessionId: string,
+  replayId: string,
+): Promise<void> {
+  const chatId = chatIdFromSessionId(sessionId, userId);
+  if (!chatId) return;
+
+  try {
+    const videoResponse = await kernel.browsers.replays.download(replayId, {
+      id: kernelSessionId,
+    });
+    const videoBuffer = await videoResponse.arrayBuffer();
+    const url = await uploadReplayVideo(chatId, kernelSessionId, videoBuffer);
+    await upsertSessionMapping({ chatId, userId, kernelReplayUrl: url });
+  } catch (err) {
+    console.error('[Kernel] Failed to archive replay video:', err);
+  }
+}
+
+// =============================================================================
 // Types
 // =============================================================================
 
@@ -294,6 +340,20 @@ export async function standbyBrowser(
     console.log(
       `[Kernel] Session ${session.kernelSessionId} confirmed idle (standby).`,
     );
+    // Snapshot the replay so far to object storage. Idle → standby is the
+    // common way a session ends (the user navigates away or stops interacting
+    // and never formally deletes the chat), so without this most sessions
+    // would never get a video. We do NOT stop the replay: the browser is
+    // parked but reconnectable, so recording must continue. The deterministic
+    // GCS path means a later standby/delete overwrites with a fuller video.
+    if (session.replayId) {
+      await archiveReplayVideo(
+        sessionId,
+        userId,
+        session.kernelSessionId,
+        session.replayId,
+      );
+    }
     return true;
   }
 
@@ -397,43 +457,23 @@ export async function deleteBrowser(
   // Remove from cache first
   sessions.delete(key);
 
-  // Stop the replay recording, then download the finished video and archive it
-  // to object storage. Stopping first ensures the recording is complete before
-  // we download it. All best-effort — teardown must not fail on archival.
+  // Stop the replay recording, then archive the finished video. Stopping first
+  // ensures the recording is complete (and persisted) before download. All
+  // best-effort — teardown must not fail on archival.
   if (session.replayId) {
     try {
       await kernel.browsers.replays.stop(session.replayId, {
         id: session.kernelSessionId,
       });
-
-      const chatId = sessionId.endsWith(`-${userId}`)
-        ? sessionId.slice(0, -(userId.length + 1))
-        : null;
-
-      if (chatId) {
-        try {
-          const videoResponse = await kernel.browsers.replays.download(
-            session.replayId,
-            { id: session.kernelSessionId },
-          );
-          const videoBuffer = await videoResponse.arrayBuffer();
-          const url = await uploadReplayVideo(
-            chatId,
-            session.kernelSessionId,
-            videoBuffer,
-          );
-          await upsertSessionMapping({
-            chatId,
-            userId,
-            kernelReplayUrl: url,
-          });
-        } catch (err) {
-          console.error('[Kernel] Failed to archive replay video:', err);
-        }
-      }
     } catch (err) {
       console.error('[Kernel] Failed to stop replay:', err);
     }
+    await archiveReplayVideo(
+      sessionId,
+      userId,
+      session.kernelSessionId,
+      session.replayId,
+    );
   }
 
   // Close BrowserManager (disconnects Playwright from CDP)

--- a/lib/kernel/browser.ts
+++ b/lib/kernel/browser.ts
@@ -1,5 +1,6 @@
 import Kernel from '@onkernel/sdk';
 import { BrowserManager } from 'agent-browser/dist/browser.js';
+import { upsertSessionMapping } from '@/lib/db/queries';
 import { KERNEL_TIMEOUT_SECONDS } from './session-config';
 import {
   buildSessionStatus,
@@ -172,6 +173,26 @@ export async function getOrCreateBrowser(
       };
 
       sessions.set(key, session);
+
+      // Record the kernel session/replay ids against the chat so they can be
+      // correlated with the PostHog session (reported from the client). The
+      // sessionId is `${chatId}-${userId}`, so the chatId is everything before
+      // the trailing `-${userId}`. Best-effort: never fail browser creation.
+      const chatId = sessionId.endsWith(`-${userId}`)
+        ? sessionId.slice(0, -(userId.length + 1))
+        : null;
+      if (chatId) {
+        try {
+          await upsertSessionMapping({
+            chatId,
+            userId,
+            kernelSessionId: browser.session_id,
+            kernelReplayId: replayId,
+          });
+        } catch (err) {
+          console.error('[Kernel] Failed to record session mapping:', err);
+        }
+      }
 
       return session;
     } finally {

--- a/lib/storage/gcs.ts
+++ b/lib/storage/gcs.ts
@@ -19,15 +19,15 @@ export interface UploadResult {
 export async function uploadFile(
   filename: string,
   fileBuffer: ArrayBuffer,
-  contentType: string
+  contentType: string,
 ): Promise<UploadResult> {
   try {
     // Generate a unique filename to avoid conflicts
     const timestamp = Date.now();
     const uniqueFilename = `chat-uploads/${timestamp}-${filename}`;
-    
+
     const file = bucket.file(uniqueFilename);
-    
+
     // Upload the file
     await file.save(Buffer.from(fileBuffer), {
       metadata: {
@@ -38,7 +38,7 @@ export async function uploadFile(
 
     // Get the public URL
     const publicUrl = `https://storage.googleapis.com/${bucketName}/${uniqueFilename}`;
-    
+
     return {
       url: publicUrl,
       downloadUrl: publicUrl,
@@ -61,5 +61,29 @@ export async function deleteFile(pathname: string): Promise<void> {
 }
 
 export async function getFileUrl(pathname: string): Promise<string> {
+  return `https://storage.googleapis.com/${bucketName}/${pathname}`;
+}
+
+/**
+ * Upload a kernel browser replay video to object storage under a stable,
+ * chat-scoped path: `replays/<chatId>/<kernelSessionId>.mp4`. Deterministic
+ * (no timestamp) so a re-run overwrites rather than duplicates. Returns the
+ * stored URL to persist on the session mapping.
+ *
+ * Note: objects under `replays/` should be excluded from the bucket's default
+ * deletion lifecycle rule (see terraform/storage.tf) so videos are retained.
+ */
+export async function uploadReplayVideo(
+  chatId: string,
+  kernelSessionId: string,
+  videoBuffer: ArrayBuffer,
+): Promise<string> {
+  const pathname = `replays/${chatId}/${kernelSessionId}.mp4`;
+  const file = bucket.file(pathname);
+
+  await file.save(Buffer.from(videoBuffer), {
+    metadata: { contentType: 'video/mp4' },
+  });
+
   return `https://storage.googleapis.com/${bucketName}/${pathname}`;
 }

--- a/lib/storage/gcs.ts
+++ b/lib/storage/gcs.ts
@@ -1,9 +1,14 @@
 import { Storage } from '@google-cloud/storage';
 
-// Initialize Google Cloud Storage
+// Initialize Google Cloud Storage.
+//
+// Authenticate via Application Default Credentials — on Cloud Run that is the
+// per-env runtime service account (cloud-run-<env>@…), which is granted
+// storage.objectAdmin on the bucket in terraform/storage.tf. No keyFilename:
+// the same runtime SA is used for GCS, Cloud SQL, secrets, and Vertex (it holds
+// aiplatform.user), so no per-service key files are needed.
 const storage = new Storage({
   projectId: process.env.GOOGLE_CLOUD_PROJECT,
-  keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
 });
 
 const bucketName = process.env.GCS_BUCKET_NAME || 'nava-storage-dev';


### PR DESCRIPTION
## What

Adds a `SessionMapping` table that correlates each chat with its **PostHog session id** and its **Kernel browser session/replay ids** — the index/mapping table for tying chat logs and LLM traces back to a PostHog session (the BigQuery/analytics-tracing groundwork from standup).

## Why

These three ids live in different places and we've been wiring them up manually. One row per chat gives us a durable mapping. Columns for kernel session + replay are included now (nullable) so wiring the kernel video later needs no second migration.

## How it works

The row is populated from **two directions**, keyed by `chatId` (the one id both sides share):

- **PostHog session id** — client-only (`posthog.get_session_id()`). New `useSessionMapping` hook reports it to `POST /api/session-mapping` once an assistant message exists (guarantees the chat row is persisted server-side, avoiding the lazy-create 403 race), and re-reports if PostHog rotates the id.
- **Kernel session/replay ids** — server-only. `getOrCreateBrowser` upserts them after the browser + replay are created (best-effort; never fails browser creation).

`upsertSessionMapping` does `insert … onConflictDoUpdate` on `chatId`, writing only the fields each side provides so neither write clobbers the other's.

## Deploy / migration

Migration `0005_abandoned_madame_hydra.sql` applies **automatically on container startup** — `Dockerfile.ai-chatbot` CMD runs `lib/db/migrate` before `next start`, against `app_db` via the injected `DATABASE_URL`. **No Terraform / infra change needed** (`NEXT_PUBLIC_POSTHOG_KEY` and `KERNEL_API_KEY` are already wired into Cloud Run).

## How to test (on dev/preview)

1. Deploy this branch; the container runs the migration on boot.
2. Open a chat, send a message, wait for the reply → `POST /api/session-mapping` fires; the chat's `SessionMapping` row gets `posthogSessionId`.
3. Trigger a web-automation task (spins up the kernel browser) → same row gains `kernelSessionId` + `kernelReplayId`.
4. End state: one row per chat with all three ids populated.