### PR TITLE
ci: add AI test classifier caller workflow

### DIFF
--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -1,0 +1,49 @@
+name: AI test classifier
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# For provider: bedrock, OIDC needs id-token: write here in the CALLER too —
+# the permission can't be granted by the reusable workflow alone. Harmless to
+# include on the default (anthropic) path. contents/pull-requests mirror the
+# reusable workflow's needs.
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  classify:
+    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@pilot
+    with:
+      # Which AI CLI runs the classifier: claude | codex.
+      # Set the matching API-key secret below for whichever you pick.
+      tool: claude
+
+      # ── Provider: where inference runs (default: anthropic) ────────────────
+      # provider: anthropic  → direct API via ANTHROPIC_API_KEY / OPENAI_API_KEY.
+      # provider: bedrock    → Amazon Bedrock in YOUR AWS account. No code leaves
+      #   your AWS boundary; this is the CMS-internal path. Works with tool: claude
+      #   (Claude models) or tool: codex (OpenAI GPT-5.x) — not copilot. Codex on
+      #   Bedrock runs OpenAI models, not Claude. Needs the bedrock inputs below.
+      #   Full setup (use-case form, API key, optional IAM role/OIDC):
+      #   testing/classifier/docs/BEDROCK.md
+      #
+      # To use Bedrock, uncomment the lines below. The default auth is `static`
+      # (one Bedrock API key — simplest, recommended for the pilot); also
+      # uncomment the AWS_BEARER_TOKEN_BEDROCK secret at the bottom.
+      # provider: bedrock
+      # aws-region: us-east-1
+      # aws-auth: static     # static (default): one bearer-token secret, no role | oidc: assume a role, no stored key
+      # bedrock-model: us.anthropic.claude-sonnet-4-6   # claude default; codex → openai.gpt-5.5
+      #
+      # Hardened OIDC variant instead: set `aws-auth: oidc`, leave the
+      # AWS_BEARER_TOKEN_BEDROCK secret unset, and add (id-token: write already set above):
+      # aws-role-to-assume: arn:aws:iam::123456789012:role/ai-test-classifier
+    secrets:
+      # Needed when provider: anthropic and tool: claude. Leave unset for bedrock.
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Needed when tool: codex
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # Needed only for provider: bedrock + aws-auth: static
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}


### PR DESCRIPTION
Adds the AI test-failure classifier via the navapbc reusable workflow (pinned to `@pilot`).

## What this does
On each PR, the classifier runs the test suite in CI, triages failing tests (`APPLICATION_BUG` / `TEST_BUG` / `FLAKY_FAILURE` / `ENVIRONMENT_ISSUE`), and posts **one non-blocking PR comment** with verdicts and a 👍/👎 ask. The full report also uploads as the `ai-test-classification` artifact.

## Config
- CI: GitHub Actions (default reusable-workflow path — no files vendored)
- `tool: claude`, `provider: anthropic`
- Gating intentionally **not** enabled

## Required manual step (blocks the run)
A maintainer must add the API key secret:
```
gh secret set ANTHROPIC_API_KEY -R navapbc/ai-chatbot
```
Key from https://console.anthropic.com/settings/keys

Per navapbc/ai-transformation-delivery-systems `AGENT_INSTALL.md`.