### PR TITLE
Add slugify util with tests

### DIFF
--- a/lib/slugify.ts
+++ b/lib/slugify.ts
@@ -1,0 +1,14 @@
+/**
+ * Convert an arbitrary string into a URL-friendly slug.
+ *
+ * Lowercases, trims, replaces any run of non-alphanumeric characters with a
+ * single hyphen, and strips leading/trailing hyphens.
+ */
+export function slugify(input: string): string {
+  return input
+    .normalize('NFKD')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/tests/client/slugify.test.ts
+++ b/tests/client/slugify.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { slugify } from '@/lib/slugify';
+
+describe('slugify', () => {
+  test('lowercases and hyphenates spaces', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  test('collapses runs of non-alphanumeric characters into one hyphen', () => {
+    expect(slugify('foo   bar!!!baz')).toBe('foo-bar-baz');
+  });
+
+  test('trims leading and trailing separators', () => {
+    expect(slugify('  --Edge Case--  ')).toBe('edge-case');
+  });
+
+  test('returns empty string for input with no alphanumerics', () => {
+    expect(slugify('!!! ???')).toBe('');
+  });
+});


### PR DESCRIPTION
Adds a pure-logic `slugify` util in `lib/slugify.ts` with colocated Vitest coverage in `tests/client/slugify.test.ts`.

Used to exercise the test-classifier end-to-end workflow (`AI_RUN_SUITE=1 test-classifier --pr N --submit`).