### PR TITLE
Demo: add truncate util + tests (test-classifier validation)

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -114,3 +114,13 @@ export function getTextFromMessage(message: ChatMessage): string {
     .map((part) => part.text)
     .join('');
 }
+
+/**
+ * Truncate a string to at most `max` characters, appending an ellipsis when
+ * the input was shortened. A non-positive `max` yields an empty string.
+ */
+export function truncate(text: string, max: number): string {
+  if (max <= 0) return '';
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}…`;
+}

--- a/tests/client/truncate.test.ts
+++ b/tests/client/truncate.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { truncate } from '@/lib/utils';
+
+describe('truncate', () => {
+  test('returns the string unchanged when within the limit', () => {
+    expect(truncate('hello', 5)).toBe('hello');
+    expect(truncate('hi', 10)).toBe('hi');
+  });
+
+  test('truncates and appends an ellipsis when over the limit', () => {
+    expect(truncate('hello world', 5)).toBe('hello…');
+  });
+
+  test('returns an empty string for a non-positive max', () => {
+    expect(truncate('hello', 0)).toBe('');
+    expect(truncate('hello', -3)).toBe('');
+  });
+
+  test('handles an empty input string', () => {
+    expect(truncate('', 5)).toBe('');
+  });
+});


### PR DESCRIPTION
Throwaway PR to validate the local `test-classifier` CLI `--pr`/`--submit` flow.

## Change
- Add `truncate(text, max)` pure util to `lib/utils.ts`
- Add unit tests in `tests/client/truncate.test.ts`

This is a clean application change with matching tests — expected classifier verdict is application-side, not test-bug/flaky/environment. Safe to close after validation.