### PR TITLE
Demo: example wordCount util + test for AI test classifier

### DIFF
--- a/lib/example/word-count.test.ts
+++ b/lib/example/word-count.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { wordCount } from '@/lib/example/word-count';
+
+describe('wordCount', () => {
+  test('returns 0 for an empty string', () => {
+    expect(wordCount('')).toBe(0);
+    expect(wordCount('   ')).toBe(0);
+  });
+
+  test('counts a single word', () => {
+    expect(wordCount('hello')).toBe(1);
+  });
+
+  test('counts multiple words separated by whitespace', () => {
+    expect(wordCount('the quick brown fox')).toBe(4);
+  });
+
+  test('collapses repeated and surrounding whitespace', () => {
+    expect(wordCount('  foo   bar  ')).toBe(2);
+  });
+});

--- a/lib/example/word-count.ts
+++ b/lib/example/word-count.ts
@@ -1,0 +1,13 @@
+/**
+ * Example utility used to demo the AI test classifier.
+ * Counts the number of whitespace-separated words in a string.
+ */
+export function wordCount(input: string): number {
+  const trimmed = input.trim();
+  if (trimmed === '') {
+    return 0;
+  }
+  const words = trimmed.split(/\s+/);
+  // BUG: off-by-one — drops the final word.
+  return words.length - 1;
+}


### PR DESCRIPTION
Adds a small `wordCount` utility and its unit test under `lib/example/` to exercise the AI test classifier `--pr` flow.

The implementation has a deliberate off-by-one bug (drops the final word), so the test suite fails — giving the classifier a real failure to triage. Not for merge.