### PR TITLE
feat: bring deployment infra (terraform, docker, github actions) from labs-asp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.claude
+.next
+node_modules
+terraform
+docs
+test-results
+playwright-report
+blob-report
+coverage
+artifacts/session_*
+*.log
+.env
+.env.*
+Dockerfile
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 .next
 node_modules
 terraform
-docs
 test-results
 playwright-report
 blob-report

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,73 @@
+name: Cleanup Preview Environment
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to clean up'
+        required: true
+
+env:
+  PROJECT_ID: nava-labs
+  REGION: us-central1
+  PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: github-actions-deploy@nava-labs.iam.gserviceaccount.com
+          workload_identity_provider: projects/279889631214/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.0"
+
+      - name: Terraform Init
+        working-directory: ./terraform
+        run: |
+          terraform init \
+            -backend-config="prefix=terraform/state/preview-pr-${{ env.PR_NUMBER }}"
+
+      - name: Terraform Destroy Preview Environment
+        working-directory: ./terraform
+        run: |
+          terraform destroy -auto-approve \
+            -var="environment=preview-pr-${{ env.PR_NUMBER }}" \
+            -var="browser_image_url=placeholder" \
+            -var="mastra_image_url=placeholder" \
+            -var="chatbot_image_url=placeholder" \
+            -var="browser_ws_proxy_image_url=placeholder" \
+            -var="enable_custom_domain=false"
+
+      - name: Delete Terraform State
+        run: |
+          gsutil -m rm -r "gs://labs-asp-terraform-state/terraform/state/preview-pr-${{ env.PR_NUMBER }}/" || echo "State already deleted"
+
+      - name: Cleanup Summary
+        run: |
+          echo "## Preview Environment Cleanup Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Destroyed preview-pr-${{ env.PR_NUMBER }} environment" >> $GITHUB_STEP_SUMMARY
+          echo "- Deleted Cloud Run services" >> $GITHUB_STEP_SUMMARY
+          echo "- Deleted VM instance" >> $GITHUB_STEP_SUMMARY
+          echo "- Deleted firewall rules" >> $GITHUB_STEP_SUMMARY
+          echo "- Deleted service accounts" >> $GITHUB_STEP_SUMMARY
+          echo "- Removed terraform state" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,59 @@
+name: Code Quality & Standards
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  push:
+    branches: [ main ]
+
+jobs:
+  validate-pr:
+    name: Validate Pull Request
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check PR title format
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            docs
+            style
+            refactor
+            perf
+            test
+            chore
+            ci
+          requireScope: false
+          disallowScopes: |
+            release
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+
+  validate-yaml:
+    name: Validate YAML
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate YAML files
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: |
+            .github/
+          config_data: |
+            extends: default
+            rules:
+              line-length: disable
+              trailing-spaces: disable
+              new-line-at-end-of-file: disable
+              document-start: disable
+              brackets: disable
+              truthy: disable
+              indentation:
+                spaces: 2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,378 @@
+name: Deploy Infrastructure
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches: [develop, main]  # Preview deployment on PRs
+  workflow_dispatch:  # Manual trigger
+    inputs:
+      environment:
+        description: 'Environment to deploy'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - dev
+          - preview
+          - prod
+
+env:
+  PROJECT_ID: nava-labs
+  REGION: us-central1
+  ARTIFACT_REGISTRY: us-central1-docker.pkg.dev/nava-labs/labs-asp
+
+jobs:
+  # Determine environment based on branch/trigger
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.env.outputs.environment }}
+      should_deploy: ${{ steps.env.outputs.should_deploy }}
+
+    steps:
+      - name: Determine environment
+        id: env
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            ENVIRONMENT="${{ github.event.inputs.environment }}"
+            SHOULD_DEPLOY="true"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            ENVIRONMENT="preview-pr-${{ github.event.pull_request.number }}"
+            SHOULD_DEPLOY="true"  # PRs deploy to isolated preview environment
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            ENVIRONMENT="prod"
+            SHOULD_DEPLOY="true"
+          elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            ENVIRONMENT="dev"
+            SHOULD_DEPLOY="true"
+          else
+            # Any other branch = preview environment with actual deployment
+            ENVIRONMENT="preview"
+            SHOULD_DEPLOY="true"
+          fi
+
+          echo "environment=${ENVIRONMENT}" >> $GITHUB_OUTPUT
+          echo "should_deploy=${SHOULD_DEPLOY}" >> $GITHUB_OUTPUT
+          echo "Environment: ${ENVIRONMENT} (deploy: ${SHOULD_DEPLOY})"
+
+  # Build and push Docker images
+  build:
+    runs-on: ubuntu-latest
+    needs: setup
+
+    permissions:
+      contents: read
+      id-token: write
+
+    outputs:
+      chatbot_image: ${{ steps.images.outputs.chatbot_image }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: github-actions-deploy@nava-labs.iam.gserviceaccount.com
+          workload_identity_provider: projects/279889631214/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev
+
+      - name: Set image tags
+        id: images
+        run: |
+          TAG=${GITHUB_SHA:0:7}
+          echo "chatbot_image=${ARTIFACT_REGISTRY}/ai-chatbot:${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Get PostHog API key
+        id: posthog_key
+        run: |
+          POSTHOG_KEY=$(gcloud secrets versions access latest --secret=posthog-api-key)
+          echo "::add-mask::$POSTHOG_KEY"
+          echo "key=$POSTHOG_KEY" >> $GITHUB_OUTPUT
+
+      - name: Get Kernel API key
+        id: kernel_key
+        run: |
+          KERNEL_KEY=$(gcloud secrets versions access latest --secret=kernel-api-key)
+          echo "::add-mask::$KERNEL_KEY"
+          echo "key=$KERNEL_KEY" >> $GITHUB_OUTPUT
+
+      - name: Build and push ai-chatbot image
+        run: |
+          # Enable guest login only for preview-pr-* environments
+          USE_GUEST="false"
+          if [[ "${{ needs.setup.outputs.environment }}" == preview-pr-* ]]; then
+            USE_GUEST="true"
+          fi
+
+          docker build \
+            --build-arg NEXT_PUBLIC_POSTHOG_KEY=${{ steps.posthog_key.outputs.key }} \
+            --build-arg NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com \
+            --build-arg KERNEL_API_KEY=${{ steps.kernel_key.outputs.key }} \
+            --build-arg USE_GUEST_LOGIN=${USE_GUEST} \
+            --build-arg ENVIRONMENT=${{ needs.setup.outputs.environment }} \
+            -f Dockerfile \
+            -t ${{ steps.images.outputs.chatbot_image }} \
+            .
+          docker push ${{ steps.images.outputs.chatbot_image }}
+
+  # Deploy infrastructure with Terraform
+  terraform:
+    runs-on: ubuntu-latest
+    needs: [setup, build]
+    if: needs.setup.outputs.should_deploy == 'true' || github.event_name == 'pull_request'
+    environment:
+      name: ${{ needs.setup.outputs.environment }}
+      url: ${{ steps.tf_outputs.outputs.chatbot_url }}
+
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: github-actions-deploy@nava-labs.iam.gserviceaccount.com
+          workload_identity_provider: projects/279889631214/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.0"
+
+      # Deploy shared preview VPC first (only for preview environments, before anything else)
+      - name: Deploy Shared Preview VPC
+        if: startsWith(needs.setup.outputs.environment, 'preview-')
+        working-directory: ./terraform/shared-preview-vpc
+        run: |
+          echo "🔧 Ensuring shared preview VPC exists..."
+
+          # Initialize shared VPC terraform
+          terraform init
+
+          # Check if VPC already exists
+          if gcloud compute networks describe labs-asp-vpc-preview-shared --project=nava-labs 2>/dev/null; then
+            echo "✅ Shared preview VPC already exists, skipping creation"
+          else
+            echo "🚀 Creating shared preview VPC (first preview deployment)..."
+            terraform apply -auto-approve
+            echo "✅ Shared preview VPC created successfully"
+          fi
+
+      - name: Terraform Init
+        working-directory: ./terraform
+        run: |
+          terraform init \
+            -backend-config="prefix=terraform/state/${{ needs.setup.outputs.environment }}"
+
+      - name: Verify Terraform State
+        working-directory: ./terraform
+        run: |
+          echo "Checking Terraform state for environment: ${{ needs.setup.outputs.environment }}"
+          terraform state list || echo "No existing state found (expected for first deployment)"
+
+      # Establish VPC peering on dev environment deployment
+      - name: Establish VPC Peering with Shared Preview VPC
+        if: needs.setup.outputs.environment == 'dev'
+        working-directory: ./terraform/shared-preview-vpc
+        run: |
+          echo "🔗 Ensuring VPC peering between dev and shared preview VPC..."
+
+          # Initialize shared VPC terraform
+          terraform init
+
+          # Check if shared preview VPC exists
+          if gcloud compute networks describe labs-asp-vpc-preview-shared --project=nava-labs 2>/dev/null; then
+            echo "✅ Shared preview VPC exists, ensuring peering is configured..."
+            terraform apply -auto-approve
+            echo "✅ VPC peering established/updated successfully"
+          else
+            echo "⚠️  Shared preview VPC does not exist yet (will be created on first preview deployment)"
+          fi
+
+      - name: Set VPC CIDR blocks and Firewall rules
+        id: vpc_cidrs
+        run: |
+          ENV="${{ needs.setup.outputs.environment }}"
+
+          # Set VPC CIDR blocks based on environment
+          # Pattern: 10.X.0.0/16 where X is determined by environment
+          # Note: Preview environments use shared VPC (10.1.0.0/16) but still need CIDR values for Terraform variables
+          case ${ENV} in
+            dev)
+              # Dev: 10.0.0.0/16
+              echo "vpc_cidr_public=10.0.0.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_cidr_private=10.0.16.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_cidr_db=10.0.32.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_connector_cidr=10.0.48.0/28" >> $GITHUB_OUTPUT
+
+              # Dev: Allow public access for all services (JSON in single line)
+              echo 'firewall_rules={"browser_mcp":{"port":8931,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]},"browser_streaming":{"port":8933,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]},"mastra_api":{"port":4112,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]}}' >> $GITHUB_OUTPUT
+              ;;
+            preview|preview-*)
+              # Preview: Uses shared VPC (10.1.0.0/16) - values for reference only
+              echo "vpc_cidr_public=10.1.0.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_cidr_private=10.1.16.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_cidr_db=10.1.32.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_connector_cidr=10.1.48.0/28" >> $GITHUB_OUTPUT
+
+              # Preview: Allow public access for testing (JSON in single line)
+              echo 'firewall_rules={"browser_mcp":{"port":8931,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]},"browser_streaming":{"port":8933,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]},"mastra_api":{"port":4112,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]}}' >> $GITHUB_OUTPUT
+              ;;
+            prod)
+              # Production: 10.2.0.0/16
+              echo "vpc_cidr_public=10.2.0.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_cidr_private=10.2.16.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_cidr_db=10.2.32.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_connector_cidr=10.2.48.0/28" >> $GITHUB_OUTPUT
+
+              # Prod: Granular firewall rules per service (JSON in single line)
+              # TODO: Update with your production IP ranges and ports
+              echo 'firewall_rules={"browser_mcp":{"port":8931,"allow_public_access":false,"allowed_ip_ranges":["203.0.113.0/24"]},"browser_streaming":{"port":8933,"allow_public_access":false,"allowed_ip_ranges":["203.0.113.0/24","198.51.100.0/24"]},"mastra_api":{"port":4112,"allow_public_access":false,"allowed_ip_ranges":["203.0.113.0/24"]}}' >> $GITHUB_OUTPUT
+              ;;
+            *)
+              # Default to dev range
+              echo "vpc_cidr_public=10.0.0.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_cidr_private=10.0.16.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_cidr_db=10.0.32.0/20" >> $GITHUB_OUTPUT
+              echo "vpc_connector_cidr=10.0.48.0/28" >> $GITHUB_OUTPUT
+
+              # Default: Public access (JSON in single line)
+              echo 'firewall_rules={"browser_mcp":{"port":8931,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]},"browser_streaming":{"port":8933,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]},"mastra_api":{"port":4112,"allow_public_access":true,"allowed_ip_ranges":["0.0.0.0/0"]}}' >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+          echo "VPC CIDRs and Firewall rules configured for ${ENV}"
+
+      - name: Terraform Plan
+        working-directory: ./terraform
+        run: |
+          # Enable custom domain only for dev and prod environments
+          ENABLE_DOMAIN="false"
+          if [[ "${{ needs.setup.outputs.environment }}" == "dev" ]] || [[ "${{ needs.setup.outputs.environment }}" == "prod" ]]; then
+            ENABLE_DOMAIN="true"
+          fi
+
+          # Enable guest login only for preview-pr-* environments
+          USE_GUEST="false"
+          if [[ "${{ needs.setup.outputs.environment }}" == preview-pr-* ]]; then
+            USE_GUEST="true"
+          fi
+
+          terraform plan \
+            -var="environment=${{ needs.setup.outputs.environment }}" \
+            -var="chatbot_image_url=${{ needs.build.outputs.chatbot_image }}" \
+            -var="enable_custom_domain=${ENABLE_DOMAIN}" \
+            -var="use_guest_login=${USE_GUEST}" \
+            -var="vpc_cidr_public=${{ steps.vpc_cidrs.outputs.vpc_cidr_public }}" \
+            -var="vpc_cidr_private=${{ steps.vpc_cidrs.outputs.vpc_cidr_private }}" \
+            -var="vpc_cidr_db=${{ steps.vpc_cidrs.outputs.vpc_cidr_db }}" \
+            -var="vpc_connector_cidr=${{ steps.vpc_cidrs.outputs.vpc_connector_cidr }}" \
+            -var='firewall_rules=${{ steps.vpc_cidrs.outputs.firewall_rules }}' \
+            -out=tfplan
+
+      - name: Terraform Apply
+        if: needs.setup.outputs.should_deploy == 'true'
+        working-directory: ./terraform
+        run: terraform apply -auto-approve tfplan
+
+      - name: Get Terraform Outputs
+        if: needs.setup.outputs.should_deploy == 'true'
+        working-directory: ./terraform
+        id: tf_outputs
+        run: |
+          echo "chatbot_url=$(terraform output -raw chatbot_public_url)" >> $GITHUB_OUTPUT
+          echo "custom_domain=$(terraform output -raw custom_domain)" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR with deployment info
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const shouldDeploy = '${{ needs.setup.outputs.should_deploy }}' === 'true';
+            const customDomain = '${{ steps.tf_outputs.outputs.custom_domain }}';
+            const hasCustomDomain = customDomain && customDomain.length > 0;
+
+            const body = shouldDeploy
+              ? `## Preview Deployment Complete
+
+            Infrastructure deployed to **${{ needs.setup.outputs.environment }}** environment.
+
+            ### Access URLs
+            - **AI Chatbot (Cloud Run)**: ${{ steps.tf_outputs.outputs.chatbot_url }}
+
+            ${hasCustomDomain ? `**Custom Domain**: https://${customDomain}\n\n**Note:** Custom domain SSL certificate may take 5-15 minutes to provision on first deployment.` : '**Note:** Custom domain not configured for preview environments. Use Cloud Run URL to access the application.'}`
+              : `## Terraform Plan Complete
+
+            Infrastructure changes have been planned for **${{ needs.setup.outputs.environment }}** environment.
+
+            ### Changes
+            - Cloud Run services: ai-chatbot
+            - All services connect to **dev database** and **dev GCS bucket**
+
+            **Note:** This is a plan only. Merge to deploy.`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+      - name: Create deployment summary
+        if: needs.setup.outputs.should_deploy == 'true'
+        id: summary
+        run: |
+          CUSTOM_DOMAIN="${{ steps.tf_outputs.outputs.custom_domain }}"
+
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          ## Deployment Complete: ${{ needs.setup.outputs.environment }}
+
+          ### Access URLs
+          - **AI Chatbot (Cloud Run)**: ${{ steps.tf_outputs.outputs.chatbot_url }}
+          EOF
+
+          if [ -n "$CUSTOM_DOMAIN" ]; then
+            cat >> $GITHUB_STEP_SUMMARY <<EOF
+
+          ### Custom Domain
+          - **AI Chatbot**: https://$CUSTOM_DOMAIN
+
+          **Note:** Custom domain SSL certificate may take 5-15 minutes to provision on first deployment.
+          EOF
+          fi
+
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+
+          ### Environment
+          - **Environment**: ${{ needs.setup.outputs.environment }}
+          EOF
+
+      - name: Deployment Summary (console)
+        if: needs.setup.outputs.should_deploy == 'true'
+        run: |
+          CUSTOM_DOMAIN="${{ steps.tf_outputs.outputs.custom_domain }}"
+
+          echo "Deployment to ${{ needs.setup.outputs.environment }} complete"
+          echo "Cloud Run URL: ${{ steps.tf_outputs.outputs.chatbot_url }}"
+
+          if [ -n "$CUSTOM_DOMAIN" ]; then
+            echo "Custom Domain: https://$CUSTOM_DOMAIN"
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,17 +9,17 @@ jobs:
       matrix:
         node-version: [20]
     steps:
-    - uses: actions/checkout@v4
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 9.12.3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-    - name: Install dependencies
-      run: pnpm install
-    - name: Run lint
-      run: pnpm lint
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run lint
+        run: pnpm lint

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,133 @@
+name: Promote to Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to promote to'
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+      version:
+        description: 'Git tag/version to promote (e.g., v1.2.3)'
+        required: true
+        type: string
+
+env:
+  PROJECT_ID: nava-labs
+  REGION: us-central1
+  ARTIFACT_REGISTRY: us-central1-docker.pkg.dev/nava-labs/labs-asp
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.environment }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code at specified version
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: github-actions-deploy@nava-labs.iam.gserviceaccount.com
+          workload_identity_provider: projects/279889631214/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev
+
+      - name: Get commit SHA from tag
+        id: sha
+        run: |
+          FULL_SHA=$(git rev-parse HEAD)
+          SHORT_SHA=${FULL_SHA:0:7}
+          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "full_sha=${FULL_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Set image tags
+        id: images
+        run: |
+          TAG=${{ steps.sha.outputs.short_sha }}
+          echo "browser_image=${ARTIFACT_REGISTRY}/browser-streaming:${TAG}" >> $GITHUB_OUTPUT
+          echo "browser_ws_proxy_image=${ARTIFACT_REGISTRY}/browser-ws-proxy:${TAG}" >> $GITHUB_OUTPUT
+          echo "mastra_image=${ARTIFACT_REGISTRY}/mastra-app:${TAG}" >> $GITHUB_OUTPUT
+          echo "chatbot_image=${ARTIFACT_REGISTRY}/ai-chatbot:${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Verify images exist
+        run: |
+          echo "Verifying images exist in Artifact Registry..."
+          gcloud artifacts docker images describe ${{ steps.images.outputs.browser_image }} || echo "Warning: browser image not found"
+          gcloud artifacts docker images describe ${{ steps.images.outputs.browser_ws_proxy_image }} || echo "Warning: proxy image not found"
+          gcloud artifacts docker images describe ${{ steps.images.outputs.mastra_image }} || echo "Warning: mastra image not found"
+          gcloud artifacts docker images describe ${{ steps.images.outputs.chatbot_image }} || echo "Warning: chatbot image not found"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.0"
+
+      - name: Terraform Init
+        working-directory: ./terraform
+        run: |
+          terraform init \
+            -backend-config="prefix=terraform/state/${{ github.event.inputs.environment }}"
+
+      - name: Terraform Plan
+        working-directory: ./terraform
+        run: |
+          terraform plan \
+            -var="environment=${{ github.event.inputs.environment }}" \
+            -var="browser_image_url=${{ steps.images.outputs.browser_image }}" \
+            -var="mastra_image_url=${{ steps.images.outputs.mastra_image }}" \
+            -var="chatbot_image_url=${{ steps.images.outputs.chatbot_image }}" \
+            -var="browser_ws_proxy_image_url=${{ steps.images.outputs.browser_ws_proxy_image }}" \
+            -out=tfplan
+
+      - name: Terraform Apply
+        working-directory: ./terraform
+        run: terraform apply -auto-approve tfplan
+
+      # REMOVED: Automatic rollback with terraform destroy is too dangerous
+      # It can destroy global resources like IAM bindings and workload identity pools
+      # With lifecycle prevent_destroy rules, destroy would fail anyway
+      # Better to fix forward than destroy on failure
+
+      - name: Get Terraform Outputs
+        working-directory: ./terraform
+        id: tf_outputs
+        run: |
+          echo "chatbot_url=$(terraform output -raw chatbot_public_url)" >> $GITHUB_OUTPUT
+          echo "vm_ip=$(terraform output -raw vm_internal_ip)" >> $GITHUB_OUTPUT
+
+      - name: Deployment Summary
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          ## Promotion Complete: ${{ github.event.inputs.version }} → ${{ github.event.inputs.environment }}
+
+          ### Service URLs
+          - **AI Chatbot**: ${{ steps.tf_outputs.outputs.chatbot_url }}
+          - **Mastra API**: http://${{ steps.tf_outputs.outputs.vm_ip }}:4112 (internal IP, accessible via VPC)
+          - **Browser MCP**: http://${{ steps.tf_outputs.outputs.vm_ip }}:8931/mcp (internal IP, accessible via VPC)
+          - **Browser Streaming**: ws://${{ steps.tf_outputs.outputs.vm_ip }}:8933 (internal IP, accessible via VPC)
+
+          ### Deployment Info
+          - **Version**: ${{ github.event.inputs.version }}
+          - **Commit**: ${{ steps.sha.outputs.full_sha }}
+          - **Environment**: ${{ github.event.inputs.environment }}
+          EOF
+
+          echo "Promotion to ${{ github.event.inputs.environment }} complete"
+          echo "Version: ${{ github.event.inputs.version }}"
+          echo "Chatbot URL: ${{ steps.tf_outputs.outputs.chatbot_url }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+# Prevent concurrent releases on the same branch
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator conventional-changelog-conventionalcommits
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx semantic-release --debug
+        continue-on-error: false
+
+      - name: Release Summary
+        if: always()
+        run: |
+          echo "## Release Workflow Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Branch: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,24 +9,24 @@ jobs:
       matrix:
         node-version: [20]
     steps:
-    - uses: actions/checkout@v4
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 9.12.3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-    - name: Install dependencies
-      run: pnpm install
-    # Vitest runs in browser mode (Playwright Chromium), so the browser and its
-    # system deps must be present in CI.
-    - name: Install Playwright Chromium
-      run: pnpm exec playwright install --with-deps chromium
-    # Non-blocking: a failing test reports here but must not block merging.
-    # Remove `continue-on-error` once the suite is stable enough to gate on.
-    - name: Run tests
-      run: pnpm test -- run
-      continue-on-error: true
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      # Vitest runs in browser mode (Playwright Chromium), so the browser and its
+      # system deps must be present in CI.
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+      # Non-blocking: a failing test reports here but must not block merging.
+      # Remove `continue-on-error` once the suite is stable enough to gate on.
+      - name: Run tests
+        run: pnpm test -- run
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,12 @@ vertex-ai-credentials.json
 
 .claude/
 docs/superpowers/
+
+# Terraform
+**/.terraform/
+**/.terraform.lock.hcl
+**/terraform.tfstate
+**/terraform.tfstate.backup
+**/tfplan
+terraform/*.tfvars
+terraform/*apply.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+# Dockerfile for AI Chatbot (Next.js client)
+FROM node:20-slim AS base
+
+# Install basic system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    ca-certificates \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pnpm globally
+RUN npm install -g pnpm
+
+# Stage 1: Build stage
+FROM base AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy app source (kept at /app/client to match the pre-migration image layout)
+COPY . ./client/
+
+# Go to client directory and install dependencies
+WORKDIR /app/client
+RUN rm -rf node_modules && pnpm install --frozen-lockfile --ignore-scripts
+
+# Build args
+ARG NEXT_PUBLIC_POSTHOG_KEY
+ARG NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+ARG USE_GUEST_LOGIN=false
+ARG KERNEL_API_KEY
+ARG ENVIRONMENT=dev
+
+# Set environment variables for build time
+ENV NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
+ENV NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
+ENV USE_GUEST_LOGIN=${USE_GUEST_LOGIN}
+ENV NEXT_PUBLIC_USE_GUEST_LOGIN=${USE_GUEST_LOGIN}
+ENV KERNEL_API_KEY=${KERNEL_API_KEY}
+ENV ENVIRONMENT=${ENVIRONMENT}
+ENV NEXT_PUBLIC_ENVIRONMENT=${ENVIRONMENT}
+
+# Build Next.js client only (migrations run at container startup)
+RUN pnpm next build
+
+# Stage 2: Runtime stage
+FROM base AS runtime
+
+# Copy built application
+WORKDIR /app
+COPY --from=builder /app/client ./client
+
+# Ensure agent-browser binary has execute permissions
+RUN chmod +x /app/client/node_modules/.pnpm/agent-browser@*/node_modules/agent-browser/bin/* 2>/dev/null || true
+
+# Create a non-root user for better security
+RUN groupadd -r nextjs && useradd -r -g nextjs -d /app -s /bin/bash nextjs
+
+# Change ownership of the app directory to the nextjs user
+RUN chown -R nextjs:nextjs /app
+
+# Switch to non-root user
+USER nextjs
+
+# Set working directory to client
+WORKDIR /app/client
+
+# Expose Next.js port
+EXPOSE 3000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:3000/health || curl -f http://localhost:3000 || exit 1
+
+# Start Next.js server (run migrations first, then start)
+CMD ["sh", "-c", "pnpm tsx lib/db/migrate && pnpm start"]

--- a/terraform/DEPLOYMENT_GUIDE.md
+++ b/terraform/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,443 @@
+# Deployment Guide
+
+## Overview
+
+This project uses GitHub Actions to automatically build Docker images and deploy infrastructure using Terraform. Deployments are triggered automatically based on branch activity.
+
+## Deployment Environments
+
+| Environment | Trigger | State Prefix | Purpose |
+|------------|---------|--------------|---------|
+| **Preview** | Pull Request | `terraform/state/preview-pr-{number}` | Isolated testing environment per PR |
+| **Dev** | Push to `develop` | `terraform/state/dev` | Main development environment |
+| **Prod** | Push to `main` | `terraform/state/prod` | Production environment |
+
+## Architecture
+
+### Infrastructure Components
+
+1. **GCP Compute Engine VM** (`app-vm-{environment}`)
+   - Runs Container-Optimized OS (COS)
+   - Hosts two Docker containers:
+     - `browser-streaming`: Playwright MCP server + browser automation
+     - `mastra-app`: Mastra API server
+
+2. **Cloud Run Services**
+   - `ai-chatbot`: Web UI for interacting with agents
+   - `browser-ws-proxy`: WebSocket proxy for browser streaming
+
+3. **Shared Resources** (managed only by `dev` environment)
+   - GitHub Actions service account
+   - Workload Identity Pool
+   - IAM bindings
+   - GCS buckets (per environment, but created by dev)
+   - Secret Manager secrets
+
+## How Deployments Work
+
+### 1. Code Changes → Docker Images
+
+When you push code or open a PR, GitHub Actions:
+
+1. **Authenticates** to GCP using Workload Identity
+2. **Builds Docker images** for all components (always, regardless of what changed):
+   - `browser-streaming:${COMMIT_SHA:0:7}`
+   - `browser-ws-proxy:${COMMIT_SHA:0:7}`
+   - `mastra-app:${COMMIT_SHA:0:7}`
+   - `ai-chatbot:${COMMIT_SHA:0:7}`
+3. **Pushes images** to Artifact Registry at `us-central1-docker.pkg.dev/nava-labs/labs-asp/`
+
+### 2. Docker Images → Infrastructure Deployment
+
+Terraform then:
+
+1. **Initializes** with environment-specific state prefix
+2. **Plans changes** using the new Docker image tags
+3. **Applies changes**:
+   - Updates VM metadata with new image tags
+   - VM startup script pulls new images and restarts containers
+   - Updates Cloud Run services with new images
+
+### 3. VM Container Updates
+
+When new images are deployed:
+
+1. VM metadata is updated with new image tags (`browser-image-version`, `mastra-image-version`)
+2. Terraform triggers VM restart (metadata changes cause VM reboot)
+3. Startup script (`terraform/scripts/startup.sh`) runs on boot:
+   - Configures Docker for Artifact Registry
+   - Pulls latest images
+   - Stops old containers
+   - Starts new containers with updated configuration
+
+## Key Architecture Decisions
+
+### Global Resources Management
+
+Only the `dev` environment manages global resources:
+- GitHub Actions service account
+- Workload Identity Pool
+- IAM bindings
+- GCS buckets for all environments
+
+**Why?** Prevents preview/prod environments from destroying critical shared infrastructure.
+
+See: `terraform/iam.tf:5-6`
+```terraform
+locals {
+  is_managing_globals = var.environment == "dev"
+}
+```
+
+### Always Build All Images
+
+**Problem:** Previously, images were built conditionally based on path changes. This caused failures when only Terraform changed - new commit SHAs had no corresponding images in Artifact Registry.
+
+**Solution:** Always build all images on every deployment (`.github/workflows/deploy.yml:125-161`).
+
+**Trade-off:** Longer build times, but guaranteed image availability.
+
+### Application Default Credentials (ADC)
+
+Vertex AI authentication uses ADC instead of JSON key files:
+- VM service account has `roles/aiplatform.user` permission
+- No credential files needed
+- Works both locally (with `gcloud auth application-default login`) and on VMs
+- More secure - no secrets in containers
+
+See: `terraform/compute.tf:195-199`
+
+### VM Updates Trigger Restart
+
+VM metadata changes (new image versions) trigger automatic VM restart to run startup script:
+- `browser-image-version` metadata
+- `mastra-image-version` metadata
+
+See: `terraform/compute.tf:72-75`
+
+## Deployment Workflows
+
+### Preview Environment (Pull Request)
+
+**Automatic on PR creation/update:**
+
+```bash
+# 1. Open PR against develop or main
+# GitHub Actions automatically:
+# - Builds all Docker images
+# - Creates preview environment: preview-pr-{number}
+# - Deploys isolated infrastructure
+# - Comments on PR with service URLs
+```
+
+**What gets deployed:**
+- Isolated VM: `app-vm-preview-pr-{number}`
+- Cloud Run services with PR-specific names
+- Uses dev database and dev GCS bucket
+- Separate Terraform state
+
+**Access URLs** (posted as PR comment):
+- AI Chatbot: `https://ai-chatbot-preview-pr-{number}-{hash}.run.app`
+- Mastra API: `http://{VM_IP}:4112`
+- Browser MCP: `http://{VM_IP}:8931/mcp`
+- Browser Streaming: `ws://{VM_IP}:8933`
+
+### Dev Environment
+
+**Automatic on push to `develop`:**
+
+```bash
+git checkout develop
+git merge feature-branch
+git push origin develop
+
+# GitHub Actions automatically:
+# - Builds all Docker images
+# - Deploys to dev environment
+# - Creates/updates global resources (IAM, buckets, etc.)
+```
+
+**What gets deployed:**
+- VM: `app-vm-dev`
+- Cloud Run services: `ai-chatbot-dev`, `browser-ws-proxy-dev`
+- Global resources (managed only by dev)
+- Uses dev database and dev GCS bucket
+
+### Production Environment
+
+**Automatic on push to `main`:**
+
+```bash
+git checkout main
+git merge develop
+git push origin main
+
+# GitHub Actions automatically:
+# - Builds all Docker images
+# - Deploys to prod environment
+# - Uses production database and GCS bucket
+```
+
+**What gets deployed:**
+- VM: `app-vm-prod`
+- Cloud Run services: `ai-chatbot-prod`, `browser-ws-proxy-prod`
+- References global resources (doesn't modify them)
+- Uses production database and production GCS bucket
+
+## Manual Operations
+
+### View Deployment Status
+
+```bash
+# Check GitHub Actions runs
+gh run list --workflow=deploy.yml --limit 5
+
+# View specific run
+gh run view {run-id} --log
+```
+
+### Access VM Logs
+
+```bash
+# SSH into VM
+gcloud compute ssh app-vm-{environment} --zone=us-central1-a
+
+# View container logs
+docker logs browser-streaming
+docker logs mastra-app
+
+# View startup script logs
+sudo journalctl -u google-startup-scripts.service
+```
+
+### Manual VM Restart (if needed)
+
+```bash
+# Restart VM to re-run startup script with current image tags
+gcloud compute instances reset app-vm-{environment} --zone=us-central1-a
+
+# Check VM status
+gcloud compute instances describe app-vm-{environment} --zone=us-central1-a
+```
+
+### Force Redeploy Without Code Changes
+
+```bash
+# Use workflow dispatch
+gh workflow run deploy.yml \
+  --ref develop \
+  --field environment=dev
+```
+
+## Troubleshooting
+
+### VM Containers Not Starting
+
+**Symptoms:** VM deployed but containers not running
+
+**Check:**
+```bash
+gcloud compute ssh app-vm-{environment} --zone=us-central1-a
+
+# Check if containers are running
+docker ps
+
+# Check startup logs
+sudo journalctl -u google-startup-scripts.service -f
+
+# Common issues:
+# - Image pull failures (check Artifact Registry permissions)
+# - Port conflicts
+# - Missing secrets
+```
+
+### Image Not Found Error
+
+**Symptoms:** `manifest for {image}:{tag} not found`
+
+**Cause:** Workflow didn't build images for the commit SHA
+
+**Solution:** This should no longer happen (workflow always builds all images). If it does:
+```bash
+# Check if image exists
+gcloud artifacts docker images list us-central1-docker.pkg.dev/nava-labs/labs-asp/browser-streaming
+
+# Manually trigger build
+gh workflow run deploy.yml --ref {branch}
+```
+
+### Terraform State Issues
+
+**Symptoms:** Resources already exist, state conflicts
+
+**Check state:**
+```bash
+cd terraform
+
+# Initialize with correct environment
+terraform init -backend-config="prefix=terraform/state/{environment}"
+
+# List resources in state
+terraform state list
+
+# Import existing resource if needed
+terraform import {resource_type}.{name} {resource_id}
+```
+
+### Preview Environment Not Cleaning Up
+
+**Manual cleanup:**
+```bash
+cd terraform
+
+# Initialize with preview environment state
+terraform init -backend-config="prefix=terraform/state/preview-pr-{number}"
+
+# Destroy preview environment
+terraform destroy \
+  -var="environment=preview-pr-{number}" \
+  -var="browser_image_url={any_existing_image}" \
+  -var="mastra_image_url={any_existing_image}" \
+  -var="chatbot_image_url={any_existing_image}" \
+  -var="browser_ws_proxy_image_url={any_existing_image}"
+```
+
+## Security Notes
+
+### Service Accounts
+
+- **GitHub Actions SA:** `github-actions-deploy@nava-labs.iam.gserviceaccount.com`
+  - Managed by Workload Identity (no JSON keys)
+  - Has broad permissions for deployment
+  - Only accessible from `navapbc/labs-asp` repository
+
+- **VM SA:** `app-vm-{environment}@nava-labs.iam.gserviceaccount.com`
+  - Scoped per environment
+  - Has minimal permissions (storage, logging, artifact registry, secrets, vertex AI)
+
+- **Cloud Run SA:** `cloud-run-{environment}@nava-labs.iam.gserviceaccount.com`
+  - Scoped per environment
+  - Can access VM services, storage, secrets
+
+### Secrets
+
+All secrets stored in Google Secret Manager:
+- `database-url-dev` / `database-url-production`
+- API keys (OpenAI, Anthropic, Exa, etc.)
+- `mastra-jwt-secret`, `mastra-app-password`, `mastra-jwt-token`
+- `posthog-api-key` - Analytics and user behavior tracking
+
+Accessed via:
+- Terraform data sources (for startup script)
+- VM/Cloud Run service accounts with `secretAccessor` role
+
+### Network Security
+
+Firewall rules allow public access to:
+- Port 8931 (Browser MCP)
+- Port 8933 (Browser Streaming WebSocket)
+- Port 4112 (Mastra API)
+
+**Production consideration:** Consider restricting source IPs or using Cloud VPN/Interconnect.
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/deploy.yml` | CI/CD pipeline - builds images and deploys |
+| `terraform/main.tf` | Core Terraform config, providers, backend |
+| `terraform/compute.tf` | VM and firewall resources |
+| `terraform/cloud-run.tf` | Cloud Run services |
+| `terraform/iam.tf` | Service accounts, workload identity, IAM bindings |
+| `terraform/storage.tf` | GCS buckets for artifacts |
+| `terraform/scripts/startup.sh` | VM startup script - pulls and runs containers |
+| `terraform/variables.tf` | Input variables and defaults |
+| `terraform/outputs.tf` | Output values (URLs, IPs) |
+
+## Analytics and User Tracking
+
+### PostHog Setup
+
+PostHog is integrated for analytics and user behavior tracking across all environments (dev, prod, preview).
+
+**Configuration:**
+- Single PostHog Cloud project shared across all environments
+- Events are tagged with `environment` property (dev/prod/preview-pr-{number})
+- Client-side tracking using `posthog-js` in Next.js app
+- Automatic pageview tracking and session recording
+
+**Environment Variables:**
+- `NEXT_PUBLIC_POSTHOG_KEY` - Project API key (from Secret Manager)
+- `NEXT_PUBLIC_POSTHOG_HOST` - `https://us.i.posthog.com`
+
+**Files:**
+- `client/app/providers.tsx` - PostHog provider and pageview tracking
+- `client/app/layout.tsx` - Provider integration
+- `terraform/cloud_run.tf` - Environment variable configuration
+
+**Managing the PostHog API Key:**
+```bash
+# View current secret
+gcloud secrets versions access latest --secret=posthog-api-key --project=nava-labs
+
+# Update secret with new API key
+echo -n "phc_YOUR_NEW_KEY" | gcloud secrets versions add posthog-api-key --data-file=-
+```
+
+**Viewing Analytics:**
+- Dashboard: https://app.posthog.com
+- Filter by environment using the `environment` property
+- Session recordings available for debugging user issues
+
+## Recent Fixes
+
+### Fix: PostHog Analytics Integration
+
+**Added:** PostHog Cloud integration for user behavior tracking
+
+**Changes:**
+- Created `posthog-api-key` secret in Secret Manager
+- Added PostHog environment variables to Cloud Run service
+- Implemented PostHog provider in Next.js app with automatic pageview tracking
+- All environments use the same PostHog project with environment tagging
+
+**Files modified:**
+- `terraform/cloud_run.tf` (added PostHog env vars)
+- `client/app/providers.tsx` (created PostHog provider)
+- `client/app/layout.tsx` (integrated provider)
+- `client/package.json` (added posthog-js dependency)
+
+### Fix: Vertex AI Claude Sonnet 4.5 Authentication
+
+**Problem:** Model ID format incorrect (`claude-sonnet-4-5-20250929`)
+
+**Fix:** Changed to `claude-sonnet-4-5@20250929` in `src/mastra/agents/web-automation-agent.ts:159`
+
+### Fix: VM Not Updating After Deployment
+
+**Problem:** Terraform updated metadata but VM didn't restart
+
+**Solution:** Metadata changes now trigger VM restart automatically
+
+### Fix: Switched to Application Default Credentials (ADC)
+
+**Problem:** Using JSON credentials file caused directory conflicts and wasn't clean
+
+**Changes:**
+- Removed credentials file handling from startup script
+- Added `roles/aiplatform.user` to VM service account
+- Removed `GOOGLE_APPLICATION_CREDENTIALS` environment variable
+- Kept `GOOGLE_CLOUD_PROJECT` for ADC to work
+
+**Files modified:**
+- `terraform/compute.tf` (removed vertex credentials secret, added IAM role)
+- `terraform/scripts/startup.sh` (removed credentials file creation)
+
+### Fix: Always Build All Docker Images
+
+**Problem:** Conditional builds caused "manifest not found" errors when only Terraform changed
+
+**Fix:** Removed `if` conditions from all build steps in `.github/workflows/deploy.yml:125-161`
+
+**Trade-off:** Longer build times (~5-10 min) but guaranteed image availability
+

--- a/terraform/ENV_MAPPING.md
+++ b/terraform/ENV_MAPPING.md
@@ -1,0 +1,96 @@
+# Environment Variable Mapping
+
+This document shows how environment variables from your local `.env` files map to the Terraform-managed Cloud Run deployment.
+
+## ✅ **Secret Manager Mapping**
+
+| Local Env Var | Secret Manager Name | Service |
+|---------------|-------------------|---------|
+| `OPENAI_API_KEY` | `openai-api-key` | Both |
+| `ANTHROPIC_API_KEY` | `anthropic-api-key` | Both |
+| `EXA_API_KEY` | `exa-api-key` | Both |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | `google-generative-ai-key` | Both |
+| `GROK_API_KEY` | `grok-api-key` | Mastra |
+| `XAI_API_KEY` | `xai-api-key` | Chatbot |
+| `DATABASE_URL` | `database-url-{env}` | Both |
+| `POSTGRES_URL` | `postgres-url` | Chatbot |
+| `MASTRA_JWT_SECRET` | `mastra-jwt-secret` | Mastra |
+| `MASTRA_APP_PASSWORD` | `mastra-app-password` | Mastra |
+| `MASTRA_JWT_TOKEN` | `mastra-jwt-token` | Both |
+| `AUTH_SECRET` | `auth-secret` | Chatbot |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `vertex-ai-credentials` | Both |
+| `APRICOT_API_BASE_URL` | `apricot-api-base-url` | Both |
+| `APRICOT_CLIENT_ID` | `apricot-client-id` | Both |
+| `APRICOT_CLIENT_SECRET` | `apricot-client-secret` | Both |
+
+## 🔧 **Computed Environment Variables**
+
+| Variable | Mastra Service | Chatbot Service |
+|----------|---------------|-----------------|
+| `PLAYWRIGHT_MCP_URL` | `http://{vm-internal-ip}:8931/mcp` | `http://{vm-internal-ip}:8931/mcp` |
+| `BROWSER_STREAMING_URL` | `ws://{vm-internal-ip}:8933` | `ws://{vm-internal-ip}:8933` |
+| `BROWSER_STREAMING_HOST` | - | `{vm-internal-ip}` |
+| `BROWSER_STREAMING_PORT` | - | `8933` |
+| `NEXT_PUBLIC_MASTRA_SERVER_URL` | - | `{mastra-cloud-run-url}` |
+| `GCS_BUCKET_NAME` | - | `labs-asp-artifacts-{env}` |
+| `NEXTAUTH_URL` | - | `https://{domain}` |
+
+## 📋 **Static Configuration**
+
+| Variable | Value | Service |
+|----------|-------|---------|
+| `NODE_ENV` | `production/development` | Both |
+| `ENVIRONMENT` | `dev/preview/prod` | Both |
+| `GCP_PROJECT_ID` | `nava-labs` | Both |
+| `GOOGLE_CLOUD_PROJECT` | `nava-labs` | Both |
+| `GOOGLE_VERTEX_PROJECT` | `nava-labs` | Both |
+| `GOOGLE_VERTEX_LOCATION` | `us-east5` | Both |
+| `CORS_ORIGINS` | `https://{domain}` or `*` | Mastra |
+
+## 🏗️ **Architecture Flow**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                Browser VM                               │
+│  - Playwright MCP Server (8931)                        │
+│  - Browser Streaming WebSocket (8933)                  │
+│  - Internal IP: {computed at runtime}                  │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│                Mastra Cloud Run                         │
+│  - Connects to Browser VM via internal IP              │
+│  - Serves /chat endpoint for web-automation-model      │
+│  - All AI API keys + Mastra authentication             │
+│  - URL: https://mastra-app-{env}-{project}.run.app     │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│               AI Chatbot Cloud Run                      │
+│  - Next.js frontend with conditional routing           │
+│  - Connects to Mastra service for web-automation       │
+│  - Connects to Browser VM for direct streaming         │
+│  - All AI API keys + auth + dual database access       │
+│  - URL: https://ai-chatbot-{env}-{project}.run.app     │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 🔐 **Security Notes**
+
+1. **All sensitive keys stored in Secret Manager** - no hardcoded secrets
+2. **Service accounts** with least-privilege access
+3. **Internal networking** between services via GCP internal IPs
+4. **Firewall rules** restrict browser VM access to internal ranges only
+5. **CORS configuration** environment-specific (prod = domain only, dev = wildcard)
+
+## 🚀 **Deployment Readiness**
+
+All environment variables from your existing `.env` files are now:
+- ✅ **Mapped to Secret Manager** (18 secrets already created)
+- ✅ **Configured in Terraform** for both services
+- ✅ **Computed dynamically** for networking between services
+- ✅ **Environment-specific** (dev/preview/prod support)
+
+The infrastructure is ready for deployment with your existing Secret Manager setup!

--- a/terraform/FIREWALL_CONFIG.md
+++ b/terraform/FIREWALL_CONFIG.md
@@ -1,0 +1,601 @@
+# Firewall Configuration Guide - Multiple Rules
+
+## Overview
+
+Application firewall rules are **automatically configured per environment and per service** via GitHub Actions workflow. This allows granular control where each service (Browser MCP, Browser Streaming, Mastra API) can have different access rules.
+
+## How It Works
+
+### Granular Firewall Variable
+
+The `firewall_rules` variable controls **ports, protocols, and access** per service:
+
+```hcl
+firewall_rules = {
+  browser_mcp = {
+    port                = number         # Configurable port!
+    allow_public_access = bool
+    allowed_ip_ranges   = list(string)
+  }
+  browser_streaming = {
+    port                = number         # Configurable port!
+    allow_public_access = bool
+    allowed_ip_ranges   = list(string)
+  }
+  mastra_api = {
+    port                = number         # Configurable port!
+    allow_public_access = bool
+    allowed_ip_ranges   = list(string)
+  }
+}
+```
+
+### Services Configuration
+
+| Service | Default Port | Description | Typical Access Pattern |
+|---------|--------------|-------------|------------------------|
+| **browser_mcp** | 8931 (configurable) | Playwright MCP automation | Office/Dev team only |
+| **browser_streaming** | 8933 (configurable) | WebSocket browser streaming | Broader access for demos |
+| **mastra_api** | 4112 (configurable) | AI agents API | Restricted to specific services |
+
+> **NEW**: Ports are now fully configurable! You can use custom ports per environment.
+
+## Configuration Examples
+
+### Example 0: Custom Ports!
+
+**NEW**: You can now use completely custom ports per environment:
+
+```json
+{
+  "browser_mcp": {
+    "port": 9931,                        // Custom port!
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  },
+  "browser_streaming": {
+    "port": 9933,                        // Custom port!
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  },
+  "mastra_api": {
+    "port": 5112,                        // Custom port!
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  }
+}
+```
+
+### Example 1: All Public with Default Ports (Dev/Preview)
+
+```json
+{
+  "browser_mcp": {
+    "port": 8931,
+    "allow_public_access": true,
+    "allowed_ip_ranges": ["0.0.0.0/0"]
+  },
+  "browser_streaming": {
+    "port": 8933,
+    "allow_public_access": true,
+    "allowed_ip_ranges": ["0.0.0.0/0"]
+  },
+  "mastra_api": {
+    "port": 4112,
+    "allow_public_access": true,
+    "allowed_ip_ranges": ["0.0.0.0/0"]
+  }
+}
+```
+
+### Example 2: Different Rules per Service (Production)
+
+```json
+{
+  "browser_mcp": {
+    "port": 8931,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]              // Office only
+  },
+  "browser_streaming": {
+    "port": 8933,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24", "198.51.100.0/24"]  // Office + VPN
+  },
+  "mastra_api": {
+    "port": 4112,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.50/32", "198.51.100.10/32"]  // Specific servers
+  }
+}
+```
+
+### Example 3: Mixed Access (Hybrid)
+
+```json
+{
+  "browser_mcp": {
+    "port": 8931,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]  // Restricted
+  },
+  "browser_streaming": {
+    "port": 8933,
+    "allow_public_access": true,             // Public for demos
+    "allowed_ip_ranges": ["0.0.0.0/0"]
+  },
+  "mastra_api": {
+    "port": 4112,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["198.51.100.0/24"]  // VPN only
+  }
+}
+```
+
+### Example 4: Ultra-Restricted Production
+
+```json
+{
+  "browser_mcp": {
+    "port": 8931,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.50/32"]  // Single admin IP
+  },
+  "browser_streaming": {
+    "port": 8933,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]   // Office network
+  },
+  "mastra_api": {
+    "port": 4112,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.100/32", "198.51.100.50/32"]  // 2 specific servers
+  }
+}
+```
+
+## Configuring in GitHub Actions
+
+Edit `.github/workflows/deploy.yml` in the "Set VPC CIDR blocks and Firewall rules" step:
+
+### Production Configuration Example
+
+```yaml
+prod)
+  # Production: 10.2.0.0/16
+  echo "vpc_cidr_public=10.2.0.0/20" >> $GITHUB_OUTPUT
+  echo "vpc_cidr_private=10.2.16.0/20" >> $GITHUB_OUTPUT
+  echo "vpc_cidr_db=10.2.32.0/20" >> $GITHUB_OUTPUT
+  echo "vpc_connector_cidr=10.2.48.0/28" >> $GITHUB_OUTPUT
+  
+  # Granular firewall rules per service with custom ports
+  cat >> $GITHUB_OUTPUT << 'EOF'
+firewall_rules={
+  "browser_mcp": {
+    "port": 8931,                          # Standard or custom port
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  },
+  "browser_streaming": {
+    "port": 8933,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24", "198.51.100.0/24"]
+  },
+  "mastra_api": {
+    "port": 4112,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.50/32"]
+  }
+}
+EOF
+  ;;
+```
+
+## Real-World Scenarios
+
+### Scenario 1: Development Team + External Partners
+
+**Requirements:**
+- Dev team needs full access to MCP
+- Partners need browser streaming for demos
+- API restricted to internal services
+
+```json
+{
+  "browser_mcp": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]  // Dev team office
+  },
+  "browser_streaming": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": [
+      "203.0.113.0/24",   // Dev team
+      "198.51.100.0/24",  // Partner A
+      "192.0.2.0/24"      // Partner B
+    ]
+  },
+  "mastra_api": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24", "10.50.0.0/16"]  // Office + Internal VPC
+  }
+}
+```
+
+### Scenario 2: Multi-Office Company
+
+**Requirements:**
+- 3 office locations
+- Remote VPN users
+- Cloud monitoring service
+
+```json
+{
+  "browser_mcp": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": [
+      "203.0.113.0/24",   // Office NY
+      "198.51.100.0/24",  // Office SF
+      "192.0.2.0/24"      // Office London
+    ]
+  },
+  "browser_streaming": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": [
+      "203.0.113.0/24",   // Office NY
+      "198.51.100.0/24",  // Office SF
+      "192.0.2.0/24",     // Office London
+      "198.18.0.0/24"     // VPN users
+    ]
+  },
+  "mastra_api": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": [
+      "203.0.113.0/24",   // Office NY
+      "198.51.100.0/24",  // Office SF
+      "192.0.2.0/24",     // Office London
+      "35.190.247.0/24"   // Cloud monitoring
+    ]
+  }
+}
+```
+
+### Scenario 3: Public Demo + Private Admin
+
+**Requirements:**
+- Browser streaming public for demos
+- MCP and API restricted to admins
+
+```json
+{
+  "browser_mcp": {
+    "port": 8931,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]  // Admin only
+  },
+  "browser_streaming": {
+    "port": 8933,
+    "allow_public_access": true,             // Public demos
+    "allowed_ip_ranges": ["0.0.0.0/0"]
+  },
+  "mastra_api": {
+    "port": 4112,
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]  // Admin only
+  }
+}
+```
+
+### Scenario 4: Custom Ports for Security
+
+**Requirements:**
+- Use non-standard ports for security through obscurity
+- Restrict all access to office network
+
+```json
+{
+  "browser_mcp": {
+    "port": 19931,                           // Custom high port
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  },
+  "browser_streaming": {
+    "port": 19933,                           // Custom high port
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  },
+  "mastra_api": {
+    "port": 15112,                           // Custom high port
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  }
+}
+```
+
+## Manual Terraform Configuration
+
+### Using terraform.tfvars
+
+Create `terraform/terraform.tfvars`:
+
+```hcl
+environment = "prod"
+
+# VPC Configuration
+vpc_cidr_public      = "10.2.0.0/20"
+vpc_cidr_private     = "10.2.16.0/20"
+vpc_cidr_db          = "10.2.32.0/20"
+vpc_connector_cidr   = "10.2.48.0/28"
+
+# Granular Firewall Rules
+firewall_rules = {
+  browser_mcp = {
+    allow_public_access = false
+    allowed_ip_ranges   = ["203.0.113.0/24"]
+  }
+  browser_streaming = {
+    allow_public_access = false
+    allowed_ip_ranges   = ["203.0.113.0/24", "198.51.100.0/24"]
+  }
+  mastra_api = {
+    allow_public_access = false
+    allowed_ip_ranges   = ["203.0.113.50/32"]
+  }
+}
+```
+
+Then apply:
+
+```bash
+cd terraform
+terraform apply
+```
+
+### Using CLI Variables
+
+```bash
+terraform apply \
+  -var="environment=prod" \
+  -var='firewall_rules={
+    "browser_mcp": {
+      "allow_public_access": false,
+      "allowed_ip_ranges": ["203.0.113.0/24"]
+    },
+    "browser_streaming": {
+      "allow_public_access": false,
+      "allowed_ip_ranges": ["203.0.113.0/24", "198.51.100.0/24"]
+    },
+    "mastra_api": {
+      "allow_public_access": false,
+      "allowed_ip_ranges": ["203.0.113.50/32"]
+    }
+  }'
+```
+
+## Testing Multiple Rules
+
+### Check All Firewall Rules
+
+```bash
+# List all firewall rules for environment
+gcloud compute firewall-rules list \
+  --filter="network:labs-asp-vpc-prod" \
+  --format="table(
+    name,
+    targetTags.list(),
+    allowed[].map().firewall_rule().list(),
+    sourceRanges.list()
+  )"
+```
+
+### Test Each Service
+
+```bash
+# Get VM IP
+VM_IP=$(gcloud compute instances describe app-vm-prod \
+  --zone=us-central1-a \
+  --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
+
+# Test Browser MCP (8931)
+curl --max-time 5 http://$VM_IP:8931/mcp
+
+# Test Browser Streaming (8933)
+curl --max-time 5 http://$VM_IP:8933
+
+# Test Mastra API (4112)
+curl --max-time 5 http://$VM_IP:4112/health
+```
+
+### Verify Specific Rule
+
+```bash
+# Check Browser MCP rule
+gcloud compute firewall-rules describe labs-asp-browser-mcp-prod \
+  --format="yaml(sourceRanges, allowed)"
+
+# Check Browser Streaming rule
+gcloud compute firewall-rules describe labs-asp-browser-streaming-prod \
+  --format="yaml(sourceRanges, allowed)"
+
+# Check Mastra API rule
+gcloud compute firewall-rules describe labs-asp-mastra-app-prod \
+  --format="yaml(sourceRanges, allowed)"
+```
+
+## Monitoring and Auditing
+
+### View Denied Connections by Service
+
+```bash
+# Browser MCP denies
+gcloud logging read \
+  'resource.type="gce_subnetwork"
+   AND jsonPayload.rule_details.reference="labs-asp-browser-mcp-prod"
+   AND jsonPayload.disposition="DENIED"' \
+  --limit=50 \
+  --format="table(timestamp, jsonPayload.connection.src_ip, jsonPayload.connection.dest_port)"
+
+# Browser Streaming denies
+gcloud logging read \
+  'resource.type="gce_subnetwork"
+   AND jsonPayload.rule_details.reference="labs-asp-browser-streaming-prod"
+   AND jsonPayload.disposition="DENIED"' \
+  --limit=50
+
+# Mastra API denies
+gcloud logging read \
+  'resource.type="gce_subnetwork"
+   AND jsonPayload.rule_details.reference="labs-asp-mastra-app-prod"
+   AND jsonPayload.disposition="DENIED"' \
+  --limit=50
+```
+
+### Identify Unauthorized Access Attempts
+
+```bash
+# Find IPs trying to access restricted services
+gcloud logging read \
+  'resource.type="gce_subnetwork"
+   AND jsonPayload.disposition="DENIED"
+   AND resource.labels.subnetwork_name=~"labs-asp-.*-prod"' \
+  --limit=200 \
+  --format="value(jsonPayload.connection.src_ip)" \
+  | sort | uniq -c | sort -rn
+```
+
+## Security Best Practices
+
+### Recommended Patterns
+
+1. **Least Privilege per Service**
+   ```json
+   // MCP: Dev team only (most restrictive)
+   "browser_mcp": { "allowed_ip_ranges": ["office_ip"] }
+   
+   // Streaming: Demos + partners (moderate)
+   "browser_streaming": { "allowed_ip_ranges": ["office_ip", "partner_ips"] }
+   
+   // API: Specific backend services (restrictive)
+   "mastra_api": { "allowed_ip_ranges": ["backend_server_ips"] }
+   ```
+
+2. **Use Network Ranges**
+   ```json
+   // Good: Network range
+   "allowed_ip_ranges": ["203.0.113.0/24"]
+   
+   // Less flexible: Individual IPs
+   "allowed_ip_ranges": ["203.0.113.1/32", "203.0.113.2/32", ...]
+   ```
+
+3. **Document Each Range**
+   ```yaml
+   # Office NY: 203.0.113.0/24
+   # Office SF: 198.51.100.0/24
+   # VPN users: 198.18.0.0/24
+   # Partner A: 192.0.2.0/24
+   ```
+
+4. **Regular Audits**
+   - Review rules quarterly
+   - Remove unused IP ranges
+   - Update based on denied connection logs
+
+### Anti-Patterns
+
+1. **All Services Public in Production**
+   ```json
+   // DON'T DO THIS IN PROD
+   "allow_public_access": true  // for all services
+   ```
+
+2. **Overly Broad Ranges**
+   ```json
+   // Too broad
+   "allowed_ip_ranges": ["0.0.0.0/0", "10.0.0.0/8"]
+   ```
+
+3. **Same Rules for All Services**
+   ```json
+   // Missing opportunity for granular control
+   // All services have identical rules
+   ```
+
+## Troubleshooting
+
+### Different Services Have Different Access
+
+**Symptom**: Can access port 8933 but not 4112
+
+**Cause**: Different firewall rules per service (by design)
+
+**Solution**: Check configuration for each service separately
+
+```bash
+# Compare rules
+gcloud compute firewall-rules describe labs-asp-browser-streaming-prod
+gcloud compute firewall-rules describe labs-asp-mastra-app-prod
+```
+
+### Rule Updates Not Applied
+
+**Symptom**: Changed rules in workflow but still blocked
+
+**Solution**:
+```bash
+cd terraform
+terraform refresh
+terraform apply
+```
+
+### Emergency Access Needed
+
+**Quick fix** (temporary):
+```bash
+# Add your IP to specific service
+gcloud compute firewall-rules update labs-asp-mastra-app-prod \
+  --source-ranges="EXISTING_RANGES,YOUR_IP/32"
+
+# Remember to update workflow after!
+```
+
+## Migration Guide
+
+### From Single Rule to Multiple Rules
+
+**Old format** (deprecated):
+```yaml
+echo "allow_public_access=false" >> $GITHUB_OUTPUT
+echo 'allowed_ip_ranges=["203.0.113.0/24"]' >> $GITHUB_OUTPUT
+```
+
+**New format**:
+```yaml
+cat >> $GITHUB_OUTPUT << 'EOF'
+firewall_rules={
+  "browser_mcp": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  },
+  "browser_streaming": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  },
+  "mastra_api": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]
+  }
+}
+EOF
+```
+
+### Backward Compatibility
+
+Old variables (`allow_public_access`, `allowed_ip_ranges`) are still supported but deprecated. They will apply the same rule to all services.
+
+## Support
+
+For questions or issues:
+1. Check [VPC_ARCHITECTURE.md](./VPC_ARCHITECTURE.md) for network details
+2. Review firewall logs per service
+3. Test each service individually
+4. Compare rules: `gcloud compute firewall-rules list --filter="network:labs-asp-vpc-prod"`

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,195 @@
+# Labs ASP - Client-Server Architecture Deployment
+
+This Terraform configuration deploys the Labs ASP application using a **client-server architecture** with:
+
+- **Browser Service**: Dedicated Compute Engine VM running Playwright automation
+- **Mastra Service**: Cloud Run service for AI agent backend
+- **AI Chatbot Service**: Cloud Run service for Next.js frontend
+
+## Architecture
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│   Browser VM    │    │  Mastra Cloud   │    │ Chatbot Cloud   │
+│                 │    │      Run        │    │      Run        │
+│ • Playwright    │◄───┤                 │◄───┤                 │
+│ • MCP Server    │    │ • AI Agents     │    │ • Next.js App   │
+│ • WebSocket     │    │ • Tool Calls    │    │ • Chat UI       │
+│                 │    │ • /chat Route   │    │ • Auth          │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+        │                       │                       │
+        │                       │                       │
+        └───────────────────────┼───────────────────────┘
+                                │
+                        ┌─────────────────┐
+                        │  Cloud SQL DB   │
+                        │   (existing)    │
+                        └─────────────────┘
+```
+
+## Benefits
+
+- **Separation of Concerns**: Browser automation isolated from application logic
+- **Independent Scaling**: Each service scales based on demand
+- **Cost Optimization**: Cloud Run scales to zero when not used
+- **Build Dependency Resolution**: Browser VM runs independently of build process
+- **Resource Optimization**: Right-sized compute for each component
+
+## Prerequisites
+
+1. **Existing Infrastructure** (reused):
+   - Cloud SQL databases (`nava-db-dev`, `nava-db-prod`)
+   - Secret Manager secrets for API keys
+   - Artifact Registry repository
+
+2. **Container Images** (build required):
+   - `browser-streaming:latest` - Playwright MCP container
+   - `mastra-app:latest` - Mastra backend with chatRoute
+   - `ai-chatbot:latest` - Next.js frontend with conditional routing
+
+## Deployment
+
+### Important: Build vs Deploy Separation
+
+**Terraform manages infrastructure, NOT Docker builds.** You must build and push Docker images before deploying.
+
+#### Why This Separation?
+
+- **Terraform** = Infrastructure as Code (VMs, Cloud Run, IAM, networking)
+- **Docker Builds** = Application packaging (done by CI/CD or locally)
+- Terraform references pre-built images from Artifact Registry
+
+### Development Deployment (Local Build)
+
+#### 1. Build and Push Docker Images
+
+**IMPORTANT:** Build fresh images before deploying to ensure latest code changes are included.
+
+```bash
+# Build order matters: browser-streaming first, then others in parallel
+
+# Step 1: Build and push browser-streaming
+docker build -f playwright-mcp/Dockerfile \
+  -t us-central1-docker.pkg.dev/nava-labs/labs-asp/browser-streaming:latest \
+  ./playwright-mcp
+docker push us-central1-docker.pkg.dev/nava-labs/labs-asp/browser-streaming:latest
+
+# Step 2: Build mastra-app and ai-chatbot (can run in parallel)
+docker build -f Dockerfile \
+  -t us-central1-docker.pkg.dev/nava-labs/labs-asp/mastra-app:latest .
+docker build -f Dockerfile.ai-chatbot \
+  -t us-central1-docker.pkg.dev/nava-labs/labs-asp/ai-chatbot:latest .
+
+# Step 3: Push both images (can run in parallel)
+docker push us-central1-docker.pkg.dev/nava-labs/labs-asp/mastra-app:latest
+docker push us-central1-docker.pkg.dev/nava-labs/labs-asp/ai-chatbot:latest
+```
+
+**Authentication:** If you get "Unauthenticated" errors:
+```bash
+gcloud auth configure-docker us-central1-docker.pkg.dev
+```
+
+#### 2. Configure Variables
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars if needed (defaults should work for dev)
+```
+
+#### 3. Initialize Terraform
+
+```bash
+terraform init
+```
+
+#### 4. Plan Deployment
+
+```bash
+terraform plan -var="environment=dev"
+```
+
+Review the plan to ensure:
+- Browser VM will be created
+- Both Cloud Run services will be created
+- Workload Identity Pool will be created (for GitHub Actions)
+
+#### 5. Deploy Infrastructure
+
+```bash
+terraform apply -var="environment=dev"
+```
+
+This will:
+- Create browser VM and pull `:latest` image
+- Deploy mastra-app Cloud Run service
+- Deploy ai-chatbot Cloud Run service
+- Configure networking and IAM
+
+### Production Deployment (GitHub Actions)
+
+For preview/prod environments, use the automated GitHub Actions workflow:
+
+1. **Push your branch to GitHub**
+   ```bash
+   git push origin feat/your-branch
+   ```
+
+2. **Create a Pull Request**
+   - GitHub Actions automatically builds images
+   - Deploys preview environment
+   - Posts preview URL in PR comment
+
+3. **Merge to deploy to prod**
+   - Merging to `main` triggers prod deployment
+   - Images are built and tagged with commit SHA
+   - Terraform applies infrastructure changes
+
+## Environment Variables
+
+The deployment expects these Secret Manager secrets to exist:
+- `database-url-{environment}` or `database-url-production`
+- `openai-api-key`
+- `anthropic-api-key`
+- `exa-api-key`
+- `mastra-jwt-secret`
+- `mastra-app-password`
+- `nextauth-secret`
+
+## Networking
+
+- **Browser VM**: Internal IP accessible to Cloud Run services
+- **Mastra Service**: Connects to Browser VM via internal IP
+- **Chatbot Service**: Connects to both Browser VM and Mastra Service
+- **Public Access**: Only Chatbot service exposed publicly
+
+## Service Endpoints
+
+After deployment, access services via:
+- **AI Chatbot**: `https://ai-chatbot-{env}-{project}.{region}.run.app`
+- **Mastra API**: `https://mastra-app-{env}-{project}.{region}.run.app/chat`
+- **Browser MCP**: Internal only - `http://{vm-internal-ip}:8931/mcp`
+
+## Build Dependencies
+
+This architecture resolves the Docker build dependency issue:
+
+1. **Browser VM** runs independently with pre-built image
+2. **Mastra Service** can build knowing Browser VM endpoint
+3. **Chatbot Service** can build knowing Mastra Service endpoint
+
+## Environment Support
+
+Deploy to different environments:
+```bash
+terraform apply -var="environment=dev"     # Development
+terraform apply -var="environment=preview" # Preview/Staging
+terraform apply -var="environment=prod"    # Production
+```
+
+Each environment gets:
+- Dedicated browser VM
+- Separate Cloud Run services
+- Isolated networking
+- Environment-specific secrets

--- a/terraform/README_DEPLOYMENT.md
+++ b/terraform/README_DEPLOYMENT.md
@@ -1,0 +1,15 @@
+# Infrastructure deployed - ready for GitHub Actions testing
+# Just the browser VM deployed - ready for GitHub Actions testing
+# Triggering the deploy.yml workflow will deploy the infrastructure and the browser VM
+Just trigger the deploy.yml workflow and it will deploy the infrastructure and the browser VM
+triggering the workflow manually will deploy the infrastructure and the browser VM
+
+# Testing PostHog integration with clean preview environment
+
+# Testing fresh preview state downstream of PR 135
+# Testing fresh preview state  for shared-link-json-format 
+# Testing empty commit for merging from develop
+# Testing empty commit for doubling vm size
+# Testing for dev build for bot re-trigger
+# Trigger build for redis
+# Redeploy for Redis endpoint

--- a/terraform/README_VPC.md
+++ b/terraform/README_VPC.md
@@ -1,0 +1,266 @@
+# VPC Configuration - Labs ASP
+
+## Summary of Changes
+
+The infrastructure now uses **dedicated and isolated VPCs per environment** with subnets following the standard pattern: **public**, **private**, and **database**.
+
+## Environments and CIDRs
+
+| Environment | VPC Base | Public Subnet | Private Subnet | DB Subnet | VPC Connector |
+|----------|----------|----------------|----------------|-----------|---------------|
+| **Dev** | 10.0.0.0/16 | 10.0.0.0/20 | 10.0.16.0/20 | 10.0.32.0/20 | 10.0.48.0/28 |
+| **Preview (HML)** | 10.1.0.0/16 | 10.1.0.0/20 | 10.1.16.0/20 | 10.1.32.0/20 | 10.1.48.0/28 |
+| **Prod** | 10.2.0.0/16 | 10.2.0.0/20 | 10.2.16.0/20 | 10.2.32.0/20 | 10.2.48.0/28 |
+
+> **Note**: Preview PRs (preview-pr-N) share the Preview/HML VPC environment
+
+## Modified Files
+
+### 1. **terraform/vpc.tf** (NEW)
+Creates the entire network infrastructure:
+- Dedicated VPC network per environment
+- 3 subnets (public, private, database)
+- Cloud NAT for private subnet internet access
+- VPC Access Connector for Cloud Run
+- Private Service Connection for Cloud SQL
+- Configurable firewall rules per environment
+
+### 2. **terraform/variables.tf**
+Added variables for VPC CIDRs and Granular Firewall:
+```hcl
+variable "vpc_cidr_public" {}
+variable "vpc_cidr_private" {}
+variable "vpc_cidr_db" {}
+variable "vpc_connector_cidr" {}
+variable "firewall_rules" {
+  # Separate rules for each service:
+  # - browser_mcp (port 8931)
+  # - browser_streaming (port 8933)
+  # - mastra_api (port 4112)
+}
+```
+
+### 3. **terraform/compute.tf**
+VM now uses the VPC public subnet:
+```hcl
+network_interface {
+  network    = google_compute_network.main.id
+  subnetwork = google_compute_subnetwork.public.id
+  # ...
+}
+```
+
+### 4. **terraform/cloud_run.tf**
+Cloud Run services connected to VPC via VPC Connector:
+```hcl
+vpc_access {
+  connector = google_vpc_access_connector.cloud_run.id
+  egress    = "PRIVATE_RANGES_ONLY"
+}
+```
+
+### 5. **terraform/main.tf**
+Enabled required APIs:
+- `vpcaccess.googleapis.com`
+- `servicenetworking.googleapis.com`
+
+### 6. **.github/workflows/deploy.yml**
+Added step to automatically define CIDRs and Firewall rules based on environment:
+```yaml
+- name: Set VPC CIDR blocks and Firewall rules
+  id: vpc_cidrs
+  run: |
+    case ${ENV} in
+      prod)
+        # Granular rules per service
+        firewall_rules={
+          "browser_mcp": {
+            "allow_public_access": false,
+            "allowed_ip_ranges": ["office_ip"]
+          },
+          "browser_streaming": {
+            "allow_public_access": false,
+            "allowed_ip_ranges": ["office_ip", "partner_ip"]
+          },
+          "mastra_api": {
+            "allow_public_access": false,
+            "allowed_ip_ranges": ["backend_server_ip"]
+          }
+        }
+    esac
+```
+
+### 7. **terraform/outputs.tf**
+Added VPC outputs:
+- `vpc_id`, `vpc_name`
+- `vpc_public_subnet`, `vpc_private_subnet`, `vpc_db_subnet`
+- `vpc_connector_cidr`
+
+### 8. **terraform/terraform.tfvars.example**
+Added VPC configuration examples
+
+## How to Use
+
+### Deploy via GitHub Actions (Recommended)
+
+CIDRs are **automatically** defined by the workflow based on the environment:
+
+```bash
+# Push to develop → deploy to Dev (10.0.0.0/16)
+git push origin develop
+
+# Push to main → deploy to Prod (10.2.0.0/16)
+git push origin main
+
+# PR → deploy to Preview-PR-N (10.1.0.0/16 shared)
+# Manual dispatch → choose environment
+```
+
+### Manual Deploy with Terraform
+
+```bash
+cd terraform
+
+# Dev
+terraform init -backend-config="prefix=terraform/state/dev"
+terraform apply \
+  -var="environment=dev" \
+  -var="vpc_cidr_public=10.0.0.0/20" \
+  -var="vpc_cidr_private=10.0.16.0/20" \
+  -var="vpc_cidr_db=10.0.32.0/20" \
+  -var="vpc_connector_cidr=10.0.48.0/28"
+
+# Preview (HML)
+terraform init -backend-config="prefix=terraform/state/preview"
+terraform apply \
+  -var="environment=preview" \
+  -var="vpc_cidr_public=10.1.0.0/20" \
+  -var="vpc_cidr_private=10.1.16.0/20" \
+  -var="vpc_cidr_db=10.1.32.0/20" \
+  -var="vpc_connector_cidr=10.1.48.0/28"
+
+# Prod
+terraform init -backend-config="prefix=terraform/state/prod"
+terraform apply \
+  -var="environment=prod" \
+  -var="vpc_cidr_public=10.2.0.0/20" \
+  -var="vpc_cidr_private=10.2.16.0/20" \
+  -var="vpc_cidr_db=10.2.32.0/20" \
+  -var="vpc_connector_cidr=10.2.48.0/28"
+```
+
+## Security
+
+### Isolation
+- Each environment has an isolated VPC (dev, preview, prod)
+- No direct communication between environments
+- Preview PRs share HML VPC
+
+### Private Access
+- Cloud SQL accessible only via private IP
+- Cloud Run connects via VPC Connector
+- Private Google Access enabled (access APIs without external IP)
+
+### Firewall
+- Internal traffic allowed only within VPC
+- SSH only via Identity-Aware Proxy (IAP)
+- Application ports restricted by tags
+- **Granular rules per service** (Browser MCP, Browser Streaming, Mastra API)
+- Each service can have different IP restrictions
+- Production can be ultra-restrictive per service
+
+### Monitoring
+- VPC Flow Logs enabled (5 sec interval)
+- Firewall logs for auditing
+- VPC Connector metrics in Cloud Monitoring
+
+## Communication Flow
+
+### Cloud Run → VM (Mastra API)
+```
+Cloud Run (ai-chatbot) 
+  → VPC Connector (10.X.48.0/28)
+  → VPC Network
+  → VM Public Subnet (10.X.0.0/20)
+  → Mastra API :4112
+```
+
+### Cloud Run → Cloud SQL
+```
+Cloud Run
+  → VPC Connector
+  → VPC Network
+  → Service Networking Peering
+  → Cloud SQL Private IP (10.X.32.0/20)
+```
+
+### Internet → Cloud Run → Browser
+```
+Internet
+  → Cloud Run Public URL
+  → Browser WS Proxy (Cloud Run)
+  → VPC Connector
+  → VM Browser Service :8933 (WebSocket)
+```
+
+## Complete Documentation
+
+For more details, see:
+- **[VPC_ARCHITECTURE.md](./VPC_ARCHITECTURE.md)** - Complete technical documentation
+- **[FIREWALL_CONFIG.md](./FIREWALL_CONFIG.md)** - Firewall configuration guide
+- **[terraform.tfvars.example](./terraform.tfvars.example)** - Configuration examples
+
+## Important Notes
+
+1. **VPC Connector**: Requires /28 (16 IPs) mandatory
+2. **Cloud SQL**: Requires Private Service Connection configured
+3. **First Deployment**: APIs may take 1-2 minutes to enable
+4. **Costs**: VPC Connector costs ~$15-30/month per environment (2-10 instances)
+5. **Production Firewall**: Update `firewall_rules` in workflow for prod environment to configure granular access per service (see [FIREWALL_CONFIG.md](./FIREWALL_CONFIG.md))
+
+## Troubleshooting
+
+### Cloud Run cannot access VM
+```bash
+# Check VPC Connector
+gcloud compute networks vpc-access connectors describe \
+  labs-asp-connector-{env} --region=us-central1
+
+# Check if it's READY
+```
+
+### Firewall blocking connections
+```bash
+# List all rules for environment
+gcloud compute firewall-rules list \
+  --filter="network:labs-asp-vpc-{env}"
+
+# Check specific service rule
+gcloud compute firewall-rules describe labs-asp-mastra-app-{env}
+
+# View firewall denied logs
+gcloud logging read 'jsonPayload.disposition="DENIED"' --limit=50
+```
+
+### VM without internet access
+```bash
+# Check Cloud NAT
+gcloud compute routers nats list \
+  --router=labs-asp-router-{env} \
+  --region=us-central1
+```
+
+## Next Steps
+
+1. Deploy to Dev to test VPC
+2. Validate Cloud Run → VM connectivity
+3. Verify Cloud SQL via private IP
+4. Deploy to Preview (HML)
+5. Deploy to Prod
+
+## Support
+
+For questions or issues:
+1. Consult [VPC_ARCHITECTURE.md](./VPC_ARCHITECTURE.md)
+2. Check logs in Cloud Logging
+3. Review firewall rules

--- a/terraform/SHARED_PREVIEW_VPC_SETUP.md
+++ b/terraform/SHARED_PREVIEW_VPC_SETUP.md
@@ -1,0 +1,577 @@
+# Shared Preview VPC Architecture
+
+## Overview
+
+This document explains the shared VPC architecture for preview environments, including automatic deployment, VPC peering, and infrastructure organization.
+
+## Architecture
+
+### Previous Architecture (Individual VPCs per Preview)
+
+```
+┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+│  Dev VPC     │    │ Preview-PR-1 │    │ Preview-PR-2 │
+│  10.0.0.0/16 │    │ 10.1.0.0/16  │    │ 10.2.0.0/16  │
+└──────────────┘    └──────────────┘    └──────────────┘
+       │                    │                   │
+       └────────────────────┴───────────────────┘
+        Dynamic VPC peering (created per PR)
+```
+
+**Problems:**
+- ❌ New VPC created for each PR (~2-3 minutes)
+- ❌ Dynamic peering setup/teardown required
+- ❌ Complex state management with gcloud commands
+- ❌ High costs (NAT gateway, VPC connector, etc. per preview)
+- ❌ Slower deployments
+
+### New Architecture (Shared Preview VPC)
+
+```
+┌──────────────────┐         ┌────────────────────────┐
+│   Dev VPC        │◄───────►│ Preview Shared VPC     │
+│   10.0.0.0/16    │ Peering │    10.1.0.0/16         │
+│                  │ (auto)  │                        │
+│ ├─ app-dev       │         │ ├─ Shared NAT Gateway  │
+│ ├─ Cloud SQL Dev │         │ ├─ Shared VPC Connector│
+│ └─ Subnets       │         │ └─ Subnets             │
+└──────────────────┘         └────────┬───────────────┘
+                                      │
+                         ┌────────────┴────────────┐
+                         │                         │
+                   ┌─────▼──────┐          ┌──────▼─────┐
+                   │ PR-1       │          │ PR-2       │
+                   │ ├─ VM      │          │ ├─ VM      │
+                   │ ├─ Cloud   │          │ ├─ Cloud   │
+                   │ │  Run     │          │ │  Run     │
+                   │ └─ Services│          │ └─ Services│
+                   └────────────┘          └────────────┘
+
+┌──────────────────┐
+│   Prod VPC       │  ← Completely isolated
+│   10.2.0.0/16    │
+│                  │
+│ ├─ app-prod      │
+│ ├─ Cloud SQL Prod│
+│ └─ Subnets       │
+└──────────────────┘
+```
+
+**Benefits:**
+- ✅ One VPC for all preview environments
+- ✅ Permanent VPC peering (no dynamic setup)
+- ✅ Automatic deployment via GitHub Actions
+- ✅ Faster preview deployments (~30 seconds faster)
+- ✅ Significant cost reduction (~$125/month per preview)
+- ✅ Simplified infrastructure management
+
+## How It Works
+
+### Automatic Deployment Flow
+
+#### 1. First Preview Deployment (e.g., PR #1)
+
+```mermaid
+graph TD
+    A[PR Created] --> B{Deploy Workflow Triggered}
+    B --> C[Detect: preview-pr-1]
+    C --> D{Check: Shared VPC exists?}
+    D -->|No| E[Create Shared Preview VPC]
+    E --> F[Create Preview→Dev Peering]
+    F --> G[Deploy Preview Resources]
+    D -->|Yes| G
+    G --> H[Preview Environment Ready]
+```
+
+**GitHub Actions Steps:**
+
+1. **Setup** - Authenticate with GCP
+2. **Deploy Shared VPC** (only if doesn't exist):
+   ```bash
+   cd terraform/shared-preview-vpc
+   terraform init
+   terraform apply -auto-approve
+   ```
+   - Creates `labs-asp-vpc-preview-shared`
+   - Creates `preview-shared-to-dev-peering`
+   - Creates `dev-to-preview-shared-peering`
+3. **Deploy Preview Resources**:
+   ```bash
+   cd terraform
+   terraform apply -var="environment=preview-pr-1"
+   ```
+   - VM and services deployed to shared VPC
+   - Uses existing VPC connector
+   - Connects to dev Cloud SQL via peering
+
+**Duration:** ~3-4 minutes (first time, includes VPC creation)
+
+#### 2. Subsequent Preview Deployments (e.g., PR #2, #3)
+
+```mermaid
+graph TD
+    A[PR Created] --> B{Deploy Workflow Triggered}
+    B --> C[Detect: preview-pr-N]
+    C --> D{Check: Shared VPC exists?}
+    D -->|Yes| E[Skip VPC Creation]
+    E --> F[Deploy Preview Resources]
+    F --> G[Preview Environment Ready]
+```
+
+**GitHub Actions Steps:**
+
+1. **Setup** - Authenticate with GCP
+2. **Deploy Shared VPC** - Checks and skips:
+   ```bash
+   if gcloud compute networks describe labs-asp-vpc-preview-shared; then
+     echo "✅ VPC exists, skipping..."
+   fi
+   ```
+3. **Deploy Preview Resources** - Same as before
+
+**Duration:** ~1-2 minutes (no VPC creation needed)
+
+#### 3. Dev Environment Deployment (Merge to develop)
+
+```mermaid
+graph TD
+    A[Merge to develop] --> B{Deploy Workflow Triggered}
+    B --> C[Detect: dev]
+    C --> D{Check: Shared Preview VPC exists?}
+    D -->|Yes| E[Ensure VPC Peering]
+    D -->|No| F[Skip Peering Setup]
+    E --> G[Deploy Dev Resources]
+    F --> G
+    G --> H[Dev Environment Ready]
+```
+
+**GitHub Actions Steps:**
+
+1. **Setup** - Authenticate with GCP
+2. **Establish VPC Peering**:
+   ```bash
+   if gcloud compute networks describe labs-asp-vpc-preview-shared; then
+     cd terraform/shared-preview-vpc
+     terraform apply -auto-approve  # Ensures peering is up-to-date
+   fi
+   ```
+3. **Deploy Dev Resources**
+
+**Purpose:** Ensures bidirectional peering is properly configured if it was created from the preview side first.
+
+### Where Everything Is Defined
+
+#### Infrastructure Code
+
+| Location | Purpose | Key Resources |
+|----------|---------|---------------|
+| `terraform/shared-preview-vpc/` | Shared VPC module | VPC, subnets, NAT, connector, peering |
+| `terraform/vpc.tf` | VPC routing logic | Data sources, conditionals, local values |
+| `terraform/cloud_sql.tf` | Database instances | Dev and Prod Cloud SQL |
+| `terraform/compute.tf` | Virtual machines | VM configuration using shared VPC |
+| `terraform/cloud_run.tf` | Cloud Run services | Services using shared VPC connector |
+
+#### GitHub Actions Workflows
+
+| File | Purpose | Triggers |
+|------|---------|----------|
+| `.github/workflows/deploy.yml` | Main deployment pipeline | Push to branches, PRs |
+
+**Key Sections in `deploy.yml`:**
+
+- **Lines 200-218**: Deploy Shared Preview VPC (for preview environments)
+- **Lines 228-247**: Establish VPC Peering (for dev environment)
+- **Lines 212-262**: Set VPC CIDR blocks
+- **Lines 292-323**: Terraform Plan
+- **Lines 325-328**: Terraform Apply
+
+#### Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `terraform/shared-preview-vpc/main.tf` | Terraform backend and providers |
+| `terraform/shared-preview-vpc/variables.tf` | VPC CIDR configurations |
+| `terraform/shared-preview-vpc/vpc.tf` | VPC resources and peering |
+| `terraform/shared-preview-vpc/outputs.tf` | VPC outputs (names, IDs, IPs) |
+
+## Detailed Configuration
+
+### Shared Preview VPC (10.1.0.0/16)
+
+**File:** `terraform/shared-preview-vpc/vpc.tf`
+
+```hcl
+# Main VPC
+resource "google_compute_network" "preview_shared" {
+  name = "labs-asp-vpc-preview-shared"
+  # ...
+}
+
+# Subnets
+- Public:  10.1.0.0/20   (4,096 IPs)
+- Private: 10.1.16.0/20  (4,096 IPs)
+- DB:      10.1.32.0/20  (4,096 IPs)
+- VPC Connector: 10.1.48.0/28 (16 IPs)
+
+# VPC Peering (Lines 161-188)
+resource "google_compute_network_peering" "preview_to_dev" {
+  name = "preview-shared-to-dev-peering"
+  network = google_compute_network.preview_shared.id
+  peer_network = data.google_compute_network.dev_vpc.id
+  # ...
+}
+
+resource "google_compute_network_peering" "dev_to_preview" {
+  name = "dev-to-preview-shared-peering"
+  network = data.google_compute_network.dev_vpc.id
+  peer_network = google_compute_network.preview_shared.id
+  # ...
+}
+```
+
+### VPC Routing Logic
+
+**File:** `terraform/vpc.tf`
+
+```hcl
+# Data sources for preview environments (Lines 10-52)
+data "google_compute_network" "preview_shared" {
+  count = startswith(var.environment, "preview-") ? 1 : 0
+  name = "labs-asp-vpc-preview-shared"
+}
+
+# Create VPC only for dev/prod (Lines 54-62)
+resource "google_compute_network" "main" {
+  count = startswith(var.environment, "preview-") ? 0 : 1
+  name = "labs-asp-vpc-${var.environment}"
+  # ...
+}
+
+# Local values for abstraction (Lines 64-99)
+locals {
+  vpc_network = startswith(var.environment, "preview-") ? 
+    data.google_compute_network.preview_shared[0] : 
+    google_compute_network.main[0]
+  
+  private_subnet = startswith(var.environment, "preview-") ?
+    data.google_compute_subnetwork.preview_private[0] :
+    google_compute_subnetwork.private[0]
+  # ...
+}
+```
+
+**How it works:**
+- For `preview-*` environments: Uses data sources to reference existing shared VPC
+- For `dev`/`prod`: Creates dedicated VPC resources
+- All other files reference `local.vpc_network` instead of direct resources
+
+### Database Access
+
+**File:** `terraform/cloud_sql.tf`
+
+```hcl
+# Dev Cloud SQL (Lines 9-110)
+resource "google_sql_database_instance" "dev" {
+  count = var.environment == "dev" ? 1 : 0
+  name = "app-dev"
+  
+  settings {
+    ip_configuration {
+      ipv4_enabled = false
+      private_network = local.vpc_network.id  # Uses Dev VPC
+    }
+  }
+}
+
+# Preview environments access dev database via VPC peering
+# No Cloud SQL instance created for preview
+```
+
+**Connection Flow:**
+```
+Preview VM/Cloud Run
+    ↓
+Shared VPC Connector (10.1.48.0/28)
+    ↓
+VPC Peering (preview ↔ dev)
+    ↓
+Dev VPC (10.0.0.0/16)
+    ↓
+Cloud SQL (app-dev, private IP)
+```
+
+## Network Capacity
+
+### IP Address Allocation
+
+**Shared Preview VPC:** 10.1.0.0/16 = **65,536 IPs**
+
+**Subnet Distribution:**
+- Public subnet: 4,096 IPs
+- Private subnet: 4,096 IPs (VMs deployed here)
+- Database subnet: 4,096 IPs
+- VPC Connector: 16 IPs
+- **Free space:** ~53,232 IPs
+
+**Per Preview Environment:**
+- 1 VM: ~1-2 IPs
+- Cloud Run services: 0 IPs (use shared connector)
+- Containers: 0 IPs (internal Docker network)
+
+**Capacity:** Can support **2,000+ concurrent preview environments**
+
+## Cost Analysis
+
+### Cost Savings per Preview Environment
+
+**Before (Individual VPCs):**
+- NAT Gateway: $45/month
+- VPC Connector: $73/month
+- Static IP: $7/month
+- **Total: $125/month per preview**
+
+**After (Shared VPC):**
+- NAT Gateway: $45/month (shared)
+- VPC Connector: $73/month (shared)
+- Static IP: $7/month (shared)
+- **Total: $125/month for ALL previews**
+
+**Savings with 5 concurrent previews:** ~**$500/month**  
+**Savings with 10 concurrent previews:** ~**$1,125/month**
+
+### Additional Benefits
+- Faster deployments: ~30 seconds saved per preview
+- Reduced API calls to GCP
+- Simplified state management
+
+## Deployment Guide
+
+### First Time Setup
+
+**No manual setup required!** The shared VPC is automatically created on the first preview deployment.
+
+### Manual Deployment (if needed)
+
+```bash
+# Deploy shared VPC manually
+cd terraform/shared-preview-vpc
+terraform init
+terraform plan
+terraform apply
+
+# Verify VPC creation
+gcloud compute networks describe labs-asp-vpc-preview-shared
+```
+
+### Verify VPC Peering
+
+```bash
+# Check preview → dev peering
+gcloud compute networks peerings list --network=labs-asp-vpc-preview-shared
+
+# Check dev → preview peering
+gcloud compute networks peerings list --network=labs-asp-vpc-dev
+
+# Expected output:
+# NAME: preview-shared-to-dev-peering
+# STATE: ACTIVE
+# NAME: dev-to-preview-shared-peering
+# STATE: ACTIVE
+```
+
+### Deploy Preview Environment
+
+```bash
+# Automatic via PR
+# Just create a PR - GitHub Actions handles everything
+
+# Or manual deployment
+cd terraform
+terraform init -backend-config="prefix=terraform/state/preview-pr-123"
+terraform apply -var="environment=preview-pr-123"
+```
+
+## Troubleshooting
+
+### Preview Deployment Fails: "VPC not found"
+
+**Cause:** Shared VPC doesn't exist yet and automatic creation failed.
+
+**Solution:**
+```bash
+# Check if VPC exists
+gcloud compute networks describe labs-asp-vpc-preview-shared
+
+# If not, create manually
+cd terraform/shared-preview-vpc
+terraform apply
+
+# Then retry preview deployment
+```
+
+### Preview Can't Connect to Dev Database
+
+**Cause:** VPC peering not established or not active.
+
+**Check Peering Status:**
+```bash
+gcloud compute networks peerings list --network=labs-asp-vpc-preview-shared
+gcloud compute networks peerings list --network=labs-asp-vpc-dev
+```
+
+**Both should show STATE: ACTIVE**
+
+**Fix:**
+```bash
+# Re-apply shared VPC to fix peering
+cd terraform/shared-preview-vpc
+terraform apply
+```
+
+### "Network already exists" Error
+
+**Cause:** VPC was created manually or outside Terraform.
+
+**Solution (Import):**
+```bash
+cd terraform/shared-preview-vpc
+terraform import google_compute_network.preview_shared labs-asp-vpc-preview-shared
+terraform import google_compute_subnetwork.public labs-asp-public-preview-shared
+# ... import other resources
+```
+
+### Preview Deployment is Slow
+
+**Possible Causes:**
+1. First deployment (VPC creation takes ~2 minutes)
+2. Image pulls taking time
+3. VM startup time
+
+**Check:**
+```bash
+# View GitHub Actions logs
+# Look for "Deploy Shared Preview VPC" step
+# If it shows "Creating shared preview VPC..." - this is expected for first PR
+# If it shows "VPC already exists, skipping" - VPC creation is not the issue
+```
+
+## Cleanup
+
+### Destroying a Preview Environment
+
+```bash
+# Automatic via PR close
+# GitHub Actions handles cleanup
+
+# Or manual
+cd terraform
+terraform destroy -var="environment=preview-pr-123"
+```
+
+**Note:** Only destroys preview resources (VM, services). Shared VPC remains.
+
+### Destroying Shared VPC
+
+⚠️ **Only destroy when NO preview environments are active!**
+
+```bash
+# Check for active preview VMs
+gcloud compute instances list --filter="name~preview"
+
+# If none, safe to destroy
+cd terraform/shared-preview-vpc
+terraform destroy
+```
+
+**This will:**
+- Remove VPC peering with dev
+- Delete shared VPC and all subnets
+- Delete NAT gateway and VPC connector
+- **All active preview environments will break!**
+
+## Migration from Old Architecture
+
+If you have existing preview environments with individual VPCs:
+
+### Step 1: Destroy Existing Previews
+
+```bash
+# List active previews
+gcloud compute instances list --filter="name~preview"
+
+# Destroy each one
+cd terraform
+terraform destroy -var="environment=preview-pr-N"
+```
+
+### Step 2: Deploy Shared VPC
+
+```bash
+cd terraform/shared-preview-vpc
+terraform apply
+```
+
+### Step 3: Redeploy Previews
+
+```bash
+# Rerun PR deployments - they'll automatically use shared VPC
+# Or trigger workflow_dispatch for each preview
+```
+
+## FAQ
+
+### Q: What happens if shared VPC is deleted while previews are active?
+
+**A:** Preview environments will lose connectivity. VMs and services will still run but won't be able to access dev database or external services.
+
+**Fix:** Redeploy shared VPC and restart preview services.
+
+### Q: Can I use a different CIDR for shared VPC?
+
+**A:** Yes, edit `terraform/shared-preview-vpc/variables.tf` before first deployment:
+
+```hcl
+variable "vpc_cidr_public" {
+  default = "10.1.0.0/20"  # Change this
+}
+```
+
+### Q: How do I update firewall rules for preview environments?
+
+**A:** Edit `terraform/shared-preview-vpc/vpc.tf` (Lines 190-250) and apply:
+
+```bash
+cd terraform/shared-preview-vpc
+terraform apply
+```
+
+Changes apply to all preview environments immediately.
+
+### Q: Can dev and prod VPCs peer with the preview VPC?
+
+**A:** Only dev VPC has peering with preview VPC (for database access). Prod VPC is **completely isolated** by design.
+
+### Q: What if I need more than 2,000 preview environments?
+
+**A:** Increase the shared VPC CIDR from `/16` to `/14` or `/12`:
+
+```hcl
+# terraform/shared-preview-vpc/vpc.tf
+# Change from 10.1.0.0/16 to 10.0.0.0/14
+# Provides 262,144 IPs instead of 65,536
+```
+
+## References
+
+- [Google Cloud VPC Documentation](https://cloud.google.com/vpc/docs)
+- [VPC Peering Best Practices](https://cloud.google.com/vpc/docs/vpc-peering)
+- [Cloud SQL Private IP](https://cloud.google.com/sql/docs/mysql/private-ip)
+- [Terraform Google Provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs)
+
+## Support
+
+For issues or questions:
+1. Check GitHub Actions logs for detailed error messages
+2. Review this documentation
+3. Check `terraform/shared-preview-vpc/README.md` for module details
+4. Contact the infrastructure team

--- a/terraform/VPC_ARCHITECTURE.md
+++ b/terraform/VPC_ARCHITECTURE.md
@@ -1,0 +1,344 @@
+# VPC Network Architecture
+
+## Overview
+
+The infrastructure uses dedicated and isolated VPCs per environment, following the subnet naming pattern: **public**, **private**, and **database**.
+
+## Network Architecture
+
+### Environments and CIDRs
+
+Each environment has its own VPC with /16 CIDR, subdivided into /20 subnets:
+
+| Environment | VPC Base | Public Subnet | Private Subnet | DB Subnet | VPC Connector |
+|----------|----------|----------------|----------------|-----------|---------------|
+| **Dev** | 10.0.0.0/16 | 10.0.0.0/20 | 10.0.16.0/20 | 10.0.32.0/20 | 10.0.48.0/28 |
+| **Preview (HML)** | 10.1.0.0/16 | 10.1.0.0/20 | 10.1.16.0/20 | 10.1.32.0/20 | 10.1.48.0/28 |
+| **Prod** | 10.2.0.0/16 | 10.2.0.0/20 | 10.2.16.0/20 | 10.2.32.0/20 | 10.2.48.0/28 |
+
+### Subnet Structure
+
+#### 1. Public Subnet (`10.X.0.0/20`)
+- **Resources**: VMs with external IP, Load Balancers, NAT Gateways
+- **Capacity**: ~4,096 IPs
+- **Current usage**: 
+  - Application VM (browser-streaming + mastra-app)
+  - External access via public IP
+- **Features**:
+  - Private Google Access enabled
+  - Secondary ranges for GKE (future)
+  - Flow logs enabled
+
+#### 2. Private Subnet (`10.X.16.0/20`)
+- **Resources**: Cloud Run (via VPC Connector), internal services
+- **Capacity**: ~4,096 IPs
+- **Current usage**:
+  - VPC Access Connector for Cloud Run
+  - Internal communication between services
+- **Features**:
+  - No direct internet access
+  - Access via Cloud NAT
+  - Private Google Access enabled
+
+#### 3. Database Subnet (`10.X.32.0/20`)
+- **Resources**: Cloud SQL, Redis, managed databases
+- **Capacity**: ~4,096 IPs
+- **Current usage**:
+  - Reserved for Cloud SQL Private IP
+  - Private Service Connection configured
+- **Features**:
+  - Isolated from direct access
+  - Private Google Access enabled
+  - VPC Peering with Google Service Networking
+
+#### 4. VPC Connector (`10.X.48.0/28`)
+- **Resources**: Serverless VPC Access Connector
+- **Capacity**: 16 IPs (fixed /28 size)
+- **Current usage**:
+  - Connects Cloud Run to VPC
+  - 2-10 instances (e2-micro)
+- **Features**:
+  - Bridge between Cloud Run and VPC
+  - Automatically scalable
+
+## Network Components
+
+### Cloud NAT
+- **Purpose**: Provides internet access for resources in private subnet
+- **Configuration**: 
+  - Automatic NAT IP
+  - Logs for errors only
+  - All subnets enabled
+
+### Cloud Router
+- **Purpose**: Manages dynamic routing for Cloud NAT
+- **ASN**: 64514 (private default)
+
+### VPC Peering
+- **Service Networking**: Connects VPC to Google Service Networking
+- **Usage**: Cloud SQL with private IP
+- **Reserved range**: Additional /16 for Google services
+
+## Firewall Rules
+
+### 1. Internal Traffic (`allow-internal`)
+- **Source**: All VPC subnets
+- **Destination**: All VPC subnets
+- **Protocols**: TCP, UDP, ICMP (all ports)
+- **Purpose**: Free communication between internal resources
+
+### 2. SSH via IAP (`allow-iap-ssh`)
+- **Source**: 35.235.240.0/20 (Identity-Aware Proxy)
+- **Destination**: All VMs
+- **Protocol**: TCP port 22
+- **Purpose**: Secure access via `gcloud compute ssh`
+
+### 3. Health Checks (`allow-health-checks`)
+- **Source**: 35.191.0.0/16, 130.211.0.0/22 (Google LB)
+- **Destination**: Resources with target tags
+- **Protocol**: TCP (all ports)
+- **Purpose**: Load Balancer health checks
+
+### 4. Application Ports
+
+#### Browser MCP (port 8931)
+- **Tags**: `browser-mcp`
+- **Source**: Internal VPC + Configurable external IPs
+- **Configuration**: Set via `allow_public_access` and `allowed_ip_ranges` variables
+- **Usage**: Playwright MCP server
+
+#### Browser Streaming (port 8933)
+- **Tags**: `browser-streaming`
+- **Source**: Internal VPC + Configurable external IPs
+- **Configuration**: Set via `allow_public_access` and `allowed_ip_ranges` variables
+- **Usage**: WebSocket streaming
+
+#### Mastra API (port 4112)
+- **Tags**: `mastra-app`
+- **Source**: Internal VPC + Configurable external IPs
+- **Configuration**: Set via `allow_public_access` and `allowed_ip_ranges` variables
+- **Usage**: AI agents API
+
+### Firewall Configuration by Environment
+
+Firewall rules are automatically configured **per service** based on environment:
+
+| Environment | Services | Configuration | Use Case |
+|-------------|----------|---------------|----------|
+| **Dev** | All | Public (0.0.0.0/0) | Development & testing |
+| **Preview** | All | Public (0.0.0.0/0) | Staging & demos |
+| **Prod** | Per-service | Granular restrictions | Production security |
+
+**Production Granular Configuration:**
+```json
+{
+  "browser_mcp": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24"]  // Office only
+  },
+  "browser_streaming": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.0/24", "198.51.100.0/24"]  // Office + VPN
+  },
+  "mastra_api": {
+    "allow_public_access": false,
+    "allowed_ip_ranges": ["203.0.113.50/32"]  // Specific server
+  }
+}
+```
+
+**See [FIREWALL_CONFIG.md](./FIREWALL_CONFIG.md) for comprehensive examples and scenarios.**
+
+## Communication Flow
+
+### Cloud Run → VM (Mastra API)
+```
+Cloud Run (ai-chatbot)
+  ↓
+VPC Connector (10.X.48.0/28)
+  ↓
+VPC Network (labs-asp-vpc-{env})
+  ↓
+VM in Public Subnet (10.X.0.0/20)
+  ↓
+Mastra API :4112
+```
+
+### Cloud Run → Cloud SQL
+```
+Cloud Run (ai-chatbot)
+  ↓
+VPC Connector (10.X.48.0/28)
+  ↓
+VPC Network
+  ↓
+Service Networking Peering
+  ↓
+Cloud SQL Private IP (10.X.32.0/20)
+```
+
+### Internet → Cloud Run → Browser
+```
+Internet
+  ↓
+Cloud Run Public URL
+  ↓
+Browser WS Proxy (Cloud Run)
+  ↓
+VPC Connector
+  ↓
+VM Browser Service :8933 (WebSocket)
+```
+
+## GitHub Actions Configuration
+
+The `.github/workflows/deploy.yml` workflow automatically defines CIDRs based on environment:
+
+```yaml
+- name: Set VPC CIDR blocks
+  id: vpc_cidrs
+  run: |
+    case ${ENV} in
+      dev)
+        echo "vpc_cidr_public=10.0.0.0/20"
+        echo "vpc_cidr_private=10.0.16.0/20"
+        echo "vpc_cidr_db=10.0.32.0/20"
+        echo "vpc_connector_cidr=10.0.48.0/28"
+        ;;
+      preview|preview-*)
+        echo "vpc_cidr_public=10.1.0.0/20"
+        echo "vpc_cidr_private=10.1.16.0/20"
+              echo "vpc_cidr_db=10.1.32.0/20"
+              echo "vpc_connector_cidr=10.1.48.0/28"
+              echo "allow_public_access=true"
+              ;;
+            prod)
+              echo "vpc_cidr_public=10.2.0.0/20"
+              echo "vpc_cidr_private=10.2.16.0/20"
+              echo "vpc_cidr_db=10.2.32.0/20"
+              echo "vpc_connector_cidr=10.2.48.0/28"
+              echo "allow_public_access=false"
+              echo 'allowed_ip_ranges=["office_ip", "vpn_ip"]'
+              ;;
+          esac
+```
+
+## Manual Deployment
+
+For manual deployment with Terraform:
+
+```bash
+cd terraform
+
+# Initialize Terraform
+terraform init -backend-config="prefix=terraform/state/dev"
+
+# Apply with specific CIDRs
+terraform apply \
+  -var="environment=dev" \
+  -var="vpc_cidr_public=10.0.0.0/20" \
+  -var="vpc_cidr_private=10.0.16.0/20" \
+  -var="vpc_cidr_db=10.0.32.0/20" \
+  -var="vpc_connector_cidr=10.0.48.0/28" \
+  -var="allow_public_access=true" \
+  -var='allowed_ip_ranges=["0.0.0.0/0"]'
+```
+
+## Security
+
+### Environment Isolation
+- Each environment has its own isolated VPC
+- No direct traffic between VPCs of different environments
+- Preview environments use shared VPC (10.1.0.0/16)
+
+### Private Google Access
+- Enabled on all subnets
+- Allows access to Google APIs without external IP
+- Reduces egress traffic cost
+
+### Flow Logs
+- Enabled on all subnets
+- Interval: 5 seconds
+- Full metadata for auditing
+
+### Least Privilege Principle
+- Firewalls restrict traffic by tags
+- Cloud SQL accessible only via private VPC
+- SSH only via Identity-Aware Proxy
+
+## Monitoring
+
+### VPC Flow Logs
+- **Location**: Cloud Logging
+- **Example query**:
+```
+resource.type="gce_subnetwork"
+resource.labels.subnetwork_name=~"labs-asp-.*"
+```
+
+### VPC Connector Metrics
+- **Location**: Cloud Monitoring
+- **Important metrics**:
+  - `connector.googleapis.com/connector/connections`
+  - `connector.googleapis.com/connector/sent_bytes_count`
+  - `connector.googleapis.com/connector/received_bytes_count`
+
+## Future Expansion
+
+### Subnet Expansion
+Each /20 subnet can be expanded within the environment's /16:
+- Public Subnet: up to 10.X.15.255
+- Private Subnet: up to 10.X.31.255
+- Database Subnet: up to 10.X.47.255
+
+### New Environments
+To add new environments:
+1. Choose new /16 CIDR (example: 10.3.0.0/16)
+2. Add mapping in workflow
+3. Update `variables.tf` with validation
+4. Deploy via GitHub Actions
+
+### Kubernetes (GKE)
+Secondary ranges already configured in public subnet:
+- **Pods**: `cidrsubnet(vpc_cidr_public, 4, 1)` → 10.X.1.0/24
+- **Services**: `cidrsubnet(vpc_cidr_public, 4, 2)` → 10.X.2.0/24
+
+## Troubleshooting
+
+### Cloud Run → VM Connectivity
+```bash
+# Check if VPC Connector is healthy
+gcloud compute networks vpc-access connectors describe \
+  labs-asp-connector-{env} \
+  --region=us-central1
+
+# Test connectivity
+gcloud compute ssh app-vm-{env} --zone=us-central1-a \
+  --tunnel-through-iap \
+  -- curl http://localhost:4112/health
+```
+
+### Firewall Blocking Traffic
+```bash
+# List firewall rules
+gcloud compute firewall-rules list \
+  --filter="network:labs-asp-vpc-{env}"
+
+# Check firewall logs
+gcloud logging read 'resource.type="gce_subnetwork" 
+  AND logName:"/logs/compute.googleapis.com/firewall"' \
+  --limit=50 \
+  --format=json
+```
+
+### VPC Peering Issues
+```bash
+# Check peering status
+gcloud services vpc-peerings list \
+  --network=labs-asp-vpc-{env}
+
+# List reserved ranges
+gcloud compute addresses list \
+  --filter="purpose:VPC_PEERING" \
+  --global
+```

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -1,0 +1,502 @@
+# Cloud Run Services
+# Note: mastra-app now runs on VM, only ai-chatbot frontend runs on Cloud Run
+
+# AI Chatbot Service - Next.js Frontend
+resource "google_cloud_run_v2_service" "ai_chatbot" {
+  name     = local.env_config.chatbot_service_name
+  location = local.region
+
+  # Disable deletion protection for preview environments to allow easy cleanup
+  deletion_protection = startswith(var.environment, "preview-") ? false : true
+
+  template {
+    service_account = google_service_account.cloud_run.email
+
+    # VPC Access - Connect to VPC network
+    vpc_access {
+      connector = local.vpc_connector.id
+      egress    = "ALL_TRAFFIC"  # Route all traffic through VPC/Cloud NAT for static IP
+    }
+
+    containers {
+      image = var.chatbot_image_url
+
+      # Resource configuration for Next.js app
+      resources {
+        limits = {
+          cpu    = var.chatbot_cpu
+          memory = var.chatbot_memory
+        }
+      }
+
+      # Database (Cloud SQL PostgreSQL)
+      # - dev: uses private IP within dev VPC
+      # - preview: uses PSC endpoint to reach dev DB from preview VPC
+      # - prod: uses private IP within prod VPC
+      env {
+        name = "DATABASE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = var.environment == "prod" ? "database-url-production" : (startswith(var.environment, "preview") ? "database-url-preview" : "database-url-dev")
+            version = "latest"
+          }
+        }
+      }
+
+      # AI API Keys
+      env {
+        name = "OPENAI_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "openai-api-key"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "ANTHROPIC_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "anthropic-api-key"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "EXA_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "exa-api-key"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "GOOGLE_GENERATIVE_AI_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "google-generative-ai-key"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "XAI_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "xai-api-key"
+            version = "latest"
+          }
+        }
+      }
+
+      # Apricot API Configuration
+      # Prod uses /api/ endpoint with prod credentials, all others use /sandbox/ with sandbox credentials
+      env {
+        name = "APRICOT_API_BASE_URL"
+        value = "https://f5r-api.iws.sidekick.solutions/apricot"
+      }
+
+      env {
+        name = "APRICOT_CLIENT_ID"
+        value_source {
+          secret_key_ref {
+            secret  = var.environment == "prod" ? "apricot-client-id-prod" : "apricot-client-id-sandbox"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "APRICOT_CLIENT_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = var.environment == "prod" ? "apricot-client-secret-prod" : "apricot-client-secret-sandbox"
+            version = "latest"
+          }
+        }
+      }
+
+      # PostHog Analytics
+      env {
+        name = "NEXT_PUBLIC_POSTHOG_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "posthog-api-key"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "NEXT_PUBLIC_POSTHOG_HOST"
+        value = "https://us.i.posthog.com"
+      }
+
+      # Next.js Auth configuration
+      # Preview envs: NEXTAUTH_URL not set, code falls back to x-forwarded-host header
+      dynamic "env" {
+        for_each = startswith(var.environment, "preview-") ? [] : [1]
+        content {
+          name  = "NEXTAUTH_URL"
+          value = var.environment == "prod" ? "https://${var.domain_name}" : "https://${local.env_config.domain_prefix}.${var.domain_name}"
+        }
+      }
+
+      env {
+        name = "AUTH_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = "auth-secret"
+            version = "latest"
+          }
+        }
+      }
+
+      # Google OAuth configuration
+      env {
+        name = "GOOGLE_CLIENT_ID"
+        value_source {
+          secret_key_ref {
+            secret  = "google-oauth-client-id"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "GOOGLE_CLIENT_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = "google-oauth-client-secret"
+            version = "latest"
+          }
+        }
+      }
+
+      # Microsoft Entra ID OAuth configuration
+      env {
+        name = "AUTH_MICROSOFT_ENTRA_ID_ID"
+        value_source {
+          secret_key_ref {
+            secret  = "microsoft-entra-id-client-id"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "AUTH_MICROSOFT_ENTRA_ID_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = "microsoft-entra-id-client-secret"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "AUTH_MICROSOFT_ENTRA_ID_ISSUER"
+        value_source {
+          secret_key_ref {
+            secret  = "microsoft-entra-id-issuer"
+            version = "latest"
+          }
+        }
+      }
+
+      # Google Cloud configuration
+      env {
+        name  = "GOOGLE_APPLICATION_CREDENTIALS"
+        value = "/secrets/vertex/vertex-ai-credentials.json"
+      }
+
+      env {
+        name  = "GOOGLE_VERTEX_LOCATION"
+        value = "global"
+      }
+
+      env {
+        name  = "GOOGLE_VERTEX_PROJECT"
+        value = local.project_id
+      }
+
+      env {
+        name  = "GOOGLE_CLOUD_PROJECT"
+        value = local.project_id
+      }
+
+      # Google Cloud Storage
+      env {
+        name  = "GCS_BUCKET_NAME"
+        value = local.storage_bucket_name
+      }
+
+      # Upstash Redis for shared links
+      env {
+        name = "UPSTASH_REDIS_REST_URL"
+        value_source {
+          secret_key_ref {
+            secret  = var.environment == "prod" ? "upstash-redis-rest-url-prod" : "upstash-redis-rest-url-dev"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "UPSTASH_REDIS_REST_TOKEN"
+        value_source {
+          secret_key_ref {
+            secret  = var.environment == "prod" ? "upstash-redis-rest-token-prod" : "upstash-redis-rest-token-dev"
+            version = "latest"
+          }
+        }
+      }
+
+      # Allowed email domains for OAuth sign-in (comma-separated)
+      env {
+        name = "ALLOWED_EMAIL_DOMAINS"
+        value_source {
+          secret_key_ref {
+            secret  = "allowed-email-domains"
+            version = "latest"
+          }
+        }
+      }
+
+      # Cloudflare Verified Bots - Ed25519 private key for signing key directory
+      env {
+        name = "CLOUDFLARE_BOT_PRIVATE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "cloudflare-bot-private-key"
+            version = "latest"
+          }
+        }
+      }
+
+      # Feature flag for guest login (bypasses OAuth in preview environments)
+      env {
+        name  = "USE_GUEST_LOGIN"
+        value = var.use_guest_login
+      }
+
+      env {
+        name  = "NEXT_PUBLIC_USE_GUEST_LOGIN"
+        value = var.use_guest_login
+      }
+
+      # Kernel.sh API key for remote browser management
+      env {
+        name = "KERNEL_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "kernel-api-key"
+            version = "latest"
+          }
+        }
+      }
+
+      # Runtime configuration
+      env {
+        name  = "NODE_ENV"
+        value = var.environment == "prod" ? "production" : "development"
+      }
+
+      env {
+        name  = "ENVIRONMENT"
+        value = var.environment
+      }
+
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = local.project_id
+      }
+
+      env {
+        name  = "CLOUD_SQL_INSTANCE"
+        value = var.environment == "prod" ? "nava-labs:us-central1:nava-db-prod" : "nava-labs:us-central1:nava-db-dev"
+      }
+
+      # Port configuration - Next.js port
+      ports {
+        container_port = 3000
+      }
+
+      # Volume mount for Cloud SQL proxy
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      # Volume mount for Vertex AI credentials file
+      volume_mounts {
+        name       = "vertex-credentials"
+        mount_path = "/secrets/vertex"
+      }
+
+    }
+
+    # Scaling configuration
+    scaling {
+      min_instance_count = var.chatbot_min_instances
+      max_instance_count = var.chatbot_max_instances
+    }
+
+    # Pin each user to the same instance so in-memory BrowserManager
+    # CDP connections persist across tool calls
+    session_affinity = true
+
+    # Standard timeout for web requests
+    timeout = "${var.chatbot_timeout}s"
+
+    # Cloud SQL connection for database access
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [var.environment == "prod" ? "nava-labs:us-central1:nava-db-prod" : "nava-labs:us-central1:nava-db-dev"]
+      }
+    }
+
+    # Vertex AI credentials file (mounted from Secret Manager)
+    volumes {
+      name = "vertex-credentials"
+      secret {
+        secret = "vertex-ai-credentials"
+        items {
+          version = "latest"
+          path    = "vertex-ai-credentials.json"
+        }
+      }
+    }
+  }
+
+  # Traffic configuration
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  labels = merge(local.common_labels, {
+    environment = var.environment
+    component   = "chatbot-frontend"
+  })
+
+  depends_on = [
+    google_project_service.required_apis,
+    google_service_account.cloud_run,
+    google_vpc_access_connector.cloud_run,
+    # Wait for database URL secrets to be created before starting Cloud Run
+    # This ensures the DATABASE_URL env var can be resolved on startup
+    google_secret_manager_secret_version.database_url_dev,
+    google_secret_manager_secret_version.database_url_preview,
+    google_secret_manager_secret_version.database_url_prod
+  ]
+}
+
+# Drop legacy proxy service from state without destroying
+# (deletion_protection=true blocks terraform destroy; service is no longer used)
+removed {
+  from = google_cloud_run_v2_service.browser_ws_proxy
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = google_cloud_run_v2_service_iam_member.browser_ws_proxy_public_access
+  lifecycle {
+    destroy = false
+  }
+}
+
+# IAM policies for public access
+resource "google_cloud_run_v2_service_iam_member" "chatbot_public_access" {
+  name     = google_cloud_run_v2_service.ai_chatbot.name
+  location = google_cloud_run_v2_service.ai_chatbot.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# Service account for Cloud Run services
+resource "google_service_account" "cloud_run" {
+  account_id   = "cloud-run-${var.environment}"
+  display_name = "Cloud Run Service Account (${var.environment})"
+  description  = "Service account for Cloud Run services in ${var.environment} environment"
+
+  # Force recreation to fix deleted service account issues
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# IAM bindings for Cloud Run service account
+resource "google_project_iam_member" "cloud_run_sql" {
+  project = local.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+
+  # Recreate when service account changes
+  lifecycle {
+    replace_triggered_by = [google_service_account.cloud_run]
+  }
+}
+
+resource "google_project_iam_member" "cloud_run_storage" {
+  project = local.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+
+  # Recreate when service account changes
+  lifecycle {
+    replace_triggered_by = [google_service_account.cloud_run]
+  }
+}
+
+resource "google_project_iam_member" "cloud_run_secrets" {
+  project = local.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+
+  # Recreate when service account changes
+  lifecycle {
+    replace_triggered_by = [google_service_account.cloud_run]
+  }
+}
+
+resource "google_project_iam_member" "cloud_run_logging" {
+  project = local.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+
+  # Recreate when service account changes
+  lifecycle {
+    replace_triggered_by = [google_service_account.cloud_run]
+  }
+}
+
+resource "google_project_iam_member" "cloud_run_monitoring" {
+  project = local.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+
+  # Recreate when service account changes
+  lifecycle {
+    replace_triggered_by = [google_service_account.cloud_run]
+  }
+}
+
+resource "google_project_iam_member" "cloud_run_vertex_ai" {
+  project = local.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+
+  # Recreate when service account changes
+  lifecycle {
+    replace_triggered_by = [google_service_account.cloud_run]
+  }
+}

--- a/terraform/cloud_sql.tf
+++ b/terraform/cloud_sql.tf
@@ -1,0 +1,339 @@
+# Cloud SQL Database Configuration
+# 
+# Strategy:
+# - Dev: Creates and manages nava-db-dev Cloud SQL instance
+# - Preview: Does NOT create database, uses VPC peering to connect to dev database
+# - Prod: Creates and manages nava-db-prod Cloud SQL instance (completely isolated from dev/preview)
+
+# Cloud SQL Instance for DEV environment
+resource "google_sql_database_instance" "dev" {
+  count            = var.environment == "dev" ? 1 : 0
+  name             = "nava-db-dev"
+  database_version = "POSTGRES_15"
+  region           = local.region
+
+  settings {
+    tier                        = "db-custom-2-3840"  # Dev: 2 vCPUs, 3.75GB RAM
+    availability_type           = "ZONAL"
+    deletion_protection_enabled = false  # Allow deletion for dev environment
+
+    # Storage configuration
+    disk_type       = "PD_SSD"
+    disk_size       = 100  # 50GB storage for dev
+    disk_autoresize = true  # Enable autoresize
+
+    # Backup configuration
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "03:00"
+      point_in_time_recovery_enabled = true
+      transaction_log_retention_days = 7
+      backup_retention_settings {
+        retained_backups = 7
+        retention_unit   = "COUNT"
+      }
+    }
+
+    # IP configuration - Private IP via VPC peering + PSC for preview environments
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = local.vpc_network.id
+      enable_private_path_for_google_cloud_services = true
+      
+      # Enable Private Service Connect for preview environments
+      # PSC allows the preview VPC (labs-asp-vpc-preview-shared) to create endpoints
+      psc_config {
+        psc_enabled               = true
+        allowed_consumer_projects = [local.project_id]
+        
+        # Auto-create PSC endpoint for preview shared VPC
+        psc_auto_connections {
+          consumer_network            = "projects/${local.project_id}/global/networks/labs-asp-vpc-preview-shared"
+          consumer_service_project_id = local.project_id
+        }
+      }
+    }
+
+    # Database flags
+    database_flags {
+      name  = "max_connections"
+      value = "100"  # Appropriate for dev tier
+    }
+  }
+
+  depends_on = [
+    google_service_networking_connection.private_vpc_connection,
+    google_compute_network.main
+  ]
+
+  deletion_protection = false
+}
+
+# Cloud SQL Database for DEV
+resource "google_sql_database" "dev" {
+  count    = var.environment == "dev" ? 1 : 0
+  name     = "app_db"
+  instance = google_sql_database_instance.dev[0].name
+}
+
+# Generate random password for DEV database
+resource "random_password" "dev_password" {
+  count   = var.environment == "dev" ? 1 : 0
+  length  = 32
+  special = true
+  upper   = true
+  lower   = true
+  numeric = true
+}
+
+# Create secret in Secret Manager for DEV database password
+resource "google_secret_manager_secret" "database_password_dev" {
+  count     = var.environment == "dev" ? 1 : 0
+  secret_id = "nava-db-password-dev"
+  project   = local.project_id
+
+  replication {
+    user_managed {
+      replicas {
+        location = local.region
+      }
+    }
+  }
+
+  labels = merge(local.common_labels, {
+    environment = "dev"
+    purpose     = "database-password"
+  })
+}
+
+# Store password in Secret Manager
+resource "google_secret_manager_secret_version" "database_password_dev" {
+  count       = var.environment == "dev" ? 1 : 0
+  secret      = google_secret_manager_secret.database_password_dev[0].id
+  secret_data = random_password.dev_password[0].result
+}
+
+# Cloud SQL User for DEV
+resource "google_sql_user" "dev" {
+  count    = var.environment == "dev" ? 1 : 0
+  name     = "app_user"
+  instance = google_sql_database_instance.dev[0].name
+  password = random_password.dev_password[0].result
+  type     = "BUILT_IN"
+}
+
+# =============================================================================
+# DATABASE_URL Secrets for DEV environment
+# =============================================================================
+
+# DATABASE_URL for dev environment (uses private IP within dev VPC)
+resource "google_secret_manager_secret" "database_url_dev" {
+  count     = var.environment == "dev" ? 1 : 0
+  secret_id = "database-url-dev"
+  project   = local.project_id
+
+  replication {
+    user_managed {
+      replicas {
+        location = local.region
+      }
+    }
+  }
+
+  labels = merge(local.common_labels, {
+    environment = "dev"
+    purpose     = "database-url"
+  })
+}
+
+resource "google_secret_manager_secret_version" "database_url_dev" {
+  count       = var.environment == "dev" ? 1 : 0
+  secret      = google_secret_manager_secret.database_url_dev[0].id
+  secret_data = "postgresql://app_user:${urlencode(random_password.dev_password[0].result)}@${google_sql_database_instance.dev[0].private_ip_address}:5432/app_db"
+
+  depends_on = [google_sql_user.dev]
+}
+
+# =============================================================================
+# DATABASE_URL for preview environments
+# =============================================================================
+# Preview environments use PSC (Private Service Connect) to access dev DB
+# 
+# With provider 7.0+ (PR #24201), psc_auto_connections now exposes ip_address attribute
+# Structure: settings[0].ip_configuration[0].psc_config[0].psc_auto_connections[0].ip_address
+# 
+# Example from gcloud CLI:
+#   pscAutoConnections:
+#     - ipAddress: 10.1.16.11
+#       status: ACTIVE
+#       consumerNetworkStatus: VALID
+
+resource "google_secret_manager_secret" "database_url_preview" {
+  count     = var.environment == "dev" ? 1 : 0
+  secret_id = "database-url-preview"
+  project   = local.project_id
+
+  replication {
+    user_managed {
+      replicas {
+        location = local.region
+      }
+    }
+  }
+
+  labels = merge(local.common_labels, {
+    environment = "preview"
+    purpose     = "database-url"
+  })
+}
+
+# Use PSC endpoint IP from psc_auto_connections
+# This IP (e.g., 10.1.16.11) is in the preview VPC and routes to dev Cloud SQL
+resource "google_secret_manager_secret_version" "database_url_preview" {
+  count       = var.environment == "dev" ? 1 : 0
+  secret      = google_secret_manager_secret.database_url_preview[0].id
+  # Access the PSC connection IP using ip_address attribute (available in provider 7.0+)
+  # Note: psc_config and psc_auto_connections are sets, not lists - use one() to extract the single element
+  secret_data = "postgresql://app_user:${urlencode(random_password.dev_password[0].result)}@${one(one(google_sql_database_instance.dev[0].settings[0].ip_configuration[0].psc_config).psc_auto_connections).ip_address}:5432/app_db"
+
+  depends_on = [google_sql_user.dev]
+}
+
+# Cloud SQL Instance for PROD environment (completely isolated)
+resource "google_sql_database_instance" "prod" {
+  count            = var.environment == "prod" ? 1 : 0
+  name             = "nava-db-prod"
+  database_version = "POSTGRES_15"
+  region           = local.region
+
+  settings {
+    tier                        = "db-custom-4-7680"  # Prod: 4 vCPUs, 7.5GB RAM
+    availability_type           = "REGIONAL" # Prod: Regional availability
+    deletion_protection_enabled = true  # Protect production database
+
+    # Storage configuration
+    disk_type       = "PD_SSD"
+    disk_size       = 100  # 100GB storage for prod
+    disk_autoresize = true  # Enable autoresize
+
+    # Backup configuration
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "03:00"
+      point_in_time_recovery_enabled = true
+      transaction_log_retention_days = 7
+      backup_retention_settings {
+        retained_backups = 7
+        retention_unit   = "COUNT"
+      }
+    }
+
+    # IP configuration - Private IP only via VPC peering
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = local.vpc_network.id
+      enable_private_path_for_google_cloud_services = true
+    }
+
+    # Database flags
+    database_flags {
+      name  = "max_connections"
+      value = "200"  # Higher for production tier
+    }
+  }
+
+  depends_on = [
+    google_service_networking_connection.private_vpc_connection,
+    google_compute_network.main
+  ]
+
+  deletion_protection = true  # Critical: Protect production database
+}
+
+# Cloud SQL Database for PROD
+resource "google_sql_database" "prod" {
+  count    = var.environment == "prod" ? 1 : 0
+  name     = "app_db"
+  instance = google_sql_database_instance.prod[0].name
+}
+
+# Generate random password for PROD database
+resource "random_password" "prod_password" {
+  count   = var.environment == "prod" ? 1 : 0
+  length  = 32
+  special = true
+  upper   = true
+  lower   = true
+  numeric = true
+}
+
+# Create secret in Secret Manager for PROD database password
+resource "google_secret_manager_secret" "database_password_prod" {
+  count     = var.environment == "prod" ? 1 : 0
+  secret_id = "nava-db-password-prod"
+  project   = local.project_id
+
+  replication {
+    user_managed {
+      replicas {
+        location = local.region
+      }
+    }
+  }
+
+  labels = merge(local.common_labels, {
+    environment = "prod"
+    purpose     = "database-password"
+  })
+}
+
+# Store password in Secret Manager
+resource "google_secret_manager_secret_version" "database_password_prod" {
+  count       = var.environment == "prod" ? 1 : 0
+  secret      = google_secret_manager_secret.database_password_prod[0].id
+  secret_data = random_password.prod_password[0].result
+}
+
+# Cloud SQL User for PROD
+resource "google_sql_user" "prod" {
+  count    = var.environment == "prod" ? 1 : 0
+  name     = "app_user"
+  instance = google_sql_database_instance.prod[0].name
+  password = random_password.prod_password[0].result
+  type     = "BUILT_IN"
+}
+
+# =============================================================================
+# DATABASE_URL Secret for PROD environment
+# =============================================================================
+
+resource "google_secret_manager_secret" "database_url_prod" {
+  count     = var.environment == "prod" ? 1 : 0
+  secret_id = "database-url-production"
+  project   = local.project_id
+
+  replication {
+    user_managed {
+      replicas {
+        location = local.region
+      }
+    }
+  }
+
+  labels = merge(local.common_labels, {
+    environment = "prod"
+    purpose     = "database-url"
+  })
+}
+
+resource "google_secret_manager_secret_version" "database_url_prod" {
+  count       = var.environment == "prod" ? 1 : 0
+  secret      = google_secret_manager_secret.database_url_prod[0].id
+  secret_data = "postgresql://app_user:${urlencode(random_password.prod_password[0].result)}@${google_sql_database_instance.prod[0].private_ip_address}:5432/app_db"
+
+  depends_on = [google_sql_user.prod]
+}
+
+# Note: VPC Peering configuration has been moved to vpc.tf for better organization
+# See vpc.tf for preview-to-dev and dev-to-preview peering resources
+

--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -1,0 +1,229 @@
+# Secret data sources for VM startup script
+# - dev: uses private IP within dev VPC
+# - preview: uses PSC endpoint to reach dev DB from preview VPC
+# - prod: uses private IP within prod VPC
+
+# Local for apricot credentials (prod uses /api/ endpoint, all others use /sandbox/)
+locals {
+  # Apricot credentials - prod uses /api/ endpoint, all others use /sandbox/
+  apricot_client_id = (
+    var.environment == "prod"
+    ? data.google_secret_manager_secret_version.apricot_client_id_prod.secret_data
+    : data.google_secret_manager_secret_version.apricot_client_id_sandbox.secret_data
+  )
+  apricot_client_secret = (
+    var.environment == "prod"
+    ? data.google_secret_manager_secret_version.apricot_client_secret_prod.secret_data
+    : data.google_secret_manager_secret_version.apricot_client_secret_sandbox.secret_data
+  )
+}
+
+data "google_secret_manager_secret_version" "openai_api_key" {
+  secret = "openai-api-key"
+}
+
+data "google_secret_manager_secret_version" "anthropic_api_key" {
+  secret = "anthropic-api-key"
+}
+
+data "google_secret_manager_secret_version" "exa_api_key" {
+  secret = "exa-api-key"
+}
+
+data "google_secret_manager_secret_version" "google_ai_key" {
+  secret = "google-generative-ai-key"
+}
+
+data "google_secret_manager_secret_version" "grok_api_key" {
+  secret = "grok-api-key"
+}
+
+data "google_secret_manager_secret_version" "xai_api_key" {
+  secret = "xai-api-key"
+}
+
+data "google_secret_manager_secret_version" "mastra_jwt_secret" {
+  count  = 0
+  secret = "mastra-jwt-secret"
+}
+
+data "google_secret_manager_secret_version" "mastra_app_password" {
+  count  = 0
+  secret = "mastra-app-password"
+}
+
+data "google_secret_manager_secret_version" "mastra_jwt_token" {
+  count  = 0
+  secret = "mastra-jwt-token"
+}
+
+data "google_secret_manager_secret_version" "vertex_ai_credentials" {
+  secret = "vertex-ai-credentials"
+}
+
+data "google_secret_manager_secret_version" "apricot_api_base_url" {
+  secret = "apricot-api-base-url"
+}
+
+# Apricot credentials - prod and sandbox require separate credentials
+data "google_secret_manager_secret_version" "apricot_client_id_prod" {
+  secret = "apricot-client-id-prod"
+}
+
+data "google_secret_manager_secret_version" "apricot_client_secret_prod" {
+  secret = "apricot-client-secret-prod"
+}
+
+data "google_secret_manager_secret_version" "apricot_client_id_sandbox" {
+  secret = "apricot-client-id-sandbox"
+}
+
+data "google_secret_manager_secret_version" "apricot_client_secret_sandbox" {
+  secret = "apricot-client-secret-sandbox"
+}
+
+# Note: VM uses private subnet without external IP
+# Internet access is provided via Cloud NAT
+# If external IP is needed for API whitelisting, consider using Cloud NAT's external IPs
+
+# Compute VM - Runs browser-streaming and mastra-app containers
+resource "google_compute_instance" "app_vm" {
+  count        = 0
+  name         = "app-vm-${var.environment}"
+  machine_type = var.vm_machine_type
+  zone         = local.zone
+
+  # Allow Terraform to stop the VM for updates (e.g., network changes)
+  allow_stopping_for_update = true
+
+  # Container-Optimized OS for running Docker containers
+  boot_disk {
+    initialize_params {
+      image = "cos-cloud/cos-stable"
+      size  = var.vm_disk_size
+      type  = "pd-standard"
+    }
+  }
+
+  # Network configuration - Use private subnet without external IP
+  # Internet access via Cloud NAT (configured in vpc.tf)
+  network_interface {
+    network    = local.vpc_network.id
+    subnetwork = local.private_subnet.id
+    # No access_config - VM uses Cloud NAT for outbound internet access
+  }
+
+  # Service account for VM
+  service_account {
+    email  = google_service_account.vm[0].email
+    scopes = ["cloud-platform"]
+  }
+
+  # Startup script to run both containers
+  # IMPORTANT: Image version metadata triggers VM restart when images change
+  metadata = {
+    browser-image-version = var.browser_image_url
+    mastra-image-version  = var.mastra_image_url
+    startup-script = templatefile("${path.module}/scripts/startup.sh", {
+      browser_image           = var.browser_image_url
+      mastra_image            = var.mastra_image_url
+      project_id              = local.project_id
+      environment             = var.environment
+      database_url            = ""
+      openai_api_key          = data.google_secret_manager_secret_version.openai_api_key.secret_data
+      anthropic_api_key       = data.google_secret_manager_secret_version.anthropic_api_key.secret_data
+      exa_api_key             = data.google_secret_manager_secret_version.exa_api_key.secret_data
+      google_ai_key           = data.google_secret_manager_secret_version.google_ai_key.secret_data
+      grok_api_key            = data.google_secret_manager_secret_version.grok_api_key.secret_data
+      xai_api_key             = data.google_secret_manager_secret_version.xai_api_key.secret_data
+      mastra_jwt_secret       = length(data.google_secret_manager_secret_version.mastra_jwt_secret) > 0 ? data.google_secret_manager_secret_version.mastra_jwt_secret[0].secret_data : ""
+      mastra_app_password     = length(data.google_secret_manager_secret_version.mastra_app_password) > 0 ? data.google_secret_manager_secret_version.mastra_app_password[0].secret_data : ""
+      mastra_jwt_token        = length(data.google_secret_manager_secret_version.mastra_jwt_token) > 0 ? data.google_secret_manager_secret_version.mastra_jwt_token[0].secret_data : ""
+      vertex_ai_credentials   = data.google_secret_manager_secret_version.vertex_ai_credentials.secret_data
+      apricot_api_base_url    = data.google_secret_manager_secret_version.apricot_api_base_url.secret_data
+      apricot_client_id       = local.apricot_client_id
+      apricot_client_secret   = local.apricot_client_secret
+    })
+  }
+
+  # Allow HTTP traffic for MCP, WebSocket, and Mastra API
+  tags = ["http-server", "https-server", "browser-mcp", "browser-streaming", "mastra-app"]
+
+  labels = merge(local.common_labels, {
+    environment = var.environment
+    component   = "app-vm"
+  })
+
+  # Recreate VM when container images change
+  lifecycle {
+    replace_triggered_by = [terraform_data.image_versions[0]]
+  }
+
+  depends_on = [
+    google_project_service.required_apis,
+    google_compute_network.main,
+    google_compute_subnetwork.private,
+    google_compute_router_nat.main  # Ensure NAT is ready for internet access
+  ]
+}
+
+# Track image versions to trigger VM restart when they change
+resource "terraform_data" "image_versions" {
+  count = 0
+  input = {
+    browser_image = var.browser_image_url
+    mastra_image  = var.mastra_image_url
+  }
+}
+
+
+# Service account for VM
+resource "google_service_account" "vm" {
+  count        = 0
+  account_id   = "app-vm-${var.environment}"
+  display_name = "App VM Service Account (${var.environment})"
+  description  = "Service account for application VM in ${var.environment} environment"
+}
+
+# IAM bindings for VM service account
+resource "google_project_iam_member" "vm_storage" {
+  count   = 0
+  project = local.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.vm[0].email}"
+}
+
+resource "google_project_iam_member" "vm_logging" {
+  count   = 0
+  project = local.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.vm[0].email}"
+}
+
+resource "google_project_iam_member" "vm_monitoring" {
+  count   = 0
+  project = local.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.vm[0].email}"
+}
+
+resource "google_project_iam_member" "vm_artifact_registry" {
+  count   = 0
+  project = local.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.vm[0].email}"
+}
+
+resource "google_project_iam_member" "vm_secret_accessor" {
+  count   = 0
+  project = local.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.vm[0].email}"
+}
+
+resource "google_project_iam_member" "vm_vertex_ai_user" {
+  count   = 0
+  project = local.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.vm[0].email}"
+}

--- a/terraform/domain_mappings.tf
+++ b/terraform/domain_mappings.tf
@@ -1,0 +1,37 @@
+# Custom domain mappings for Cloud Run services
+# Maps custom domains (via Route53 CNAME) to Cloud Run services with auto-provisioned SSL
+# Note: Requires domain ownership verification via Google Search Console for parent domain
+# Preview environments skip domain mappings to avoid verification issues
+
+# Domain mapping for AI Chatbot service (only for dev and prod)
+resource "google_cloud_run_domain_mapping" "chatbot" {
+  count    = var.enable_custom_domain ? 1 : 0
+  name     = local.env_config.domain_prefix == "app" ? var.domain_name : "${local.env_config.domain_prefix}.${var.domain_name}"
+  location = local.region
+
+  metadata {
+    namespace = local.project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_v2_service.ai_chatbot.name
+  }
+
+  # Ensure service exists before creating mapping
+  depends_on = [google_cloud_run_v2_service.ai_chatbot]
+}
+
+# Output the custom domain for this environment
+output "custom_domain" {
+  description = "Custom domain for this environment (empty string if domain mapping disabled)"
+  value       = var.enable_custom_domain ? google_cloud_run_domain_mapping.chatbot[0].name : ""
+}
+
+# Output domain mapping status
+output "domain_mapping_status" {
+  description = "Status of the domain mapping (null if domain mapping disabled)"
+  value = var.enable_custom_domain ? {
+    domain = google_cloud_run_domain_mapping.chatbot[0].name
+    status = google_cloud_run_domain_mapping.chatbot[0].status
+  } : null
+}

--- a/terraform/github-actions/github-actions-auth.tf
+++ b/terraform/github-actions/github-actions-auth.tf
@@ -1,0 +1,93 @@
+# Workload Identity Federation for GitHub Actions
+# Allows GitHub Actions workflows to authenticate to GCP without storing service account keys
+
+locals {
+  project_id    = var.project_id
+  repo_owner    = "navapbc"
+  repo_name     = "ai-chatbot"
+  # Repos allowed to impersonate the deploy service account.
+  # "labs-asp" kept during the migration transition; remove once its workflows are disabled.
+  repo_names    = ["ai-chatbot", "labs-asp"]
+  service_account_email = "github-actions-deploy@${var.project_id}.iam.gserviceaccount.com"
+}
+
+# Workload Identity Pool for GitHub Actions
+resource "google_iam_workload_identity_pool" "github_actions" {
+  workload_identity_pool_id = "github-actions-pool"
+  display_name             = "GitHub Actions Pool"
+  description              = "Identity pool for GitHub Actions workflows"
+  project                  = local.project_id
+}
+
+# OIDC Provider for GitHub
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-provider"
+  display_name                       = "GitHub Provider"
+  description                        = "OIDC provider for GitHub Actions"
+  project                            = local.project_id
+
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.actor"            = "assertion.actor"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+  }
+
+  attribute_condition = "assertion.repository_owner == '${local.repo_owner}'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# Allow GitHub Actions to impersonate the service account
+moved {
+  from = google_service_account_iam_member.github_actions_workload_identity
+  to   = google_service_account_iam_member.github_actions_workload_identity["labs-asp"]
+}
+
+resource "google_service_account_iam_member" "github_actions_workload_identity" {
+  for_each           = toset(local.repo_names)
+  service_account_id = "projects/${local.project_id}/serviceAccounts/${local.service_account_email}"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/${local.repo_owner}/${each.value}"
+}
+
+# Grant the service account access to Google Sheets API (read and write)
+resource "google_project_iam_member" "github_actions_sheets_editor" {
+  project = local.project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:${local.service_account_email}"
+  
+  # Note: This grants broad permissions. For production, consider:
+  # - Creating a custom role with only sheets.spreadsheets.* permissions
+  # - Using Domain-Wide Delegation for more granular control
+  # - Limiting to specific sheets via resource-level IAM
+}
+
+# Output the values needed for GitHub Secrets
+output "gcp_workload_identity_provider" {
+  description = "The Workload Identity Provider resource name for GitHub Actions"
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "gcp_service_account" {
+  description = "The service account email for GitHub Actions"
+  value       = local.service_account_email
+}
+
+output "github_secrets_instructions" {
+  description = "Instructions for setting up GitHub secrets"
+  value = <<-EOT
+  
+  Add these secrets to GitHub repository settings:
+  https://github.com/${local.repo_owner}/${local.repo_name}/settings/secrets/actions
+  
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${google_iam_workload_identity_pool_provider.github.name}
+  GCP_SERVICE_ACCOUNT: ${local.service_account_email}
+  GOOGLE_CLOUD_PROJECT: ${local.project_id}
+  DATABASE_URL: (Use your existing DATABASE_URL from .env)
+  EOT
+}
+

--- a/terraform/github-actions/github-secrets.tf
+++ b/terraform/github-actions/github-secrets.tf
@@ -1,0 +1,31 @@
+# Fetch the database URL from Google Secret Manager
+data "google_secret_manager_secret_version" "database_url" {
+  secret  = var.database_secret_name
+  project = var.project_id
+}
+
+# GitHub Actions Secrets
+resource "github_actions_secret" "gcp_workload_identity_provider" {
+  repository      = var.github_repo
+  secret_name     = "GCP_WORKLOAD_IDENTITY_PROVIDER"
+  plaintext_value = google_iam_workload_identity_pool_provider.github.name
+}
+
+resource "github_actions_secret" "gcp_service_account" {
+  repository      = var.github_repo
+  secret_name     = "GCP_SERVICE_ACCOUNT"
+  plaintext_value = local.service_account_email
+}
+
+resource "github_actions_secret" "google_cloud_project" {
+  repository      = var.github_repo
+  secret_name     = "GOOGLE_CLOUD_PROJECT"
+  plaintext_value = var.project_id
+}
+
+resource "github_actions_secret" "database_url" {
+  repository      = var.github_repo
+  secret_name     = "DATABASE_URL"
+  plaintext_value = data.google_secret_manager_secret_version.database_url.secret_data
+}
+

--- a/terraform/github-actions/main.tf
+++ b/terraform/github-actions/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+}
+
+provider "github" {
+  owner = var.github_owner
+}
+
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+  default     = "nava-labs"
+}
+
+variable "github_owner" {
+  description = "GitHub organization or user"
+  type        = string
+  default     = "navapbc"
+}
+
+variable "github_repo" {
+  description = "GitHub repository name"
+  type        = string
+  default     = "ai-chatbot"
+}
+
+variable "database_secret_name" {
+  description = "Name of the database URL secret in Google Secret Manager"
+  type        = string
+  default     = "database-url-dev"
+}
+

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,278 @@
+# GitHub Actions Service Account
+# IMPORTANT: This is a GLOBAL resource managed ONLY by 'dev' environment
+# Preview and prod environments reference it via data source
+locals {
+  is_managing_globals = var.environment == "dev"
+}
+
+resource "google_service_account" "github_actions" {
+  count = local.is_managing_globals ? 1 : 0
+
+  account_id   = "github-actions-deploy"
+  display_name = "GitHub Actions Deployment Service Account"
+  description  = "Service account for GitHub Actions deployments"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+data "google_service_account" "github_actions" {
+  count = local.is_managing_globals ? 0 : 1
+
+  account_id = "github-actions-deploy"
+}
+
+# Unified reference for both resource and data source
+locals {
+  github_actions_sa_email = local.is_managing_globals ? google_service_account.github_actions[0].email : data.google_service_account.github_actions[0].email
+  github_actions_sa_name  = local.is_managing_globals ? google_service_account.github_actions[0].name : data.google_service_account.github_actions[0].name
+}
+
+# IAM roles for GitHub Actions service account
+# IMPORTANT: These are GLOBAL permissions managed ONLY by 'dev' environment
+# NEVER destroy these, even during rollback
+resource "google_project_iam_member" "github_actions_cloud_run_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "github_actions_storage_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "github_actions_secret_accessor" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "github_actions_artifact_registry_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/artifactregistry.admin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "github_actions_cloud_build_editor" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/cloudbuild.builds.editor"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "github_actions_service_account_user" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "github_actions_compute_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Compute network admin for firewall rules
+resource "google_project_iam_member" "github_actions_compute_network_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/compute.networkAdmin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Compute security admin for firewall management
+resource "google_project_iam_member" "github_actions_compute_security_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/compute.securityAdmin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Security Admin for managing IAM policies
+resource "google_project_iam_member" "github_actions_security_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/iam.securityAdmin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Workload Identity Pool Admin for managing workload identity
+resource "google_project_iam_member" "github_actions_workload_identity_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/iam.workloadIdentityPoolAdmin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Secret Manager Admin for reading secrets during terraform plan
+resource "google_project_iam_member" "github_actions_secret_manager_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/secretmanager.admin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Service Account Admin for creating/deleting service accounts
+resource "google_project_iam_member" "github_actions_service_account_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/iam.serviceAccountAdmin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Cloud SQL Admin for managing Cloud SQL instances and databases
+resource "google_project_iam_member" "github_actions_cloud_sql_admin" {
+  count = local.is_managing_globals ? 1 : 0
+
+  project = local.project_id
+  role    = "roles/cloudsql.admin"
+  member  = "serviceAccount:${local.github_actions_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Workload Identity Pool for GitHub Actions
+# IMPORTANT: GLOBAL resource managed ONLY by 'dev' environment
+# NEVER destroy these, even during rollback
+resource "google_iam_workload_identity_pool" "github_actions" {
+  count = local.is_managing_globals ? 1 : 0
+
+  workload_identity_pool_id = "github-actions-pool"
+  display_name              = "GitHub Actions Pool"
+  description               = "Workload Identity Pool for GitHub Actions"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+data "google_iam_workload_identity_pool" "github_actions" {
+  count = local.is_managing_globals ? 0 : 1
+
+  workload_identity_pool_id = "github-actions-pool"
+}
+
+locals {
+  wip_name                  = local.is_managing_globals ? google_iam_workload_identity_pool.github_actions[0].name : data.google_iam_workload_identity_pool.github_actions[0].name
+  wip_workload_identity_pool_id = local.is_managing_globals ? google_iam_workload_identity_pool.github_actions[0].workload_identity_pool_id : data.google_iam_workload_identity_pool.github_actions[0].workload_identity_pool_id
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  count = local.is_managing_globals ? 1 : 0
+
+  workload_identity_pool_id          = local.wip_workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-provider"
+  display_name                       = "GitHub Provider"
+  description                        = "Workload Identity Pool Provider for GitHub Actions"
+
+  attribute_condition = "assertion.repository_owner=='navapbc'"
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.actor"            = "assertion.actor"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+  }
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_service_account_iam_member" "github_actions_workload_identity" {
+  count = local.is_managing_globals ? 1 : 0
+
+  service_account_id = local.github_actions_sa_name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${local.wip_name}/attribute.repository/navapbc/labs-asp"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Allow GitHub Actions service account to act as Cloud Run service account (only for current environment)
+resource "google_service_account_iam_member" "github_actions_act_as_cloud_run" {
+  service_account_id = google_service_account.cloud_run.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${local.github_actions_sa_email}"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,116 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 7.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+  }
+
+  # Use existing GCS backend for state storage
+  # Note: prefix should be set per-environment via terraform init -backend-config
+  backend "gcs" {
+    bucket = "labs-asp-terraform-state"
+  }
+}
+
+# Configure the Google Cloud Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Local values for common configurations
+locals {
+  project_id = var.project_id
+  region     = var.region
+  zone       = var.zone
+
+  # Determine base environment (dev, preview, prod) from environment name
+  # For preview-pr-123, base_environment = "preview"
+  base_environment = startswith(var.environment, "preview-pr-") ? "preview" : var.environment
+
+  # Environment configurations - reuse existing pattern
+  environments = {
+    dev = {
+      mastra_service_name = "mastra-app-dev"
+      chatbot_service_name = "ai-chatbot-dev"
+      sql_instance_name = "nava-db-dev"  # dev database
+      storage_bucket_name = "nava-storage-dev"  # dev storage bucket
+      domain_prefix = "dev"
+    }
+    preview = {
+      mastra_service_name = "mastra-app-${var.environment}"  # Use full env name for unique resources
+      chatbot_service_name = "ai-chatbot-${var.environment}"
+      sql_instance_name = "nava-db-dev"  # ALL preview environments use dev database
+      storage_bucket_name = "nava-storage-dev"  # ALL preview environments use dev storage bucket
+      domain_prefix = var.environment  # preview-pr-123 gets preview-pr-123.labs-asp.com
+    }
+    prod = {
+      mastra_service_name = "mastra-app-prod"
+      chatbot_service_name = "ai-chatbot-prod"
+      sql_instance_name = "nava-db-prod"  # prod database
+      storage_bucket_name = "nava-storage-prod"  # prod storage bucket
+      domain_prefix = "app"
+    }
+  }
+
+  # Get current environment config using base_environment as key
+  env_config = local.environments[local.base_environment]
+
+  # Common labels
+  common_labels = {
+    project     = "labs-asp"
+    managed_by  = "terraform"
+    deployment  = "client-server-architecture"
+  }
+
+  # VPC Connector name - must be max 25 chars, start/end with alphanumeric
+  # Pattern: ^[a-z][-a-z0-9]{0,23}[a-z0-9]$
+  # Map environments to short names that fit the pattern
+  connector_names = {
+    dev     = "labs-conn-dev"
+    preview = "labs-conn-prev"
+    prod    = "labs-conn-prod"
+  }
+  # For preview-pr-N, use prN format (e.g., preview-pr-114 -> labs-conn-pr114)
+  connector_env_short = startswith(var.environment, "preview-pr-") ? "pr${replace(var.environment, "preview-pr-", "")}" : var.environment
+  vpc_connector_name = lookup(local.connector_names, local.connector_env_short, "labs-conn-${substr(local.connector_env_short, 0, 14)}")
+}
+
+# Enable required APIs
+resource "google_project_service" "required_apis" {
+  for_each = toset([
+    "run.googleapis.com",
+    "sql-component.googleapis.com",
+    "sqladmin.googleapis.com",
+    "secretmanager.googleapis.com",
+    "storage.googleapis.com",
+    "compute.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "servicenetworking.googleapis.com"
+  ])
+
+  service = each.key
+  project = local.project_id
+
+  disable_dependent_services = false
+  disable_on_destroy        = false
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,85 @@
+# Cloud NAT static IP for external API whitelisting
+output "nat_external_ip" {
+  description = "Static external IP for Cloud NAT (use for external API whitelisting)"
+  value       = length(google_compute_address.nat_static_ip) > 0 ? google_compute_address.nat_static_ip[0].address : null
+}
+
+output "api_whitelisting_info" {
+  description = "Information needed for external API whitelisting"
+  value = length(google_compute_address.nat_static_ip) > 0 ? {
+    static_ip   = google_compute_address.nat_static_ip[0].address
+    environment = var.environment
+    region      = local.region
+    purpose     = "Outbound traffic via Cloud NAT"
+  } : null
+}
+
+# AI Chatbot service outputs
+output "chatbot_service_name" {
+  description = "Name of the AI Chatbot Cloud Run service"
+  value       = google_cloud_run_v2_service.ai_chatbot.name
+}
+
+output "chatbot_service_url" {
+  description = "URL of the AI Chatbot Cloud Run service"
+  value       = google_cloud_run_v2_service.ai_chatbot.uri
+}
+
+output "chatbot_public_url" {
+  description = "Public URL for accessing the AI chatbot"
+  value       = google_cloud_run_v2_service.ai_chatbot.uri
+}
+
+# Service account outputs
+output "cloud_run_service_account" {
+  description = "Service account email for Cloud Run services"
+  value       = google_service_account.cloud_run.email
+}
+
+# Environment information
+output "environment" {
+  description = "Deployed environment"
+  value       = var.environment
+}
+
+output "project_id" {
+  description = "GCP project ID"
+  value       = local.project_id
+}
+
+output "region" {
+  description = "GCP region"
+  value       = local.region
+}
+
+# VPC Network outputs
+output "vpc_id" {
+  description = "VPC network ID"
+  value       = local.vpc_network.id
+}
+
+output "vpc_name" {
+  description = "VPC network name"
+  value       = local.vpc_network.name
+}
+
+output "vpc_public_subnet" {
+  description = "Public subnet CIDR"
+  value       = var.vpc_cidr_public
+}
+
+output "vpc_private_subnet" {
+  description = "Private subnet CIDR"
+  value       = var.vpc_cidr_private
+}
+
+output "vpc_db_subnet" {
+  description = "Database subnet CIDR"
+  value       = var.vpc_cidr_db
+}
+
+output "vpc_connector_cidr" {
+  description = "VPC Connector CIDR"
+  value       = var.vpc_connector_cidr
+}
+

--- a/terraform/scripts/startup.sh
+++ b/terraform/scripts/startup.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# VM startup script for Container-Optimized OS
+# Runs browser-streaming and mastra-app containers
+
+set -euo pipefail
+
+# Log function
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [STARTUP] $1" | systemd-cat -t vm-startup
+}
+
+log "Starting services initialization..."
+
+# Configure Docker for Artifact Registry
+log "Configuring Docker for Artifact Registry..."
+export DOCKER_CONFIG=/tmp/.docker
+mkdir -p "$DOCKER_CONFIG"
+
+if command -v docker-credential-gcr >/dev/null 2>&1; then
+    log "Using docker-credential-gcr..."
+    docker-credential-gcr configure-docker --registries=us-central1-docker.pkg.dev
+else
+    log "Using gcloud auth configure-docker..."
+    gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+fi
+
+# Pull images
+log "Pulling browser-streaming image: ${browser_image}"
+DOCKER_CONFIG="$DOCKER_CONFIG" docker pull "${browser_image}" || {
+    log "Failed to pull browser image"
+    exit 1
+}
+
+log "Pulling mastra-app image: ${mastra_image}"
+DOCKER_CONFIG="$DOCKER_CONFIG" docker pull "${mastra_image}" || {
+    log "Failed to pull mastra image"
+    exit 1
+}
+
+# Create Docker network
+log "Creating Docker network..."
+docker network create mastra-network 2>/dev/null || log "Network already exists"
+
+# Stop and remove existing containers
+log "Cleaning up existing containers..."
+docker stop browser-streaming mastra-app 2>/dev/null || true
+docker rm browser-streaming mastra-app 2>/dev/null || true
+
+# Create artifacts directory
+mkdir -p /tmp/artifacts
+chmod 755 /tmp/artifacts
+
+# Write Vertex AI credentials to file for Docker container mounting
+# Clean up if previous run left a directory instead of file (Docker creates dirs for missing mount paths)
+log "Writing Vertex AI credentials file..."
+rm -rf /tmp/vertex-ai-credentials.json
+cat > /tmp/vertex-ai-credentials.json << 'EOFCREDS'
+${vertex_ai_credentials}
+EOFCREDS
+chmod 644 /tmp/vertex-ai-credentials.json
+
+# Start browser-streaming container
+log "Starting browser-streaming container..."
+docker run -d \
+    --name browser-streaming \
+    --restart unless-stopped \
+    --network mastra-network \
+    -p 8931:8931 \
+    -p 8933:8933 \
+    -v /tmp/artifacts:/app/artifacts \
+    -e ENVIRONMENT="${environment}" \
+    -e GCP_PROJECT_ID="${project_id}" \
+    "${browser_image}"
+
+# Wait for browser service to be running
+log "Waiting for browser-streaming container to start..."
+sleep 10
+if ! docker ps | grep -q browser-streaming; then
+    log "Browser-streaming container failed to start"
+    docker logs browser-streaming
+    exit 1
+fi
+log "Browser-streaming container is running"
+
+# Start mastra-app container
+log "Starting mastra-app container..."
+docker run -d \
+    --name mastra-app \
+    --restart unless-stopped \
+    --network mastra-network \
+    -p 4112:4112 \
+    -v /tmp/artifacts:/app/artifacts \
+    -v /tmp/vertex-ai-credentials.json:/app/vertex-ai-credentials.json:ro \
+    -e PLAYWRIGHT_MCP_URL=http://browser-streaming:8931/mcp \
+    -e BROWSER_STREAMING_URL=ws://browser-streaming:8933 \
+    -e NODE_ENV=production \
+    -e ENVIRONMENT="${environment}" \
+    -e GCP_PROJECT_ID="${project_id}" \
+    -e DATABASE_URL="${database_url}" \
+    -e OPENAI_API_KEY="${openai_api_key}" \
+    -e ANTHROPIC_API_KEY="${anthropic_api_key}" \
+    -e EXA_API_KEY="${exa_api_key}" \
+    -e GOOGLE_GENERATIVE_AI_API_KEY="${google_ai_key}" \
+    -e GROK_API_KEY="${grok_api_key}" \
+    -e XAI_API_KEY="${xai_api_key}" \
+    -e MASTRA_JWT_SECRET="${mastra_jwt_secret}" \
+    -e MASTRA_APP_PASSWORD="${mastra_app_password}" \
+    -e MASTRA_JWT_TOKEN="${mastra_jwt_token}" \
+    -e GOOGLE_APPLICATION_CREDENTIALS=/app/vertex-ai-credentials.json \
+    -e GOOGLE_VERTEX_LOCATION=global \
+    -e GOOGLE_VERTEX_PROJECT="${project_id}" \
+    -e GOOGLE_CLOUD_PROJECT="${project_id}" \
+    -e CORS_ORIGINS="*" \
+    -e APRICOT_API_BASE_URL="${apricot_api_base_url}" \
+    -e APRICOT_CLIENT_ID="${apricot_client_id}" \
+    -e APRICOT_CLIENT_SECRET="${apricot_client_secret}" \
+    "${mastra_image}"
+
+# Wait for mastra service to be running and healthy
+log "Waiting for mastra-app container to start..."
+sleep 15
+if ! docker ps | grep -q mastra-app; then
+    log "Mastra-app container failed to start"
+    docker logs mastra-app
+    exit 1
+fi
+
+# Check mastra health endpoint (it has one)
+log "Checking mastra-app health..."
+for i in {1..30}; do
+    if docker exec mastra-app curl -f http://localhost:4112/health 2>/dev/null; then
+        log "Mastra-app is healthy!"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        log "Warning: Mastra-app health check failed, but container is running"
+        docker logs mastra-app | tail -20
+    fi
+    sleep 2
+done
+
+# Set up log forwarding
+log "Setting up log forwarding..."
+docker logs -f browser-streaming &
+docker logs -f mastra-app &
+
+log "All services started successfully!"
+
+# Signal readiness
+ZONE=$(curl -H "Metadata-Flavor: Google" -s http://metadata.google.internal/computeMetadata/v1/instance/zone | cut -d/ -f4)
+INSTANCE_NAME=$(curl -H "Metadata-Flavor: Google" -s http://metadata.google.internal/computeMetadata/v1/instance/name)
+
+gcloud compute instances add-metadata "$${INSTANCE_NAME}" \
+  --metadata services-ready=true \
+  --zone="$${ZONE}" || {
+  log "Warning: Could not set readiness metadata"
+}
+
+log "Services ready!"

--- a/terraform/shared-preview-vpc/README.md
+++ b/terraform/shared-preview-vpc/README.md
@@ -1,0 +1,494 @@
+# Shared Preview VPC Terraform Module
+
+This module creates and manages a shared VPC infrastructure used by all preview environments (preview-pr-*).
+
+## Purpose
+
+Instead of creating a separate VPC for each PR, all preview environments share this single VPC. This:
+- Reduces infrastructure costs (~$125/month per preview eliminated)
+- Speeds up deployments (no VPC creation per PR)
+- Simplifies VPC peering management (permanent peering with dev)
+
+## Architecture
+
+```
+┌─────────────────────────┐
+│ Shared Preview VPC      │
+│ 10.1.0.0/16            │
+├─────────────────────────┤
+│ Public Subnet           │  10.1.0.0/20  (4,096 IPs)
+│ Private Subnet          │  10.1.16.0/20 (4,096 IPs) ← VMs deployed here
+│ Database Subnet         │  10.1.32.0/20 (4,096 IPs)
+│ VPC Connector           │  10.1.48.0/28 (16 IPs)
+├─────────────────────────┤
+│ NAT Gateway (shared)    │  Single static IP for all previews
+│ Cloud Router            │  ASN: 64515
+│ VPC Connector (shared)  │  Used by all Cloud Run services
+├─────────────────────────┤
+│ VPC Peering             │
+│ ├─ preview → dev        │  Bidirectional peering
+│ └─ dev → preview        │  Access to dev Cloud SQL
+└─────────────────────────┘
+```
+
+## Resources Created
+
+### Network Infrastructure
+
+- **VPC Network:** `labs-asp-vpc-preview-shared`
+  - Routing mode: REGIONAL
+  - Auto-create subnets: false
+
+- **Subnets:**
+  - `labs-asp-public-preview-shared` (10.1.0.0/20)
+  - `labs-asp-private-preview-shared` (10.1.16.0/20)
+  - `labs-asp-db-preview-shared` (10.1.32.0/20)
+
+- **Cloud Router:** `labs-asp-router-preview-shared`
+  - BGP ASN: 64515 (different from dev: 64514)
+
+- **NAT Gateway:** `labs-asp-nat-preview-shared`
+  - Static IP: `labs-asp-nat-ip-preview-shared`
+  - Source: ALL_SUBNETWORKS_ALL_IP_RANGES
+
+- **VPC Connector:** `labs-conn-preview-shared`
+  - IP range: 10.1.48.0/28
+  - Machine type: e2-micro
+  - Min instances: 2
+  - Max instances: 10
+
+### VPC Peering
+
+- **Preview → Dev Peering:** `preview-shared-to-dev-peering`
+  - Connects to: `labs-asp-vpc-dev`
+  - Import/Export custom routes: true
+
+- **Dev → Preview Peering:** `dev-to-preview-shared-peering`
+  - Connects from: `labs-asp-vpc-dev`
+  - Import/Export custom routes: true
+
+### Firewall Rules
+
+- **allow-internal-preview-shared:** Allow all internal VPC traffic + dev VPC (10.0.0.0/16)
+- **allow-iap-ssh-preview-shared:** SSH access via Identity-Aware Proxy
+- **allow-health-checks-preview-shared:** Google Cloud load balancer health checks
+
+## Terraform State
+
+**Backend:** GCS Bucket  
+**State Path:** `gs://labs-asp-terraform-state/terraform/state/shared-preview-vpc`
+
+This state is **separate** from individual environment states to prevent conflicts.
+
+## Variables
+
+All variables are defined in `variables.tf` with sensible defaults:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `project_id` | `nava-labs` | GCP project ID |
+| `region` | `us-central1` | GCP region |
+| `vpc_cidr_public` | `10.1.0.0/20` | Public subnet CIDR |
+| `vpc_cidr_private` | `10.1.16.0/20` | Private subnet CIDR (VMs) |
+| `vpc_cidr_db` | `10.1.32.0/20` | Database subnet CIDR |
+| `vpc_connector_cidr` | `10.1.48.0/28` | VPC connector CIDR |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `vpc_id` | VPC network ID |
+| `vpc_name` | VPC network name (`labs-asp-vpc-preview-shared`) |
+| `vpc_self_link` | VPC self link (for references) |
+| `public_subnet_id` | Public subnet ID |
+| `private_subnet_id` | Private subnet ID |
+| `db_subnet_id` | Database subnet ID |
+| `vpc_connector_id` | VPC connector ID (used by Cloud Run) |
+| `vpc_connector_name` | VPC connector name |
+| `nat_external_ip` | Static NAT IP for whitelisting |
+| `peering_status` | VPC peering status (preview↔dev) |
+
+## Deployment
+
+### Automatic Deployment (Recommended)
+
+The shared VPC is **automatically deployed** by GitHub Actions on the first preview environment deployment.
+
+**Workflow:** `.github/workflows/deploy.yml`  
+**Step:** "Deploy Shared Preview VPC" (Lines 200-218)
+
+```yaml
+- name: Deploy Shared Preview VPC
+  if: startsWith(needs.setup.outputs.environment, 'preview-')
+  working-directory: ./terraform/shared-preview-vpc
+  run: |
+    terraform init
+    if gcloud compute networks describe labs-asp-vpc-preview-shared; then
+      echo "✅ VPC exists, skipping..."
+    else
+      terraform apply -auto-approve
+    fi
+```
+
+### Manual Deployment
+
+If you need to deploy or update manually:
+
+```bash
+# Navigate to module directory
+cd terraform/shared-preview-vpc
+
+# Initialize Terraform
+terraform init
+
+# Review changes
+terraform plan
+
+# Apply changes
+terraform apply
+```
+
+### First Time Setup
+
+On first deployment, Terraform will create:
+1. VPC network and subnets (~30 seconds)
+2. Cloud Router and NAT Gateway (~1 minute)
+3. VPC Connector (~2-3 minutes)
+4. VPC Peering (~30 seconds)
+5. Firewall rules (~10 seconds)
+
+**Total time:** ~4-5 minutes
+
+### Subsequent Updates
+
+Updates (e.g., firewall rule changes) typically take ~30 seconds to 1 minute.
+
+## Usage by Preview Environments
+
+Preview environments **reference** this shared VPC using Terraform data sources.
+
+**File:** `terraform/vpc.tf` (Lines 10-52)
+
+```hcl
+# Data sources for shared preview VPC
+data "google_compute_network" "preview_shared" {
+  count   = startswith(var.environment, "preview-") ? 1 : 0
+  name    = "labs-asp-vpc-preview-shared"
+  project = local.project_id
+}
+
+data "google_compute_subnetwork" "preview_private" {
+  count   = startswith(var.environment, "preview-") ? 1 : 0
+  name    = "labs-asp-private-preview-shared"
+  region  = local.region
+  project = local.project_id
+}
+
+data "google_vpc_access_connector" "preview_connector" {
+  count   = startswith(var.environment, "preview-") ? 1 : 0
+  name    = "labs-conn-preview-shared"
+  region  = local.region
+  project = local.project_id
+}
+
+# Local values for abstraction
+locals {
+  vpc_network = startswith(var.environment, "preview-") ? 
+    data.google_compute_network.preview_shared[0] : 
+    google_compute_network.main[0]
+  # ...
+}
+```
+
+All preview resources (VMs, Cloud Run) use these data sources to deploy into the shared VPC.
+
+## VPC Peering Details
+
+### How Peering Works
+
+VPC peering is **bidirectional** and requires peering connections on both sides:
+
+1. **Preview → Dev Peering** (`preview_to_dev`)
+   - Created by this module
+   - Allows preview VMs to initiate connections to dev resources
+
+2. **Dev → Preview Peering** (`dev_to_preview`)
+   - Also created by this module
+   - Allows dev resources to respond to preview connections
+   - Required for Cloud SQL access
+
+### Route Import/Export
+
+```hcl
+import_custom_routes = true  # Import routes from peer
+export_custom_routes = true  # Export routes to peer
+```
+
+This allows:
+- Preview environments to reach dev Cloud SQL private IP
+- Dev database to respond to preview connections
+- Proper routing for Private Service Connect
+
+### When Peering is Established
+
+**Scenario 1: First Preview Deployed (Before Dev)**
+1. Preview deployment creates shared VPC
+2. Both peering connections created immediately
+3. Dev VPC must exist (error if not)
+
+**Scenario 2: Dev Already Exists**
+1. Shared VPC created
+2. Peering established automatically
+3. Next dev deployment ensures peering is up-to-date
+
+**Scenario 3: Dev Deployed After Preview**
+- Dev deployment step "Establish VPC Peering" runs
+- Re-applies this module to ensure peering is correct
+- No manual intervention needed
+
+## Database Access Flow
+
+```
+Preview Environment (preview-pr-123)
+  ├─ VM (10.1.16.x)
+  │   └─ Docker containers (internal network)
+  │       └─ Connection to: nava-labs:us-central1:app-dev
+  │
+  ├─ Cloud Run (uses VPC connector: 10.1.48.0/28)
+  │   └─ Cloud SQL Proxy: nava-labs:us-central1:app-dev
+  │
+  └─ VPC Peering (preview ↔ dev)
+      └─ Dev VPC (10.0.0.0/16)
+          └─ Cloud SQL: app-dev (private IP: 10.0.x.x)
+```
+
+**No Cloud SQL instance created for preview** - all previews share dev database.
+
+## Monitoring and Verification
+
+### Check VPC Status
+
+```bash
+# Describe VPC
+gcloud compute networks describe labs-asp-vpc-preview-shared
+
+# List subnets
+gcloud compute networks subnets list \
+  --network=labs-asp-vpc-preview-shared
+
+# Check VPC connector
+gcloud compute networks vpc-access connectors describe \
+  labs-conn-preview-shared \
+  --region=us-central1
+```
+
+### Check VPC Peering Status
+
+```bash
+# List all peerings for shared VPC
+gcloud compute networks peerings list \
+  --network=labs-asp-vpc-preview-shared
+
+# Expected output:
+# NAME: preview-shared-to-dev-peering
+# PEER_NETWORK: labs-asp-vpc-dev
+# STATE: ACTIVE
+
+# NAME: dev-to-preview-shared-peering  
+# PEER_NETWORK: labs-asp-vpc-preview-shared
+# STATE: ACTIVE
+```
+
+### Check NAT Gateway
+
+```bash
+# Get NAT IP for whitelisting
+gcloud compute addresses describe labs-asp-nat-ip-preview-shared \
+  --region=us-central1 \
+  --format="value(address)"
+
+# Check NAT configuration
+gcloud compute routers nats describe labs-asp-nat-preview-shared \
+  --router=labs-asp-router-preview-shared \
+  --region=us-central1
+```
+
+### Check Active Preview VMs
+
+```bash
+# List all preview VMs using shared VPC
+gcloud compute instances list \
+  --filter="network~labs-asp-vpc-preview-shared"
+
+# Check VM subnet assignment
+gcloud compute instances describe <VM_NAME> \
+  --format="value(networkInterfaces[0].subnetwork)"
+```
+
+## Troubleshooting
+
+### VPC Creation Fails
+
+**Error:** "Network already exists"
+
+**Cause:** VPC was created manually or by previous deployment.
+
+**Fix:**
+```bash
+terraform import google_compute_network.preview_shared \
+  labs-asp-vpc-preview-shared
+```
+
+### Peering State is Not ACTIVE
+
+**Check peer VPC exists:**
+```bash
+gcloud compute networks describe labs-asp-vpc-dev
+```
+
+**If dev VPC doesn't exist:**
+```bash
+# Deploy dev environment first
+cd terraform
+terraform apply -var="environment=dev"
+```
+
+**If peering is stuck:**
+```bash
+# Delete and recreate peering
+gcloud compute networks peerings delete preview-shared-to-dev-peering \
+  --network=labs-asp-vpc-preview-shared
+
+cd terraform/shared-preview-vpc
+terraform apply
+```
+
+### Preview Can't Reach Dev Database
+
+**1. Check peering is ACTIVE:**
+```bash
+gcloud compute networks peerings list --network=labs-asp-vpc-preview-shared
+```
+
+**2. Check firewall allows traffic from preview:**
+```bash
+gcloud compute firewall-rules list \
+  --filter="network:labs-asp-vpc-dev"
+```
+
+**3. Test connectivity from preview VM:**
+```bash
+# SSH to preview VM
+gcloud compute ssh <preview-vm>
+
+# Ping dev Cloud SQL private IP
+ping <dev-cloud-sql-private-ip>
+```
+
+### VPC Connector Issues
+
+**Error:** "VPC Access Connector is not ready"
+
+**Check connector status:**
+```bash
+gcloud compute networks vpc-access connectors describe \
+  labs-conn-preview-shared \
+  --region=us-central1
+```
+
+**If state is not READY:**
+- Wait 2-3 minutes (connector can take time to provision)
+- Check logs: `gcloud logging read "resource.type=vpc_access_connector"`
+
+## Maintenance
+
+### Updating Firewall Rules
+
+Edit `vpc.tf` (Lines 190-250) and apply:
+
+```bash
+cd terraform/shared-preview-vpc
+terraform apply
+```
+
+Changes apply to all preview environments immediately (no restart needed).
+
+### Changing VPC CIDR Ranges
+
+⚠️ **Cannot be changed after creation** - VPC CIDR is immutable.
+
+**To change:**
+1. Destroy all preview environments
+2. Destroy shared VPC
+3. Update `variables.tf` with new CIDR
+4. Apply to create new VPC
+
+### Updating VPC Connector
+
+```bash
+# Connector size can be adjusted in vpc.tf
+# Lines 126-139
+machine_type = "e2-micro"  # or e2-standard-4 for more capacity
+min_instances = 2
+max_instances = 10
+```
+
+Apply changes:
+```bash
+terraform apply
+```
+
+## Cleanup
+
+### When to Destroy
+
+Only destroy when:
+- ✅ No preview environments are active
+- ✅ Migrating to new architecture
+- ✅ Project shutdown
+
+### Destroy Process
+
+```bash
+# 1. Verify no active previews
+gcloud compute instances list --filter="name~preview"
+
+# 2. Destroy shared VPC
+cd terraform/shared-preview-vpc
+terraform destroy
+
+# 3. Confirm resources deleted
+gcloud compute networks list --filter="name:preview-shared"
+```
+
+## Security Considerations
+
+- **Private IPs only:** All resources use private IPs
+- **NAT Gateway:** Single static IP for whitelisting external APIs
+- **Firewall rules:** Restrict traffic to VPC and dev VPC ranges
+- **IAP SSH:** SSH access only via Identity-Aware Proxy
+- **VPC Peering:** Only with dev VPC (prod is isolated)
+
+## Cost Breakdown
+
+**Monthly costs (approximate):**
+- VPC Network: Free
+- Subnets: Free
+- NAT Gateway: $45/month (single IP)
+- Cloud Router: Free
+- VPC Connector: $73/month (e2-micro, 2 instances)
+- Static IP: $7/month
+- Firewall rules: Free
+- VPC Peering: Free
+
+**Total: ~$125/month** (shared across ALL preview environments)
+
+Compare to: $125/month **per preview** with individual VPCs.
+
+## References
+
+- Main documentation: `terraform/SHARED_PREVIEW_VPC_SETUP.md`
+- Deployment workflow: `.github/workflows/deploy.yml`
+- VPC routing logic: `terraform/vpc.tf`
+- [Google Cloud VPC](https://cloud.google.com/vpc/docs)
+- [VPC Peering](https://cloud.google.com/vpc/docs/vpc-peering)

--- a/terraform/shared-preview-vpc/main.tf
+++ b/terraform/shared-preview-vpc/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+  }
+
+  # Dedicated state for shared preview VPC
+  backend "gcs" {
+    bucket = "labs-asp-terraform-state"
+    prefix = "terraform/state/shared-preview-vpc"
+  }
+}
+
+# Configure the Google Cloud Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Local values for common configurations
+locals {
+  project_id = var.project_id
+  region     = var.region
+  
+  common_labels = {
+    project     = "labs-asp"
+    managed_by  = "terraform"
+    environment = "shared-preview"
+  }
+}
+

--- a/terraform/shared-preview-vpc/outputs.tf
+++ b/terraform/shared-preview-vpc/outputs.tf
@@ -1,0 +1,94 @@
+# VPC Network outputs
+output "vpc_id" {
+  description = "Shared preview VPC network ID"
+  value       = google_compute_network.preview_shared.id
+}
+
+output "vpc_name" {
+  description = "Shared preview VPC network name"
+  value       = google_compute_network.preview_shared.name
+}
+
+output "vpc_self_link" {
+  description = "Shared preview VPC self link"
+  value       = google_compute_network.preview_shared.self_link
+}
+
+# Subnet outputs
+output "public_subnet_id" {
+  description = "Public subnet ID"
+  value       = google_compute_subnetwork.public.id
+}
+
+output "public_subnet_name" {
+  description = "Public subnet name"
+  value       = google_compute_subnetwork.public.name
+}
+
+output "private_subnet_id" {
+  description = "Private subnet ID"
+  value       = google_compute_subnetwork.private.id
+}
+
+output "private_subnet_name" {
+  description = "Private subnet name"
+  value       = google_compute_subnetwork.private.name
+}
+
+output "db_subnet_id" {
+  description = "Database subnet ID"
+  value       = google_compute_subnetwork.db.id
+}
+
+output "db_subnet_name" {
+  description = "Database subnet name"
+  value       = google_compute_subnetwork.db.name
+}
+
+# VPC Connector output
+output "vpc_connector_id" {
+  description = "VPC connector ID for Cloud Run"
+  value       = google_vpc_access_connector.cloud_run.id
+}
+
+output "vpc_connector_name" {
+  description = "VPC connector name"
+  value       = google_vpc_access_connector.cloud_run.name
+}
+
+# NAT IP output
+output "nat_external_ip" {
+  description = "Static external IP for Cloud NAT"
+  value       = google_compute_address.nat_static_ip.address
+}
+
+# CIDR outputs
+output "vpc_cidr_public" {
+  description = "Public subnet CIDR"
+  value       = var.vpc_cidr_public
+}
+
+output "vpc_cidr_private" {
+  description = "Private subnet CIDR"
+  value       = var.vpc_cidr_private
+}
+
+output "vpc_cidr_db" {
+  description = "Database subnet CIDR"
+  value       = var.vpc_cidr_db
+}
+
+output "vpc_connector_cidr" {
+  description = "VPC Connector CIDR"
+  value       = var.vpc_connector_cidr
+}
+
+# Peering status
+output "peering_status" {
+  description = "VPC peering status with dev"
+  value = {
+    preview_to_dev = google_compute_network_peering.preview_to_dev.state
+    dev_to_preview = google_compute_network_peering.dev_to_preview.state
+  }
+}
+

--- a/terraform/shared-preview-vpc/variables.tf
+++ b/terraform/shared-preview-vpc/variables.tf
@@ -1,0 +1,39 @@
+# Project configuration
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+  default     = "nava-labs"
+}
+
+variable "region" {
+  description = "GCP region for resources"
+  type        = string
+  default     = "us-central1"
+}
+
+# VPC CIDR blocks for shared preview VPC (larger range to accommodate all preview environments)
+# Using 10.1.0.0/16 for ALL preview environments
+variable "vpc_cidr_public" {
+  description = "CIDR block for public subnet"
+  type        = string
+  default     = "10.1.0.0/20"  # 10.1.0.0 - 10.1.15.255
+}
+
+variable "vpc_cidr_private" {
+  description = "CIDR block for private subnet"
+  type        = string
+  default     = "10.1.16.0/20"  # 10.1.16.0 - 10.1.31.255
+}
+
+variable "vpc_cidr_db" {
+  description = "CIDR block for database subnet"
+  type        = string
+  default     = "10.1.32.0/20"  # 10.1.32.0 - 10.1.47.255
+}
+
+variable "vpc_connector_cidr" {
+  description = "CIDR block for VPC connector (used by Cloud Run)"
+  type        = string
+  default     = "10.1.48.0/28"  # 10.1.48.0 - 10.1.48.15
+}
+

--- a/terraform/shared-preview-vpc/vpc.tf
+++ b/terraform/shared-preview-vpc/vpc.tf
@@ -1,0 +1,249 @@
+# Shared Preview VPC Network Configuration
+# This VPC is shared by ALL preview environments (preview-pr-*)
+
+# Enable required APIs
+resource "google_project_service" "required_apis" {
+  for_each = toset([
+    "compute.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "servicenetworking.googleapis.com",
+  ])
+
+  service            = each.key
+  disable_on_destroy = false
+}
+
+# Main VPC Network - Shared by all preview environments
+resource "google_compute_network" "preview_shared" {
+  name                    = "labs-asp-vpc-preview-shared"
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+  description             = "Shared VPC network for all labs-asp preview environments"
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# Public Subnet
+resource "google_compute_subnetwork" "public" {
+  name          = "labs-asp-public-preview-shared"
+  ip_cidr_range = var.vpc_cidr_public
+  region        = local.region
+  network       = google_compute_network.preview_shared.id
+  description   = "Public subnet for preview resources with internet access"
+
+  private_ip_google_access = true
+
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Private Subnet
+resource "google_compute_subnetwork" "private" {
+  name          = "labs-asp-private-preview-shared"
+  ip_cidr_range = var.vpc_cidr_private
+  region        = local.region
+  network       = google_compute_network.preview_shared.id
+  description   = "Private subnet for preview internal resources"
+
+  private_ip_google_access = true
+
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Database Subnet
+resource "google_compute_subnetwork" "db" {
+  name          = "labs-asp-db-preview-shared"
+  ip_cidr_range = var.vpc_cidr_db
+  region        = local.region
+  network       = google_compute_network.preview_shared.id
+  description   = "Database subnet for preview environments"
+
+  private_ip_google_access = true
+
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Cloud Router for NAT Gateway
+resource "google_compute_router" "main" {
+  name    = "labs-asp-router-preview-shared"
+  region  = local.region
+  network = google_compute_network.preview_shared.id
+
+  bgp {
+    asn = 64515  # Different ASN from dev (64514)
+  }
+}
+
+# Static external IP for Cloud NAT
+resource "google_compute_address" "nat_static_ip" {
+  name         = "labs-asp-nat-ip-preview-shared"
+  region       = local.region
+  address_type = "EXTERNAL"
+  description  = "Static IP for Cloud NAT - shared by all preview environments"
+
+  labels = merge(local.common_labels, {
+    component = "cloud-nat"
+    purpose   = "external-api-whitelisting"
+  })
+}
+
+# Cloud NAT
+resource "google_compute_router_nat" "main" {
+  name                               = "labs-asp-nat-preview-shared"
+  router                             = google_compute_router.main.name
+  region                             = google_compute_router.main.region
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = [google_compute_address.nat_static_ip.self_link]
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
+# Serverless VPC Access Connector for Cloud Run
+resource "google_vpc_access_connector" "cloud_run" {
+  name          = "labs-conn-preview-shared"
+  region        = local.region
+  network       = google_compute_network.preview_shared.name
+  ip_cidr_range = var.vpc_connector_cidr
+  
+  machine_type = "e2-micro"
+  
+  min_instances = 2
+  max_instances = 10
+
+  depends_on = [
+    google_compute_network.preview_shared,
+    google_project_service.required_apis
+  ]
+}
+
+# Private Service Connection for Cloud SQL (if needed)
+resource "google_compute_global_address" "private_ip_range" {
+  name          = "labs-asp-private-ip-preview-shared"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.preview_shared.id
+
+  labels = merge(local.common_labels, {
+    purpose = "vpc-peering"
+  })
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = google_compute_network.preview_shared.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_range.name]
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# Data source to get dev VPC for peering
+data "google_compute_network" "dev_vpc" {
+  name    = "labs-asp-vpc-dev"
+  project = local.project_id
+}
+
+# VPC Peering: Preview Shared → Dev
+resource "google_compute_network_peering" "preview_to_dev" {
+  name         = "preview-shared-to-dev-peering"
+  network      = google_compute_network.preview_shared.id
+  peer_network = data.google_compute_network.dev_vpc.id
+
+  import_custom_routes = true
+  export_custom_routes = true
+
+  depends_on = [
+    google_compute_network.preview_shared,
+    google_service_networking_connection.private_vpc_connection
+  ]
+}
+
+# VPC Peering: Dev → Preview Shared
+resource "google_compute_network_peering" "dev_to_preview" {
+  name         = "dev-to-preview-shared-peering"
+  network      = data.google_compute_network.dev_vpc.id
+  peer_network = google_compute_network.preview_shared.id
+
+  import_custom_routes = true
+  export_custom_routes = true
+
+  depends_on = [
+    google_compute_network_peering.preview_to_dev
+  ]
+}
+
+# Firewall Rules
+resource "google_compute_firewall" "allow_internal" {
+  name    = "labs-asp-allow-internal-preview-shared"
+  network = google_compute_network.preview_shared.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = [
+    var.vpc_cidr_public,
+    var.vpc_cidr_private,
+    var.vpc_cidr_db,
+    var.vpc_connector_cidr,
+    "10.0.0.0/16"  # Allow traffic from dev VPC
+  ]
+
+  description = "Allow all internal communication within preview shared VPC and from dev VPC"
+}
+
+resource "google_compute_firewall" "allow_iap_ssh" {
+  name    = "labs-asp-allow-iap-ssh-preview-shared"
+  network = google_compute_network.preview_shared.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+
+  description = "Allow SSH via Identity-Aware Proxy"
+}
+
+resource "google_compute_firewall" "allow_health_checks" {
+  name    = "labs-asp-allow-health-checks-preview-shared"
+  network = google_compute_network.preview_shared.name
+
+  allow {
+    protocol = "tcp"
+  }
+
+  source_ranges = [
+    "35.191.0.0/16",
+    "130.211.0.0/22"
+  ]
+
+  description = "Allow health checks from Google Cloud load balancers"
+}
+

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,0 +1,112 @@
+# Google Cloud Storage Configuration
+#
+# Strategy:
+# - Dev: Creates and manages nava-storage-dev bucket
+# - Preview: References existing nava-storage-dev bucket (shared with dev)
+# - Prod: Creates and manages nava-storage-prod bucket (completely isolated from dev/preview)
+
+# Storage Bucket for DEV environment (only created by dev, not preview)
+resource "google_storage_bucket" "dev" {
+  count         = var.environment == "dev" ? 1 : 0
+  name          = "nava-storage-dev"
+  location      = local.region
+  force_destroy = false  # Prevent accidental deletion in dev
+
+  # Versioning
+  versioning {
+    enabled = true
+  }
+
+  # Lifecycle management
+  lifecycle_rule {
+    condition {
+      age = 30  # days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # Uniform bucket-level access
+  uniform_bucket_level_access = true
+
+  labels = merge(local.common_labels, {
+    environment = "dev"
+    purpose     = "artifacts"
+  })
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# Data source to reference existing dev bucket for preview environments
+data "google_storage_bucket" "dev" {
+  count = startswith(var.environment, "preview-") ? 1 : 0
+  name  = "nava-storage-dev"
+}
+
+# Storage Bucket for PROD environment (completely isolated)
+resource "google_storage_bucket" "prod" {
+  count         = var.environment == "prod" ? 1 : 0
+  name          = "nava-storage-prod"
+  location      = local.region
+  force_destroy = false  # Protect production bucket
+
+  # Versioning
+  versioning {
+    enabled = true
+  }
+
+  # Lifecycle management - longer retention for prod
+  lifecycle_rule {
+    condition {
+      age = 90  # days - longer retention for production
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # Uniform bucket-level access
+  uniform_bucket_level_access = true
+
+  labels = merge(local.common_labels, {
+    environment = "prod"
+    purpose     = "artifacts"
+  })
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# Unified local for bucket references
+locals {
+  storage_bucket_name = var.environment == "prod" ? (
+    google_storage_bucket.prod[0].name
+  ) : var.environment == "dev" ? (
+    google_storage_bucket.dev[0].name
+  ) : (
+    data.google_storage_bucket.dev[0].name  # Preview references existing dev bucket
+  )
+}
+
+# IAM binding for Cloud Run services to access DEV bucket (dev and preview)
+resource "google_storage_bucket_iam_member" "cloud_run_dev_access" {
+  count  = var.environment == "dev" || startswith(var.environment, "preview-") ? 1 : 0
+  bucket = var.environment == "dev" ? google_storage_bucket.dev[0].name : data.google_storage_bucket.dev[0].name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cloud_run.email}"
+
+  depends_on = [
+    google_storage_bucket.dev,
+    data.google_storage_bucket.dev
+  ]
+}
+
+# IAM binding for Cloud Run services to access PROD bucket
+resource "google_storage_bucket_iam_member" "cloud_run_prod_access" {
+  count  = var.environment == "prod" ? 1 : 0
+  bucket = google_storage_bucket.prod[0].name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cloud_run.email}"
+
+  depends_on = [google_storage_bucket.prod]
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,78 @@
+# GCP Project Configuration
+project_id = "nava-labs"
+region     = "us-central1"
+zone       = "us-central1-a"
+
+# Domain Configuration
+domain_name = "labs-asp.com"
+
+# Environment Selection (dev, preview, preview-pr-N, prod)
+environment = "dev"
+
+# VPC Network Configuration
+# These are set automatically by GitHub Actions based on environment
+# Dev: 10.0.0.0/16, Preview: 10.1.0.0/16, Prod: 10.2.0.0/16
+vpc_cidr_public      = "10.0.0.0/20"   # Public subnet (dev default)
+vpc_cidr_private     = "10.0.16.0/20"  # Private subnet (dev default)
+vpc_cidr_db          = "10.0.32.0/20"  # Database subnet (dev default)
+vpc_connector_cidr   = "10.0.48.0/28"  # VPC Connector (must be /28)
+
+# Firewall Configuration
+# Granular firewall rules per service with configurable ports and IPs
+firewall_rules = {
+  browser_mcp = {
+    port                = 8931           # Playwright MCP port
+    allow_public_access = true
+    allowed_ip_ranges   = ["0.0.0.0/0"]
+  }
+  browser_streaming = {
+    port                = 8933           # Browser WebSocket port
+    allow_public_access = true
+    allowed_ip_ranges   = ["0.0.0.0/0"]
+  }
+  mastra_api = {
+    port                = 4112           # AI Agents API port
+    allow_public_access = true
+    allowed_ip_ranges   = ["0.0.0.0/0"]
+  }
+}
+
+# Example: Production with custom ports and different rules per service
+# firewall_rules = {
+#   browser_mcp = {
+#     port                = 9931           # Custom port!
+#     allow_public_access = false
+#     allowed_ip_ranges   = ["203.0.113.0/24"]              # Office only
+#   }
+#   browser_streaming = {
+#     port                = 9933           # Custom port!
+#     allow_public_access = false
+#     allowed_ip_ranges   = ["203.0.113.0/24", "198.51.100.0/24"]  # Office + VPN
+#   }
+#   mastra_api = {
+#     port                = 5112           # Custom port!
+#     allow_public_access = false
+#     allowed_ip_ranges   = ["203.0.113.50/32"]             # Specific server only
+#   }
+# }
+
+# Browser VM Configuration
+browser_vm_machine_type = "e2-standard-2"  # 2 vCPUs, 8GB RAM
+browser_vm_disk_size    = 20                # GB
+browser_image_url       = "us-central1-docker.pkg.dev/nava-labs/labs-asp/browser-streaming:latest"
+
+# Mastra Service Configuration (AI Agent Backend)
+mastra_image_url     = "us-central1-docker.pkg.dev/nava-labs/labs-asp/mastra-app:latest"
+mastra_cpu           = "2"      # vCPUs
+mastra_memory        = "4Gi"    # RAM
+mastra_min_instances = 0        # Scale to zero
+mastra_max_instances = 10       # Max scale
+mastra_timeout       = 300      # 5 minutes for automation tasks
+
+# AI Chatbot Service Configuration (Next.js Frontend)
+chatbot_image_url     = "us-central1-docker.pkg.dev/nava-labs/labs-asp/ai-chatbot:latest"
+chatbot_cpu           = "1"     # vCPUs
+chatbot_memory        = "2Gi"   # RAM
+chatbot_min_instances = 0       # Scale to zero
+chatbot_max_instances = 5       # Max scale
+chatbot_timeout       = 60      # 1 minute for web requests

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,208 @@
+# Project configuration
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+  default     = "nava-labs"
+}
+
+variable "region" {
+  description = "The GCP region for resources"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "The GCP zone for VM instances"
+  type        = string
+  default     = "us-central1-a"
+}
+
+# Domain configuration
+variable "domain_name" {
+  description = "Base domain name for the application"
+  type        = string
+  default     = "labs-asp.navateam.com"
+}
+
+variable "enable_custom_domain" {
+  description = "Enable custom domain mapping (requires domain verification via Google Search Console)"
+  type        = bool
+  default     = false  # Default to false to avoid verification issues
+}
+
+# VM configuration (runs browser-streaming + mastra-app)
+variable "vm_machine_type" {
+  description = "Machine type for application VM"
+  type        = string
+  default     = "e2-standard-16"  # 16 vCPUs, 64GB RAM
+}
+
+variable "vm_disk_size" {
+  description = "Boot disk size for VM in GB"
+  type        = number
+  default     = 200  # Increased for Docker image storage and accumulated layers
+}
+
+variable "browser_image_url" {
+  description = "Container image URL for browser service"
+  type        = string
+  default     = "us-central1-docker.pkg.dev/nava-labs/labs-asp/browser-streaming:latest"
+}
+
+variable "mastra_image_url" {
+  description = "Container image URL for mastra-app service"
+  type        = string
+  default     = "us-central1-docker.pkg.dev/nava-labs/labs-asp/mastra-app:latest"
+}
+
+variable "browser_ws_proxy_image_url" {
+  description = "Container image URL for browser WebSocket proxy service"
+  type        = string
+  default     = "us-central1-docker.pkg.dev/nava-labs/labs-asp/browser-ws-proxy:latest"
+}
+
+# AI Chatbot Cloud Run configuration
+variable "chatbot_image_url" {
+  description = "Container image URL for AI chatbot service"
+  type        = string
+  default     = "us-central1-docker.pkg.dev/nava-labs/labs-asp/ai-chatbot:latest"
+}
+
+variable "chatbot_cpu" {
+  description = "CPU allocation for AI Chatbot Cloud Run service"
+  type        = string
+  default     = "2"  # 2 vCPUs for better concurrent request handling
+}
+
+variable "chatbot_memory" {
+  description = "Memory allocation for AI Chatbot Cloud Run service"
+  type        = string
+  default     = "8Gi"
+}
+
+variable "chatbot_min_instances" {
+  description = "Minimum instances for AI Chatbot service"
+  type        = number
+  default     = 2  # Keep instances warm to avoid cold starts during load testing
+}
+
+variable "chatbot_max_instances" {
+  description = "Maximum instances for AI Chatbot service"
+  type        = number
+  default     = 20
+}
+
+variable "chatbot_timeout" {
+  description = "Request timeout for AI Chatbot service in seconds"
+  type        = number
+  default     = 3600  # 1 hour maximum for AI agent workflows with browser automation
+}
+
+# Environment selection
+variable "environment" {
+  description = "Environment to deploy (dev, preview, preview-pr-N, prod)"
+  type        = string
+  default     = "dev"
+  validation {
+    condition     = can(regex("^(dev|preview|preview-pr-[0-9]+|prod)$", var.environment))
+    error_message = "Environment must be one of: dev, preview, preview-pr-NUMBER, or prod"
+  }
+}
+
+# VPC Network Configuration
+# These CIDR blocks should be defined per workspace in GitHub Actions
+variable "vpc_cidr_public" {
+  description = "CIDR block for public subnet (pattern: 10.X.0.0/16)"
+  type        = string
+  default     = "10.0.0.0/20"  # Default for dev if not overridden
+}
+
+variable "vpc_cidr_private" {
+  description = "CIDR block for private subnet (pattern: 10.X.16.0/16)"
+  type        = string
+  default     = "10.0.16.0/20"  # Default for dev if not overridden
+}
+
+variable "vpc_cidr_db" {
+  description = "CIDR block for database subnet (pattern: 10.X.32.0/16)"
+  type        = string
+  default     = "10.0.32.0/20"  # Default for dev if not overridden
+}
+
+variable "vpc_connector_cidr" {
+  description = "CIDR block for VPC Serverless Connector (must be /28)"
+  type        = string
+  default     = "10.0.48.0/28"  # Default for dev if not overridden
+  validation {
+    condition     = can(cidrhost(var.vpc_connector_cidr, 0)) && tonumber(split("/", var.vpc_connector_cidr)[1]) == 28
+    error_message = "VPC connector CIDR must be a /28 block"
+  }
+}
+
+# Firewall Configuration
+# Granular firewall rules per service with configurable ports
+variable "firewall_rules" {
+  description = "Firewall rules per service. Each service can have different ports and IP restrictions."
+  type = object({
+    browser_mcp = object({
+      port                = number
+      allow_public_access = bool
+      allowed_ip_ranges   = list(string)
+    })
+    browser_streaming = object({
+      port                = number
+      allow_public_access = bool
+      allowed_ip_ranges   = list(string)
+    })
+    mastra_api = object({
+      port                = number
+      allow_public_access = bool
+      allowed_ip_ranges   = list(string)
+    })
+  })
+  default = {
+    browser_mcp = {
+      port                = 8931
+      allow_public_access = true
+      allowed_ip_ranges   = ["0.0.0.0/0"]
+    }
+    browser_streaming = {
+      port                = 8933
+      allow_public_access = true
+      allowed_ip_ranges   = ["0.0.0.0/0"]
+    }
+    mastra_api = {
+      port                = 4112
+      allow_public_access = true
+      allowed_ip_ranges   = ["0.0.0.0/0"]
+    }
+  }
+}
+
+# Legacy variables for backward compatibility (deprecated)
+variable "allowed_ip_ranges" {
+  description = "DEPRECATED: Use firewall_rules instead. List of IP ranges allowed to access application services."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "allow_public_access" {
+  description = "DEPRECATED: Use firewall_rules instead. Allow public access (0.0.0.0/0) to application services."
+  type        = bool
+  default     = true
+}
+
+# Database passwords are stored in Secret Manager:
+# - nava-db-password-dev (for dev environment)
+# - database-password-prod (for prod environment)
+# No variable needed - passwords are retrieved from Secret Manager
+
+# Note: Preview environments use shared VPC with permanent peering to dev VPC
+# No need for dynamic VPC tracking variables
+
+# Feature flag for guest login (bypasses OAuth in preview environments)
+variable "use_guest_login" {
+  description = "Feature flag to enable guest login form for preview environments"
+  type        = string
+  default     = "false"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,383 @@
+# VPC Network Configuration
+# 
+# Strategy:
+# - Dev/Prod: Creates dedicated VPC for each environment
+# - Preview: Uses shared preview VPC (created in shared-preview-vpc/)
+#
+# Preview environments reference the existing shared VPC via data sources
+
+# Data sources for shared preview VPC (used by all preview-pr-* environments)
+data "google_compute_network" "preview_shared" {
+  count   = startswith(var.environment, "preview-") ? 1 : 0
+  name    = "labs-asp-vpc-preview-shared"
+  project = local.project_id
+}
+
+data "google_compute_subnetwork" "preview_public" {
+  count   = startswith(var.environment, "preview-") ? 1 : 0
+  name    = "labs-asp-public-preview-shared"
+  region  = local.region
+  project = local.project_id
+}
+
+data "google_compute_subnetwork" "preview_private" {
+  count   = startswith(var.environment, "preview-") ? 1 : 0
+  name    = "labs-asp-private-preview-shared"
+  region  = local.region
+  project = local.project_id
+}
+
+data "google_compute_subnetwork" "preview_db" {
+  count   = startswith(var.environment, "preview-") ? 1 : 0
+  name    = "labs-asp-db-preview-shared"
+  region  = local.region
+  project = local.project_id
+}
+
+data "google_vpc_access_connector" "preview_connector" {
+  count   = startswith(var.environment, "preview-") ? 1 : 0
+  name    = "labs-conn-preview-shared"
+  region  = local.region
+  project = local.project_id
+}
+
+# Main VPC Network (only for dev and prod)
+resource "google_compute_network" "main" {
+  count                   = startswith(var.environment, "preview-") ? 0 : 1
+  name                    = "labs-asp-vpc-${var.environment}"
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+  description             = "Main VPC network for labs-asp ${var.environment} environment"
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# Local values to reference VPC/subnets regardless of source (created or data source)
+locals {
+  vpc_network = startswith(var.environment, "preview-") ? (
+    data.google_compute_network.preview_shared[0]
+  ) : (
+    google_compute_network.main[0]
+  )
+  
+  public_subnet = startswith(var.environment, "preview-") ? (
+    data.google_compute_subnetwork.preview_public[0]
+  ) : (
+    google_compute_subnetwork.public[0]
+  )
+  
+  private_subnet = startswith(var.environment, "preview-") ? (
+    data.google_compute_subnetwork.preview_private[0]
+  ) : (
+    google_compute_subnetwork.private[0]
+  )
+  
+  db_subnet = startswith(var.environment, "preview-") ? (
+    data.google_compute_subnetwork.preview_db[0]
+  ) : (
+    google_compute_subnetwork.db[0]
+  )
+  
+  vpc_connector = startswith(var.environment, "preview-") ? (
+    data.google_vpc_access_connector.preview_connector[0]
+  ) : (
+    google_vpc_access_connector.cloud_run[0]
+  )
+}
+
+# Public Subnet - For resources that need direct internet access (only for dev/prod)
+resource "google_compute_subnetwork" "public" {
+  count         = startswith(var.environment, "preview-") ? 0 : 1
+  name          = "labs-asp-public-${var.environment}"
+  ip_cidr_range = var.vpc_cidr_public
+  region        = local.region
+  network       = google_compute_network.main[0].id
+  description   = "Public subnet for resources with internet access"
+
+  # Enable Private Google Access for API calls
+  private_ip_google_access = true
+
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Private Subnet - For internal resources (only for dev/prod)
+resource "google_compute_subnetwork" "private" {
+  count         = startswith(var.environment, "preview-") ? 0 : 1
+  name          = "labs-asp-private-${var.environment}"
+  ip_cidr_range = var.vpc_cidr_private
+  region        = local.region
+  network       = google_compute_network.main[0].id
+  description   = "Private subnet for internal resources"
+
+  # Enable Private Google Access for API calls without external IPs
+  private_ip_google_access = true
+
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Database Subnet - For Cloud SQL and database resources (only for dev/prod)
+resource "google_compute_subnetwork" "db" {
+  count         = startswith(var.environment, "preview-") ? 0 : 1
+  name          = "labs-asp-db-${var.environment}"
+  ip_cidr_range = var.vpc_cidr_db
+  region        = local.region
+  network       = google_compute_network.main[0].id
+  description   = "Database subnet for Cloud SQL and related services"
+
+  # Enable Private Google Access
+  private_ip_google_access = true
+
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Cloud Router for NAT Gateway (only for dev/prod, preview uses shared router)
+resource "google_compute_router" "main" {
+  count   = startswith(var.environment, "preview-") ? 0 : 1
+  name    = "labs-asp-router-${var.environment}"
+  region  = local.region
+  network = google_compute_network.main[0].id
+
+  bgp {
+    asn = 64514
+  }
+}
+
+# Static external IP for Cloud NAT (only for dev/prod)
+resource "google_compute_address" "nat_static_ip" {
+  count        = startswith(var.environment, "preview-") ? 0 : 1
+  name         = "labs-asp-nat-ip-${var.environment}"
+  region       = local.region
+  address_type = "EXTERNAL"
+  description  = "Static IP for Cloud NAT - used for external API whitelisting in ${var.environment} environment"
+
+  labels = merge(local.common_labels, {
+    environment = var.environment
+    component   = "cloud-nat"
+    purpose     = "external-api-whitelisting"
+  })
+}
+
+# Cloud NAT - Provides internet access for private subnet instances (only for dev/prod)
+resource "google_compute_router_nat" "main" {
+  count                              = startswith(var.environment, "preview-") ? 0 : 1
+  name                               = "labs-asp-nat-${var.environment}"
+  router                             = google_compute_router.main[0].name
+  region                             = google_compute_router.main[0].region
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = [google_compute_address.nat_static_ip[0].self_link]
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
+# Serverless VPC Access Connector for Cloud Run (only for dev/prod, preview uses shared connector)
+resource "google_vpc_access_connector" "cloud_run" {
+  count         = startswith(var.environment, "preview-") ? 0 : 1
+  name          = local.vpc_connector_name
+  region        = local.region
+  network       = google_compute_network.main[0].name
+  ip_cidr_range = var.vpc_connector_cidr
+  
+  # Connector machine type (f1-micro, e2-micro, or e2-standard-4)
+  machine_type = "e2-micro"
+  
+  min_instances = 2
+  max_instances = 10
+
+  depends_on = [
+    google_compute_network.main,
+    google_project_service.required_apis
+  ]
+}
+
+# Private Service Connection for Cloud SQL (only for dev/prod)
+# Preview uses the connection from shared VPC
+resource "google_compute_global_address" "private_ip_range" {
+  count         = startswith(var.environment, "preview-") ? 0 : 1
+  name          = "labs-asp-private-ip-${var.environment}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.main[0].id
+
+  labels = merge(local.common_labels, {
+    environment = var.environment
+    purpose     = "vpc-peering"
+  })
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  count                   = startswith(var.environment, "preview-") ? 0 : 1
+  network                 = google_compute_network.main[0].id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_range[0].name]
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# Firewall Rules (only for dev/prod, preview uses shared VPC firewalls)
+# Allow internal communication within VPC
+resource "google_compute_firewall" "allow_internal" {
+  count   = startswith(var.environment, "preview-") ? 0 : 1
+  name    = "labs-asp-allow-internal-${var.environment}"
+  network = google_compute_network.main[0].name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = [
+    var.vpc_cidr_public,
+    var.vpc_cidr_private,
+    var.vpc_cidr_db,
+    var.vpc_connector_cidr
+  ]
+
+  description = "Allow all internal communication within VPC"
+}
+
+# Allow SSH from IAP (Identity-Aware Proxy)
+resource "google_compute_firewall" "allow_iap_ssh" {
+  count   = startswith(var.environment, "preview-") ? 0 : 1
+  name    = "labs-asp-allow-iap-ssh-${var.environment}"
+  network = google_compute_network.main[0].name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  # IAP's IP range for SSH
+  source_ranges = ["35.235.240.0/20"]
+
+  description = "Allow SSH via Identity-Aware Proxy"
+}
+
+# Allow health checks from Google Cloud
+resource "google_compute_firewall" "allow_health_checks" {
+  count   = startswith(var.environment, "preview-") ? 0 : 1
+  name    = "labs-asp-allow-health-checks-${var.environment}"
+  network = google_compute_network.main[0].name
+
+  allow {
+    protocol = "tcp"
+  }
+
+  # Google Cloud health check IP ranges
+  source_ranges = [
+    "35.191.0.0/16",
+    "130.211.0.0/22"
+  ]
+
+  description = "Allow health checks from Google Cloud load balancers"
+}
+
+# Browser MCP access (internal only - accessed via Cloud Run → VPC → VM)
+# Preview environments use shared VPC firewall rules
+resource "google_compute_firewall" "browser_mcp" {
+  count   = 0
+  name    = "labs-asp-browser-mcp-${var.environment}"
+  network = google_compute_network.main[0].name
+
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.firewall_rules.browser_mcp.port)]
+  }
+
+  # Internal VPC access only - Cloud Run accesses via VPC Connector
+  source_ranges = [
+    var.vpc_cidr_public,
+    var.vpc_cidr_private,
+    var.vpc_cidr_db,
+    var.vpc_connector_cidr
+  ]
+
+  target_tags = ["browser-mcp"]
+
+  description = "Allow Playwright MCP access on port ${var.firewall_rules.browser_mcp.port} from internal VPC only (internal service)"
+}
+
+# Browser Streaming WebSocket access (internal only - accessed via Cloud Run browser-ws-proxy → VPC → VM)
+resource "google_compute_firewall" "browser_streaming" {
+  count   = 0
+  name    = "labs-asp-browser-streaming-${var.environment}"
+  network = google_compute_network.main[0].name
+
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.firewall_rules.browser_streaming.port)]
+  }
+
+  # Internal VPC access only - browser-ws-proxy Cloud Run accesses via VPC Connector
+  source_ranges = [
+    var.vpc_cidr_public,
+    var.vpc_cidr_private,
+    var.vpc_cidr_db,
+    var.vpc_connector_cidr
+  ]
+
+  target_tags = ["browser-streaming"]
+
+  description = "Allow browser streaming WebSocket access on port ${var.firewall_rules.browser_streaming.port} from internal VPC only (internal service)"
+}
+
+# Legacy API access (configurable port, only for dev/prod)
+resource "google_compute_firewall" "mastra_app" {
+  count   = 0
+  name    = "labs-asp-mastra-app-${var.environment}"
+  network = google_compute_network.main[0].name
+
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.firewall_rules.mastra_api.port)]
+  }
+
+  # Combine internal VPC ranges with allowed external ranges
+  source_ranges = concat(
+    [
+      var.vpc_cidr_public,
+      var.vpc_cidr_private,
+      var.vpc_connector_cidr
+    ],
+    var.firewall_rules.mastra_api.allow_public_access ? ["0.0.0.0/0"] : var.firewall_rules.mastra_api.allowed_ip_ranges
+  )
+
+  target_tags = ["mastra-app"]
+
+  description = "Allow Mastra API access on port ${var.firewall_rules.mastra_api.port} from VPC and approved external IPs"
+}
+
+# ============================================================================
+# VPC Peering Configuration
+# ============================================================================
+# 
+# Note: VPC peering for preview environments is now managed in shared-preview-vpc/
+# All preview environments use a shared VPC that has permanent peering with dev VPC
+# 
+# This eliminates the need for dynamic peering creation/destruction per preview environment
+


### PR DESCRIPTION
Migrates the deploy pipeline from navapbc/labs-asp so this repo deploys itself, eliminating the paired-PR submodule workflow.

**Zero infrastructure change**: same terraform config, same GCS state backend (`labs-asp-terraform-state`), same WIF provider and deploy service account, same Artifact Registry images and Cloud Run service names.

### Changes from the labs-asp originals
- **Dockerfile**: `COPY . ./client/` instead of `COPY client/ ./client/` — internal `/app/client` layout, build args, and startup command unchanged, so the runtime image is behaviorally identical
- **deploy.yml**: no submodule checkout; dropped the paths-filter step (its outputs were never consumed)
- **promote.yml**: no submodule checkout
- **code-quality.yml**: kept PR-title + YAML checks; dropped the lint loop (covered by `lint.yml`) and the audit loop (it skipped the repo root, so it never ran on this code)
- **github-actions-auth.tf**: WIF impersonation binding is now `for_each` over `[ai-chatbot, labs-asp]`, with a `moved` block for existing state
- **validate-submodule.yml**: not ported (obsolete — this PR removes the need for it)

### Prerequisite
The WIF impersonation binding for `navapbc/ai-chatbot` on `github-actions-deploy@nava-labs.iam.gserviceaccount.com` is required before CI runs — **already applied**.

### How this is tested
This PR deploys its own `preview-pr-N` environment via the ported pipeline — a green preview deploy is the end-to-end proof.

### Follow-up after merge
- Disable `deploy.yml` / `cleanup-preview.yml` / `promote.yml` in labs-asp so two repos never drive the same terraform state
- Remove the `client` submodule from labs-asp