### PR TITLE
chore: add semantic-release config from labs-asp

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,33 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {"type": "feat", "release": "minor"},
+          {"type": "fix", "release": "patch"},
+          {"type": "perf", "release": "patch"},
+          {"type": "revert", "release": "patch"},
+          {"type": "docs", "release": false},
+          {"type": "style", "release": false},
+          {"type": "chore", "release": false},
+          {"type": "refactor", "release": false},
+          {"type": "test", "release": false},
+          {"type": "build", "release": false},
+          {"type": "ci", "release": false}
+        ]
+      }
+    ],
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
Ports `.releaserc.json` from labs-asp `main` (it was never on develop, so it was missed in #273).

Removed the `@semantic-release/changelog` + `@semantic-release/git` plugins: they push a `chore(release)` commit with CHANGELOG.md directly to `main`, which this repo's branch protection (required PRs + enforce_admins) rejects. Release notes are published on GitHub Releases instead — same generated content, no protected-branch fight.

Versioning continues from labs-asp: `v1.14.0` is seeded on `main` (matching what prod runs today), so the first release from this repo will be `v1.15.0`.