### PR TITLE
feat: form-completion skill + masked-field fix for agent-browser prompts

### DIFF
--- a/.claude/skills/form-completion/SKILL.md
+++ b/.claude/skills/form-completion/SKILL.md
@@ -17,8 +17,10 @@ is no global installation. To attach to a local Chrome, read the
 
 **When one run has two or more applications**, read `references/multi-application.md`
 first. The main session becomes the orchestrator: it does the intake for all the
-applications, then starts one fill agent for each application in parallel. Each fill
-agent gets its own browser. Do not give one page to two writers.
+applications, then starts one fill agent for each application in parallel. For an
+application with no playbook, a background scout agent surveys the site — the
+orchestrator stays with the user and does not survey a site itself. Each fill agent
+gets its own browser. Do not give one page to two writers.
 
 ## Phase 0 — Find the Playbook
 
@@ -224,8 +226,8 @@ form. The user is not a developer.
 - `references/knowledge-scribe.md` — the parallel background agent that writes the
   playbook during a cold start; start it in Phase 0
 - `references/multi-application.md` — two or more applications in one run: the
-  orchestrator role, one fill agent for each application, browser isolation, and
-  submit gates for each application
+  orchestrator role, scouts for cold-start discovery, one fill agent for each
+  application, browser isolation, and submit gates for each application
 - `references/silent-failures.md` — the four-step diagnosis with commands
 - `playbooks/<domain>.md` — one file for each site; the scribe writes it on a cold
   start (you write it at the end of the run only when there is no scribe)

--- a/.claude/skills/form-completion/SKILL.md
+++ b/.claude/skills/form-completion/SKILL.md
@@ -35,6 +35,11 @@ If the file is available:
    tool calls.
 3. If an id is missing, the site changed. Use the cold-start procedure. Write the
    playbook again.
+4. **A partial playbook also needs the scribe.** Read the playbook for the word
+   UNCONFIRMED. When the playbook marks pages or sections UNCONFIRMED and the fill
+   will enter them, start the scribe (cold-start step 1) before the fill. The run
+   makes new site facts in that territory, and without a scribe they are lost. A
+   playbook with no UNCONFIRMED parts needs no scribe.
 
 If the file is not available, use the cold-start procedure:
 

--- a/.claude/skills/form-completion/SKILL.md
+++ b/.claude/skills/form-completion/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: form-completion
+description: Complete, test, or debug a web form with agent-browser — application, benefits, or government forms, multi-step apply flows, or any site form filling. Use when asked to fill out a form, apply on a website, drive agent-browser against a page, or when a form field silently fails to fill (fill reports done but the value shows __/__/____ or stays empty).
+---
+
+# Form Completion With agent-browser
+
+This skill gives a procedure to fill a web form on a website. Do the phases in
+sequence. Each rule comes from a failure that occurred in a real session.
+
+The most dangerous failure is the silent success. The tool shows `✓ Done`, but the
+field stays empty. Phase 4 finds these failures. Do not skip Phase 4.
+
+Use the binary `./node_modules/.bin/agent-browser` from the `client/` directory. There
+is no global installation. To attach to a local Chrome, read the
+`agent-browser-local-cdp-setup` memory.
+
+**When one run has two or more applications**, read `references/multi-application.md`
+first. The main session becomes the orchestrator: it does the intake for all the
+applications, then starts one fill agent for each application in parallel. Each fill
+agent gets its own browser. Do not give one page to two writers.
+
+## Phase 0 — Find the Playbook
+
+Look in the `playbooks/` directory of this skill for a file with the domain name of the
+target site. Example: `playbooks/forms.example.org.md`.
+
+If the file is available:
+
+1. Do the freshness probe. Use `get count` on two or three known `#id` selectors from
+   the playbook.
+2. If all the ids are present, obey the playbook. The warm path uses approximately six
+   tool calls.
+3. If an id is missing, the site changed. Use the cold-start procedure. Write the
+   playbook again.
+
+If the file is not available, use the cold-start procedure:
+
+1. **Start the knowledge scribe.** The scribe is a background agent. It reads this
+   session's transcript from disk and writes the playbook, the scripts, and the
+   reference updates in parallel while you fill the form. The start procedure and
+   the prompt template are in `references/knowledge-scribe.md`.
+2. **Do not write the playbook, scripts, or references yourself during the run.**
+   The scribe owns those files while it runs. You fill the form. This keeps the
+   full session time on the form. If the scribe fails or is not available, finish
+   the fill first and write the playbook at the end — never stop the fill to write
+   documentation.
+3. When the scribe's completion report arrives, relay its file list in your final
+   report.
+
+The playbook structure (the scribe follows this; you follow it in the no-scribe
+fallback):
+
+- The final form URL and the pages between the entry URL and the form
+- The list of required fields, compared with the usual data payload
+- A field table: id, type, maxLength, mask condition, fill method
+- The gates, the effect of each gate answer, and the fill sequence
+- The exact text of each select option
+- The condition that enables the submit button
+- Two or three stable `#id` selectors for the freshness probe
+
+## Phase 1 — Find the Form
+
+The URL you receive can be a landing page and not the form. Use `snapshot -i -u` to
+show the links with their URLs. Follow the apply, continue, or start links until form
+fields show.
+
+Do a signal test before you fill a field. Examine the id and name prefixes of the
+inputs you count. Widgets add inputs to a page. Examples: Google Translate
+(`goog-gt-*`), chat widgets, cookie banners. If all the inputs belong to widgets, the
+page has no form. The result of `get count input` alone is not sufficient.
+
+## Phase 2 — Show the Gap Analysis, Then Ask the User
+
+Read `references/gap-analysis-and-provenance.md` for the formats and the rules.
+
+1. Make a list of the fields. Use the `FIELDS` helper in `scripts/fill-helpers.sh`.
+   It gives every field with its type, id, value, and label in ONE tool call. Do not
+   scan with `get count` loops. Do not use `eval`. Use selectors in this sequence of
+   preference: `#id`, then `[name=…]`, then `@eN` refs. Refs become invalid after the
+   DOM changes. Refs cannot identify repeated Yes/No pairs.
+2. Find the required markers: `*` in labels, `required`, `aria-required`. Compare the
+   required fields with the available data.
+3. **Show the user the gap-analysis table first.** The table has five groups: READY,
+   DERIVED, GAP-REQUIRED, GAP-DECISION, NO-FIELD. The user must see what you have,
+   what you will change, and what you do not have.
+4. **Each session is a new participant.** Ask for each missing required value in
+   each session. Do not reuse participant answers from an earlier session. Only site
+   facts persist, and they persist in the playbook.
+5. **Ask for the value, not for instructions.** A gap question collects data for a
+   field. Example: "What is Maria's Social Security Number?" Do not ask the user
+   how to handle a missing value. The formats and the input-type rules are in
+   `references/gap-analysis-and-provenance.md`.
+6. Ask all the gap questions in this phase, before the fill. One `AskUserQuestion`
+   call holds a maximum of four questions. If there are more gaps, use two or more
+   calls in sequence. **Do not guess the answers that did not fit in one call.**
+   Questions during the fill are the primary cause of a bad user experience.
+7. **Write the questions in plain language.** The user completes a form. The user is
+   not a developer. Do not put element ids, selectors, character limits, or browser
+   terms in a question.
+8. Do not invent a value for a required field. A "common baseline" or a "reasonable
+   default" is an invented value. If the user gives no answer, keep the field empty
+   and show it in the final report. Do not use an identifier that looks similar. A
+   case number is not an SSN.
+9. Treat all data as real data. Do not ask if the data is real or test data. The
+   submit step always needs approval. That approval is the protection.
+
+## Phase 3 — Fill the Fields in Gate Sequence
+
+- Answer the master gates first. Fill from the top of the form to the bottom. A field
+  behind an unanswered gate accepts commands and shows success, but the field does not
+  change.
+- Read the question text before you answer a gate. You cannot know the polarity
+  without the text. Example: "Same as above?" with the answer "Yes" hides the related
+  block. A hidden block is correct in this case. Do not fill it.
+- Use `check` and `uncheck` for checkboxes. These commands are idempotent. Do not use
+  `click` on a checkbox. The `click` command changes the state each time. Two clicks
+  set the initial state again. Yes/No pairs are frequently independent checkboxes.
+  Both can become unchecked. Read the full pair again after you write it.
+- Get the list of options before you use `select`. Match the option text exactly. A
+  data value of "Hispanic/Latino" does not match an option of "Hispanic". The
+  `get value` command on a select returns the option index, not the text.
+- Put all the write commands in one Bash call. Use `scripts/fill-helpers.sh`. Then do
+  one readback of all the fields. Do not use one tool call for each field.
+
+## Phase 4 — Make Sure That Each Write Is Correct
+
+Read each field again after you write it. Use `get value` and `is checked`. Compare
+the result with the intended value.
+
+If a value is empty or not correct, do the four-step diagnosis in
+`references/silent-failures.md`. The sequence is: disabled, hidden, masked, maxLength.
+Do the steps in this sequence before you try other solutions.
+
+Masked fields need one `key` command for each character. The `fill` and `type`
+commands fail on masks that monitor keydown events. These commands show success when
+they fail.
+
+Do not use an old snapshot after the DOM changes. The ref labels become incorrect. Use
+`get text` or `is visible` with a CSS selector.
+
+## Phase 5 — Exceptions
+
+Test a possible cause before you record it or act on it. Two incorrect diagnoses
+occurred in a real session: a bot check was blamed for a disabled submit button, but
+the cause was a closed affirmation section; a correctly hidden block was identified as
+a defect. When the scribe runs, it records each solved exception from the transcript —
+continue with the fill. Without a scribe, add the exception to the playbook at the end
+of the run.
+
+## Phase 6 — Submit Only With Approval From the User
+
+**WARNING: Do not click submit without explicit approval from the user. A live
+application has legal effect. If the values look like test data, tell the user in
+one sentence in the report. The decision is the user's.**
+
+If the submit button is disabled, find the condition that enables it on this site. Do
+not assume the condition. Possible causes: a required field is empty, a consent
+checkbox is not set, a disclosure section is not open, a bot challenge is not
+complete. Test one possible cause at a time. Use `is enabled` after each test to find
+the cause. Record the condition in the playbook.
+
+Do not try to defeat a bot challenge (Turnstile, reCAPTCHA). Make sure that the
+challenge is the cause before you identify it as the cause. If the challenge is the
+cause, stop. Tell the user.
+
+Before the submit step, show the user the provenance report. The format is in
+`references/gap-analysis-and-provenance.md`. The report gives each value in the form
+and its source: USER, PAYLOAD, DERIVED, or EMPTY. There is no ASSUMED source. If a
+value has no traceable source, remove it from the form. After the report, list the
+unused payload values, the empty required fields with reasons, and the new playbook
+facts from this session. Then get explicit approval.
+
+## Rules for New Findings
+
+This file and `references/` contain only two types of content: agent-browser tool
+behavior, and patterns confirmed on more than one site.
+
+Write a finding from one site in the playbook of that site. Identify it as the
+behavior of that site. Do not write it in this file. Move a pattern to this file only
+after you see it on a different site. Write a moved pattern as a check ("check
+whether…"). Do not write it as an expectation ("expect…", "usually…").
+
+Do not put program names, site names, or real field ids from one site in this file,
+in `references/`, or in `scripts/`. Those names bias the general procedure toward a
+few applications. The product covers more than 100 application websites. Use neutral
+examples: `forms.example.org`, `#firstName`, "Maria". Program names belong in
+playbooks only.
+
+## How to Talk to the User
+
+Every message to the user — progress updates, reports, and questions — uses plain
+language at an easy reading level (approximately grade 6). The user completes a
+form. The user is not a developer.
+
+- Do not show selectors, element ids, ref numbers, browser terms, session names, or
+  tool output to the user.
+- Use the person's name and the words that the form shows.
+- When an agent report has a FOR THE USER section, show that section without change.
+- Technical detail goes in three places only: the transcript, the playbooks, and the
+  references. The scribe and the fill agents hold the technical knowledge. The main
+  session translates nothing — it relays plain sections and asks plain questions.
+
+## Tool Rules
+
+- Use the typed commands. Do not use `eval`. The `eval` command puts unknown
+  JavaScript into a third-party page. Typed commands: `is visible|enabled|checked`,
+  `get value|text|attr|count`, `snapshot -i -u`, `screenshot out.png --annotate`. The
+  `--annotate` option prints a legend: `[N] @eN role "name"`.
+- Read `<command> --help` before you use a flag. The argument sequence of `get attr`
+  is `<selector> <name>`. The full-page screenshot flag is `--full`. The tool reads an
+  unknown flag as a positional argument. If a command fails, examine your syntax
+  first.
+- Use CSS selectors only. XPath is not supported and can give a silent no-op success.
+  A selector with `[id=X]` finds only the first element with that id — see
+  `references/silent-failures.md` for duplicate-id checkbox groups.
+- The daemon keeps sessions with the `--session <name>` key. The `@eN` refs stay valid
+  across CLI calls in one session.
+
+## References
+
+- `references/gap-analysis-and-provenance.md` — the two mandatory reports: the
+  gap-analysis table before the fill, the provenance report before the submit step
+- `references/knowledge-scribe.md` — the parallel background agent that writes the
+  playbook during a cold start; start it in Phase 0
+- `references/multi-application.md` — two or more applications in one run: the
+  orchestrator role, one fill agent for each application, browser isolation, and
+  submit gates for each application
+- `references/silent-failures.md` — the four-step diagnosis with commands
+- `playbooks/<domain>.md` — one file for each site; the scribe writes it on a cold
+  start (you write it at the end of the run only when there is no scribe)
+- `scripts/fill-helpers.sh` — helpers for batch fill, keypress fill, and readback

--- a/.claude/skills/form-completion/playbooks/benefitscal.com.md
+++ b/.claude/skills/form-completion/playbooks/benefitscal.com.md
@@ -1,0 +1,397 @@
+# Playbook: benefitscal.com (California CalFresh/SNAP Application)
+
+Scout survey and five fill-agent passes, 2026-08-05, with agent-browser 0.33.2.
+Cold start. The fill agent reached a Citizenship question (page 24 of the
+chain below) and confirmed the program-selection step narrows the flow to
+CalFresh only. It stopped there, and four times before, on forbidden data
+categories. The rest of "Your Information" and Sections 2 through 8 are
+UNCONFIRMED.
+
+**WARNING: This is a live government benefits form. Do not submit test data. Do not
+submit without explicit approval from the user.**
+
+**Freshness probe.** Each command below must return 1. If a command does not return 1,
+the site changed. Use the cold-start procedure. Write this file again.
+
+```bash
+agent-browser get count "#primarylang"
+agent-browser get count "#addressLine1"
+agent-browser get count "#zip5"
+```
+
+## URL Chain — Twenty-Four Pages Confirmed So Far
+
+```
+ 1. https://benefitscal.com/                                        home page
+ 2. .../ApplyForBenefits/begin/ABOVR?lang=en                         interstitial: "Here's how it works"
+ 3. .../ApplyForBenefits/ABHLT                                       "Helpful Tips" — has an account offer, and a no-account path
+ 4. .../ApplyForBenefits/ABDEI                                       "Diversity, Equity, and Inclusion Statement" — text only
+ 5. .../ApplyForBenefits/ABSNC                                       optional mood check — none of the choices are required
+ 6. .../ApplyForBenefits/ABNAV                                       "Application Summary" — the master section list
+ 7. .../ApplyForBenefits/ABLPR                                       "Language Preferences"
+ 8. .../ApplyForBenefits/ABNMI                                       "Name Information"
+ 9. .../ApplyForBenefits/ABNHA                                       "Home Address" — has a gate, an address-check modal, a county picker
+10. .../ApplyForBenefits/ABMAD                                       "Mailing Address" — gate: same as home?
+11. .../ApplyForBenefits/ABCON                                       "Contact Information" — phone and email
+12. .../ApplyForBenefits/ABCOP                                       "Contact Preferences" — text/email alert opt-in
+13. .../ApplyForBenefits/ABPRI                                       "Select Benefit Programs" — narrows the rest of the flow
+14. .../ApplyForBenefits/ABCSD                                       "CalFresh Submit App Divider" — an informational nudge page
+15. .../ApplyForBenefits/ABDIS                                       "Disability" — a forbidden data category, answered after the user confirmed
+16. .../ApplyForBenefits/ABCOS                                       "College Student" — a forbidden data category, answered after the user confirmed
+17. .../ApplyForBenefits/ABCFA                                       "CalFresh Authorized Rep" — "authorize someone to help with your case?"
+18. .../ApplyForBenefits/ABCFS                                       "CalFresh Spend Benefits" — "name someone to get/spend your benefits?"
+19. .../ApplyForBenefits/ABRDT                                       "Birthdate" — a MASKED field, see below
+20. .../ApplyForBenefits/ABSSN                                       "SSN" — a three-way status gate, answered after the user confirmed
+21. .../ApplyForBenefits/ABSNA                                       "SSN A" — the actual SSN digit-entry page, a MASKED field
+22. .../ApplyForBenefits/ABMRS                                       "Marital Status" — a radio group of 8 options
+23. .../ApplyForBenefits/ABCID                                       "Citizenship Immigration Divider" — an informational nudge page, no fields
+24. .../ApplyForBenefits/ABDOC                                       page title "Citizenship" — CONFIRMED STOP POINT. Note: the URL slug (ABDOC) does not match the page title or topic.
+```
+
+**Do not trust the URL slug as the page topic.** `ABDOC` asks about citizenship,
+not "documents." Read the page title and heading to identify a page, not its
+URL segment.
+
+Click through in this order: APPLY FOR BENEFITS -> BEGIN -> Next -> Next -> Next
+(without a mood choice) -> Start Your Information -> Next through ABLPR, ABNMI,
+ABNHA (plus its modal and dialog, see below), ABMAD, ABCON, ABCOP, ABPRI -> on
+ABCSD click "CONTINUE APPLICATION", **not** the "Skip and submit now (not
+recommended)" link -> Next through ABDIS, ABCOS, ABCFA, ABCFS, ABRDT.
+
+**Ids on this site are sometimes generic and do not name the question they
+belong to.** Confirmed on `ABCFA` (id `filingTax` for a "authorize a
+representative" question — nothing to do with tax filing) and `ABCFS` (id
+`select_group` for a "name someone to spend your benefits" question). Do not
+guess a field's purpose from its id. Always confirm the Yes/No mapping by
+reading the visible label text, not by id name or by position.
+
+**Two different markup patterns carry the label text — check both.** Most
+radio pairs use `<label for="<id>">`. Confirmed on `ABSSN`: that page instead
+uses `aria-labelledby` pointing at a separate `<span id="..._inner_label">`
+with the visible text. A selector that only checks `for=` can miss the label
+on a page built this way. If a `for=` lookup finds nothing, check
+`aria-labelledby` and its target span next before you conclude the page has no
+accessible label.
+
+The page advance button on these pages has no id. Match it by its visible text,
+"Next" (or "CONTINUE APPLICATION" on `ABCSD`).
+
+**The site keeps entered data when you navigate back.** A fill agent went back
+five pages (from `ABDIS` through `ABNMI`) with the site's own "Back to Previous
+Page" button to fix a field, then re-advanced through every page again. Every
+value it had entered on the pages in between was still there. Back navigation is
+safe to use for a correction on this site.
+
+**The step counter changes when the program selection narrows.** Before
+`ABPRI`, pages show "Step 1 of 9". After a fill agent chose CalFresh only on
+`ABPRI`, the counter became "Step 1 of 8" from `ABCSD` onward. Do not treat a
+changed step count as a sign of a broken fill — read it as a sign of which
+programs are selected.
+
+## Account Requirement — None, if You Take the Right Path
+
+The "Helpful Tips" page (`ABHLT`) offers a "Create an account now" link. IGNORE it.
+The same page has a "Next" button that continues WITHOUT an account. Confirmed
+2026-08-05: the scout reached the first form page with no account and no login.
+
+## Section List (From the Application Summary Page, `ABNAV`)
+
+This page is the master progress list for the whole application. Section 2 was
+disabled at scout time (labeled "People Not Available") until Section 1 has data
+in it.
+
+| # | Section | Status |
+|---|---|---|
+| 1 | Your Information | REACHED |
+| 2 | People | UNCONFIRMED — button disabled until Section 1 has data |
+| 3 | Household Details | UNCONFIRMED |
+| 4 | Income | UNCONFIRMED |
+| 5 | Expenses | UNCONFIRMED |
+| 6 | Assets | UNCONFIRMED |
+| 7 | Other Situations | UNCONFIRMED |
+| 8 | Document Upload | UNCONFIRMED |
+| 9 | Review & Submit | UNCONFIRMED |
+
+The first form page (`ABLPR`) also shows its own "Step 1 of 9" sub-stepper inside
+Section 1. Steps 2 to 9 of this inner sequence are also UNCONFIRMED.
+
+## Field Table — Page `ABLPR` ("Language Preferences")
+
+| id | type | Label | Required | Fill method | Notes |
+|---|---|---|---|---|---|
+| `primarylang` | select | What language do you prefer to read? | required | select by exact text | Shows a "-Select One-" placeholder, but `get value` reads `03` (English) as the current selection at page load — confirm with `option:checked` before you trust a default |
+| `spokenlang` | select | What language do you prefer to speak? | required | select by exact text | Same option list as `primarylang`, plus "American Sign Language" |
+| `applang` | select | In what language would you like to complete this application? | required | select by exact text | Pre-selected to English (value `03`), no "-Select One-" placeholder. Shorter option list than the other two selects — check the option text is in THIS list before you select |
+
+No text `input` fields are on this page (`get count input` returned 0). One
+`iframe` is present: an "Ask Robin" chat-assistant widget
+(`daghqzwjxmect.cloudfront.net`) — not a form field, do not enter data in it. A
+"Need Language Help?" accordion is present with no additional fields observed.
+
+Confirmed by a fill agent: when the record language is English, all three selects
+already default to English. No write is needed — read each with
+`get text "#id option:checked"` to confirm, then move on.
+
+No county selector is on this page.
+
+## Field Table — Page `ABNMI` ("Name Information")
+
+| id | type | Label | Required | Fill method | Notes |
+|---|---|---|---|---|---|
+| `text1` | text | First Name | required | fill | |
+| `text2` | text | Middle Name | optional | fill | |
+| `text3` | text | Last Name | required | fill | See the suffix note below before you put a suffix word here |
+| `suffix` | select | Suffix | optional | select by exact text | Options: I, II, III, IV, V, VI, VII, VIII, IX, X, Jr., Sr. |
+| `text4` | text | Other Names | optional | fill, or leave empty | |
+
+**A suffix such as "II" has its own dropdown. Do not append it to the last name.**
+A fill on this site put a last name and its suffix word whole into `text3`
+(example: "Smith II") because the source value carried the suffix as part of the
+last name. The site has a `suffix` select with a matching "II" option. Split a
+last-name value that ends in a suffix word (II, III, Jr., Sr., and so on) between
+`text3` and `suffix`.
+
+The ids `text1` to `text4` are generic and not name-derived. The `FIELDS` helper's
+HTML-based labels can misread them, because this page's markup puts placeholder
+text before the real label. Cross-reference with `snapshot -i -u` for the true
+label of each box on this page.
+
+## Field Table — Page `ABNHA` ("Home Address")
+
+| id | type | Label | Required | Fill method | Notes |
+|---|---|---|---|---|---|
+| `radioCard_0` / `radioCard_1` | radio | Are you experiencing homelessness? | appears required, a gate | check | Yes = `radioCard_0`, No = `radioCard_1`. This is a GAP-DECISION — the usual payload has no housing-status value. Do not derive it from an address on file (see `references/gap-analysis-and-provenance.md`, "Values You Must Not Derive"). Ask the user. |
+| `addressLine1` | text | Address Line 1 | required | fill | |
+| `addressLine2` | text | Address Line 2 | optional | fill | |
+| `city` | text | City | required | fill | |
+| `state` | select | State | required | none — DISABLED | Pre-set to California and locked. This site serves California only. Do not try to change it. |
+| `zip5` | text | Zip Code | required | fill | |
+
+**The homelessness gate sits above the address fields in the DOM, but does not
+hide or disable them.** A fill agent filled every address field while the gate
+was unanswered, and every fill succeeded. This is different from a hide-on-gate
+site: read the gate's own answer requirement from the Next-button behavior, not
+from whether the address fields accept a fill. Confirmed value mapping: No =
+`radioCard_1`.
+
+**`zip5` can read back empty right after the homelessness radio is checked, even
+though the ZIP was correct moments before.** Confirmed once in one run — not
+yet seen a second time. Re-read `zip5` right before you click Next, and refill
+it if it is empty. Treat this as a possible site quirk on this page, not a
+one-time fluke, until a second run confirms or clears it.
+
+**An address-check modal can appear after Next on this page.** If the entered
+address does not match the site's validation data (for example, a test
+address), a modal opens: heading "We can't validate your address. Let's double
+check if it's right.", a pre-checked radio "Address You Entered", a button "USE
+THIS ADDRESS", and a link "Correct my address". Click "USE THIS ADDRESS" to
+keep the address exactly as entered. Do NOT click "Correct my address" — that
+lets the site rewrite the value the user gave.
+
+**A county picker can appear after the address modal.** If the site cannot
+derive the county from the address, a dialog opens: heading "What county are
+you currently in?", a required `select#county`, and a "CONTINUE" button. Select
+the county by exact option text (confirmed: "Riverside"), then verify with
+`get text "#county option:checked"`.
+
+**Confirmed stop point (first pass):** a fill agent stopped on this page with
+the homelessness gate unanswered, and did not click Next. A second pass, after
+the user answered No, passed through the modal and the county picker
+successfully and continued to `ABMAD`.
+
+## Field Table — Page `ABMAD` ("Mailing Address")
+
+| id | type | Label | Required | Fill method | Notes |
+|---|---|---|---|---|---|
+| `mailadr1_radio_0` (Y) / `mailadr1_radio_1` (N) | radio | Do you get your mail at a different address? | gate, no default | check | **Inverse polarity: "No" means the mailing address is the SAME as home.** Selecting No shows no extra text block (confirmed). Selecting Yes is UNCONFIRMED — expected to reveal a mailing-address block, not yet tested. |
+
+## Field Table — Page `ABCON` ("Contact Information")
+
+| id | type | Label | Required | Fill method | Notes |
+|---|---|---|---|---|---|
+| `homePhone` | text | Home Phone | optional | fill, or leave empty | |
+| `mobilePhone` | text | Mobile Phone | optional | fill | Ten digits go in; confirmed the site auto-formats to `(NNN) NNN-NNNN` on a plain `fill` — no mask helper needed here |
+| `altPhone` | text | Work Phone/Alternate Phone | optional | fill, or leave empty | |
+| `mail` | text | Email | optional, maxlength 100 | fill | This id is reused with a different role on `ABCOP` — see the warning below |
+
+## Field Table — Page `ABCOP` ("Contact Preferences")
+
+| id | type | Label | Required | Fill method | Notes |
+|---|---|---|---|---|---|
+| `mail` | checkbox | Email (alert opt-in) | optional | check, or leave clear | **Same id `mail` as the EMAIL TEXT FIELD on `ABCON` — a different page, a different element, a different role (checkbox here, not text).** Confirm which page you are on before you use `#mail`. |
+| `phone` | checkbox | Text Message (alert opt-in) | optional | check, or leave clear | |
+| `acceptance_agreement` | checkbox | Terms/Privacy acceptance | disabled by default | none — becomes enabled only when an alert box above it is checked (UNCONFIRMED which one) | |
+
+Neither alert checkbox has an HTML `required` attribute, and the Next button
+stayed enabled with both clear. This page's checkboxes are a contact
+PREFERENCE, not a required field — the skill's "Values You Must Not Derive"
+rule against inventing a contact preference still applies: leave both clear
+unless the user states a preference.
+
+## Field Table — Page `ABPRI` ("Select Benefit Programs")
+
+| id | type | Label | Required | Fill method | Notes |
+|---|---|---|---|---|---|
+| `snap` | checkbox | Food (CalFresh) | part of a required group (pick at least one) | check | Independent of the other two — CalFresh alone is a valid, uncontested selection |
+| `tanf` | checkbox | Cash Aid (CalWORKs, TCVAP, RCA) | part of the same group | check, or leave clear | |
+| `medicaid` | checkbox | Health Coverage (Medi-Cal) | part of the same group | check, or leave clear | |
+| `label_0` (Y) / `label_1` (N) | radio | Are you applying for benefits for yourself? | required | check | Confirmed: Yes = `label_0` |
+
+**The program selection here narrows every page after `ABCSD`.** Selecting
+CalFresh only changed the step counter from "Step 1 of 9" to "Step 1 of 8" from
+`ABCSD` onward (see the URL-chain section). Expect a different page sequence
+after this point if a future fill selects more than one program.
+
+## Page `ABCSD` ("CalFresh Submit App Divider") — No Fields, One Choice of Button
+
+An informational nudge page with no form fields. Two buttons: "CONTINUE
+APPLICATION" (advances to the next page in the normal sequence) and "Skip and
+submit now (not recommended)" (a shortcut toward submit). **Always use "CONTINUE
+APPLICATION." Never use the skip link** — it is submit-adjacent and skips
+sections the gap analysis has not covered.
+
+## Field Table — Page `ABDIS` ("Disability")
+
+| id | type | Label | Required (HTML) | Notes |
+|---|---|---|---|---|
+| `disability0` (Y) / `disability1` (N) | radio | Are you a person with a disability and need help to apply? | no `required` attribute found | FORBIDDEN DATA CATEGORY — do not answer from a derived guess. Ask the user. Confirmed value mapping: read the visible `<label for="disability1">No</label>` text before you click — do not assume index 0/1 maps to Yes/No. |
+| `deaf0` (Y) / `deaf1` (N) | radio | Are you a person who is deaf or hard of hearing? | no `required` attribute found | Same rule as above. |
+
+Answered No/No after the user confirmed both, verified by reading the label
+text before the click and `is checked` on both ids of each pair after.
+
+## Field Table — Page `ABCOS` ("College Student")
+
+| id | type | Label | Required (HTML) | Notes |
+|---|---|---|---|---|
+| `CollegeStudentE_radio_button_0` (Y) / `CollegeStudentE_radio_button_1` (N) | radio | Are you a college student? | none found in HTML | FORBIDDEN DATA CATEGORY (student status) — ask the user. |
+
+Confirmed stop, verified clean: neither radio was touched, Next was not
+clicked. Answered No after the user confirmed it, and the fill continued.
+
+## Field Table — Page `ABCFA` ("CalFresh Authorized Rep")
+
+| id | type | Label | Notes |
+|---|---|---|---|
+| `filingTax_0` (Y) / `filingTax_1` (N) | radio | Do you want to authorize someone to help you with your CalFresh case? | The id name (`filingTax`) is unrelated to the question — do not trust it. Confirm the Yes/No mapping from the label text. Answered No; do not invent a representative. |
+
+## Field Table — Page `ABCFS` ("CalFresh Spend Benefits")
+
+| id | type | Label | Notes |
+|---|---|---|---|
+| `select_group_0` (Y) / `select_group_1` (N) | radio | Do you want to name someone to get and spend your CalFresh benefits for you? | Same generic-id warning as `ABCFA` — the id (`select_group`) does not name the question. Answered No; do not invent a person. |
+
+## Field Table — Page `ABRDT` ("Birthdate") — a Masked Field
+
+| id | type | Label | Required | Mask | Fill method | Notes |
+|---|---|---|---|---|---|---|
+| `birthDate_primary_input` | `type="password"`, `datatype="date"` | Date of Birth | required | YES | **per-key (`K`)** | Placeholder shows `MM/DD/YYYY`, attribute `maxdate="today"`. Confirmed: this input renders as a password-type field. A plain `fill` is expected to fail silently here, the same as the masked fields on other sites in this skill — use the keypress helper and read the value back with `get value` to confirm the formatted date. |
+
+## Field Table — Page `ABSSN` ("SSN")
+
+| id | type | Label | Notes |
+|---|---|---|---|
+| `ssn_group0` | radio | "Do you have a Social Security number?" — option Yes | GAP-DECISION, not a simple forbidden-category skip. Ask the user which of the three options is true. |
+| `ssn_group1` | radio | same question — option No | |
+| `ssn_group2` | radio | same question — option "I don't have it right now" | |
+
+**This page is a three-way STATUS gate, not a text box for SSN digits.** It
+does not ask for the number itself — it asks whether one exists. Do not treat
+"SSN is forbidden data" as a reason to always skip this page with no answer:
+the status question itself is answerable (the user can say whether the
+applicant has a number), and the site's later flow likely depends on the
+answer. Stop and ask the user to choose Yes / No / "I don't have it right now"
+before you continue. If the answer is Yes, the site opens a SEPARATE digit-entry
+page next (`ABSNA`, below) — treat entering the digits as its own decision,
+even after the status gate is answered Yes.
+
+Confirmed: choosing Yes on this gate opens `ABSNA` next.
+
+## Field Table — Page `ABSNA` ("SSN A") — the Actual SSN Digit Entry, a Masked Field
+
+| id | type | Label | Required | Mask | Fill method | Notes |
+|---|---|---|---|---|---|---|
+| `ssn` | `type="password"`, `inputmode="numeric"` | Social Security Number | not explicitly marked, but required for this flow | YES — masked | **per-key (`K`)** | Confirmed: nine digits sent by keypress read back as `NNN-NN-NNNN` (formatted, digits match). No confirm/re-enter box on this page — a single field only. A "Show social security number" toggle button is present but not needed; verify with `get value`, not by revealing the digits on screen. |
+
+## Field Table — Page `ABMRS` ("Marital Status")
+
+| id | type | Label | Notes |
+|---|---|---|---|
+| `maritalStatus_0` … `maritalStatus_7` | radio group (8 options) | What's your marital status? | Exact option order and text: Common Law, Divorced, Married, Never Married, Registered Domestic Partner, Separated, Single, Widowed. A payload value of "single parent household" matches "Single" — a direct, unambiguous match on the household-status word. Do not match it to "Never Married," which is a different, more specific legal status the payload does not state. |
+
+## Page `ABCID` ("Citizenship Immigration Divider") — No Fields
+
+An informational transition screen with no form fields, the same pattern as
+`ABCSD`: text along the lines of "Next, let's go over some questions about
+citizenship and immigration," then a `Next` button. **This site uses these
+divider pages before it opens a new sensitive topic area.** Expect a divider
+page like this before other sensitive sections too (income, assets) — a page
+with no fields and a topic-announcement sentence is not a fill failure, it is
+this site's own section-transition pattern.
+
+## Field Table — Page `ABDOC` ("Citizenship") — CONFIRMED STOP POINT
+
+| id | type | Label | Notes |
+|---|---|---|---|
+| `citizen_radio_0` (Y) | radio | Are you a U.S. citizen or national? — option Yes | FORBIDDEN DATA CATEGORY (citizenship/immigration status) — ask the user. |
+| `citizen_radio_1` (N) | radio | same question — option No | |
+
+Confirmed stop: neither radio touched, Next not clicked.
+
+## A Site-Wide Pattern: Individual-Status Gates Never Carry a `required` Attribute
+
+Confirmed across four separate pages (`ABNHA` homelessness, `ABDIS`
+disability and hearing, `ABCOS` college student, `ABCFA`/`ABCFS` third-party
+authorization): a personal-status Yes/No question on this site never has an
+HTML `required` attribute, and its Next button stays enabled even when the
+question is unanswered. Do not read the absence of `required` or an enabled
+Next button as "this question is optional." Every one of these questions is a
+single-question page with two or three named radios (`..._0`/`..._1`, or a
+word pair) — that page shape, by itself, is the site's own signal that the
+question needs a real answer, HTML attribute or not. Expect more pages shaped
+like this later in the flow (examples: pregnancy status, citizenship, veteran
+status, striker status — none reached yet). Ask the user before you answer any
+of them; never leave one at a guessed default because the button did not
+block you.
+
+## Bot Checks
+
+None seen across the twenty-four pages reached so far (home page through
+`ABDOC`). Confirm this again if a fill agent reaches later sections — a
+captcha can appear later in a multi-page flow even when the entry pages have
+none.
+
+## Unreached Pages — Ask the User Before You Guess
+
+Everything after `ABDOC` is UNCONFIRMED. Expected but not yet seen in "Your
+Information": more citizenship/immigration sub-questions, gender/sex,
+ethnicity (the usual payload has values for both, but no page has asked for
+them yet), and more individual-status gate pages (see the pattern below —
+pregnancy, veteran, striker, work registration, and similar questions are
+plausible and untested). Expenses (rent/mortgage and utilities figures) and
+Assets (a savings amount) are now ALLOWED values once a fill agent reaches
+those pages — see the field tables above for the categories still forbidden
+inside those sections (bank name/account number, cash on hand, vehicles,
+property). Also UNCONFIRMED: the household/People section (the CalFresh
+application needs a name and birth date for every household member — this is
+a common stop point when a payload describes only the primary applicant),
+Household Details, Other Situations, Document Upload, and Review & Submit.
+This is a large state benefits application — expect 20 or more gaps once
+these sections open. Do not derive a household size or an income answer from
+an adjacent fact (see `references/gap-analysis-and-provenance.md`, "Values You
+Must Not Derive"). Ask the user.
+
+## Forbidden and Sensitive Categories Seen So Far
+
+Some pages ask for data that a fill agent should not answer even when a value
+is technically available or pattern-matchable, because a wrong or guessed
+answer on a benefits application has consequences beyond a simple form error.
+Confirmed categories seen through `ABDOC`: disability status, hearing status,
+college-student status, citizenship/immigration status, and Social Security
+number (the status gate is answerable by the user; the digits, on the
+follow-up page `ABSNA`, are a separate and stricter stop — ask again even
+after the status gate is answered Yes). Treat these the same way as financial
+account numbers — ask the user, do not guess, do not pattern-match from an
+adjacent fact. A value the user already gave for a DIFFERENT application in
+the same session (example: an SSN typed for a different site's form) is not
+automatically valid for this site — ask again before reusing it.

--- a/.claude/skills/form-completion/playbooks/benefitscal.com.md
+++ b/.claude/skills/form-completion/playbooks/benefitscal.com.md
@@ -1,11 +1,10 @@
 # Playbook: benefitscal.com (California CalFresh/SNAP Application)
 
-Scout survey and five fill-agent passes, 2026-08-05, with agent-browser 0.33.2.
-Cold start. The fill agent reached a Citizenship question (page 24 of the
-chain below) and confirmed the program-selection step narrows the flow to
-CalFresh only. It stopped there, and four times before, on forbidden data
-categories. The rest of "Your Information" and Sections 2 through 8 are
-UNCONFIRMED.
+Scout survey and eight fill-agent passes, 2026-08-05, with agent-browser 0.33.2.
+Cold start. The fill agent completed the "Your Information" and "People"
+sections, entered "Household Details", and stopped on the work-program detail
+page `ABDWP` (page 41 of the chain below). Each stop before that was on a
+forbidden data category. Everything after `ABDWP` is UNCONFIRMED.
 
 **WARNING: This is a live government benefits form. Do not submit test data. Do not
 submit without explicit approval from the user.**
@@ -19,7 +18,7 @@ agent-browser get count "#addressLine1"
 agent-browser get count "#zip5"
 ```
 
-## URL Chain — Twenty-Four Pages Confirmed So Far
+## URL Chain — Forty-One Pages Confirmed So Far
 
 ```
  1. https://benefitscal.com/                                        home page
@@ -45,7 +44,24 @@ agent-browser get count "#zip5"
 21. .../ApplyForBenefits/ABSNA                                       "SSN A" — the actual SSN digit-entry page, a MASKED field
 22. .../ApplyForBenefits/ABMRS                                       "Marital Status" — a radio group of 8 options
 23. .../ApplyForBenefits/ABCID                                       "Citizenship Immigration Divider" — an informational nudge page, no fields
-24. .../ApplyForBenefits/ABDOC                                       page title "Citizenship" — CONFIRMED STOP POINT. Note: the URL slug (ABDOC) does not match the page title or topic.
+24. .../ApplyForBenefits/ABDOC                                       page title "Citizenship" — the URL slug (ABDOC) does not match the page title or topic
+25. .../ApplyForBenefits/ABBID                                       "Background Info Divider" — no fields
+26. .../ApplyForBenefits/ABASX                                       "Assigned Sex" — "What's your gender?"
+27. .../ApplyForBenefits/ABGNR                                       "Gender" — "What's your gender identity?" (a second, separate gender page)
+28. .../ApplyForBenefits/ABSXO                                       "Sexual Orientation" — optional, Next works with no answer
+29. .../ApplyForBenefits/ABHSP                                       "Hispanic" — Hispanic/Latino/Spanish origin, a Yes/No/prefer-not question
+30. .../ApplyForBenefits/ABRAE                                       "Race and Ethnicity" — a race select, separate from ABHSP
+31. .../ApplyForBenefits/ABYSD                                       "Your Information Section Completed" — milestone, click "START THE NEXT SECTION"
+32. .../ApplyForBenefits/ABNAV                                       "Application Summary" again — click "Start People"
+33. .../ApplyForBenefits/ABHSD                                       "Household Member Definition" — other people in the household?
+34. .../ApplyForBenefits/ABPLS                                       "People Summary" — a read-only list of the household members
+35. .../ApplyForBenefits/ABTCD                                       "People Section Completed" — milestone
+36. .../ApplyForBenefits/ABNAV                                       "Application Summary" again — click "Start Household"
+37. .../ApplyForBenefits/ABHGW                                       "Household Gateway" — a situational checklist
+38. .../SupportRequest/ABDEG                                         "ABAWD Exemption Screener" — a checklist. The URL path changes to /SupportRequest/ from this page on.
+39. .../SupportRequest/ABDWR                                         "Work Requirement Screener" — work/volunteer/training checklist, a BRANCH GATE
+40. .../SupportRequest/ABDWT                                         "Work Or Training Info" — hours for each week (opens when ABDWR has a work/training check)
+41. .../SupportRequest/ABDWP                                         "Work Or Training Info" — organization name — LAST CONFIRMED PAGE
 ```
 
 **Do not trust the URL slug as the page topic.** `ABDOC` asks about citizenship,
@@ -76,11 +92,31 @@ accessible label.
 The page advance button on these pages has no id. Match it by its visible text,
 "Next" (or "CONTINUE APPLICATION" on `ABCSD`).
 
-**The site keeps entered data when you navigate back.** A fill agent went back
-five pages (from `ABDIS` through `ABNMI`) with the site's own "Back to Previous
-Page" button to fix a field, then re-advanced through every page again. Every
-value it had entered on the pages in between was still there. Back navigation is
-safe to use for a correction on this site.
+**Back navigation: the "Back to Previous Page" button is safe, the step-tracker
+links are NOT.** A fill agent went back five pages (from `ABDIS` through `ABNMI`)
+with the site's own "Back to Previous Page" button to fix a field, then
+re-advanced through every page again. Every value it had entered on the pages in
+between was still there. But a jump through a step-tracker link (example: "Your
+Information Reviewed") RESET corrected fields to their earlier values — a
+corrected last-name/suffix split reverted to the combined value, and the suffix
+select reverted to "-Select One-". Use "Back to Previous Page" for corrections.
+After any use of a review link, re-verify every field that was corrected earlier.
+
+**Some ids regenerate on every page load.** Fields on several pages (`ABRAE`,
+`ABDEG`, `ABDWR`, `ABDWT`) carry a generated id with the pattern
+`lift-ux-id-<32 hex chars>` or `..._N`. The id changes on each load — do not
+save one, do not reuse one across visits, and do not put one in a freshness
+probe. The `model` attribute on the same element is constant (example:
+`model="ABRAE.APP_INDV_Collection.race_cd"`) — find these fields through the
+`model` attribute in the page HTML, then use the id from THAT load. The pattern
+is not universal: other fields on the same pages keep static ids (example:
+`#ABDWP_PrgmName1`).
+
+**A partially completed section restarts from its first page.** Clicking "Start
+Household" on `ABNAV` when the section shows as not complete opened the section's
+FIRST page (`ABHGW`), not the page where the previous pass stopped. There is no
+mid-section resume. Expect to walk and re-verify every page of a section that a
+previous pass left incomplete.
 
 **The step counter changes when the program selection narrows.** Before
 `ABPRI`, pages show "Step 1 of 9". After a fill agent chose CalFresh only on
@@ -102,10 +138,10 @@ in it.
 
 | # | Section | Status |
 |---|---|---|
-| 1 | Your Information | REACHED |
-| 2 | People | UNCONFIRMED — button disabled until Section 1 has data |
-| 3 | Household Details | UNCONFIRMED |
-| 4 | Income | UNCONFIRMED |
+| 1 | Your Information | CONFIRMED — completed in one run, pages 7 to 31 of the chain |
+| 2 | People | CONFIRMED — pages 33 to 35. Only the "no other people" path is confirmed. |
+| 3 | Household Details | PARTIAL — pages 37 to 41. The section restarts from `ABHGW` when it is not complete. |
+| 4 | Income | UNCONFIRMED — locked ("Not Available") until Household Details is complete |
 | 5 | Expenses | UNCONFIRMED |
 | 6 | Assets | UNCONFIRMED |
 | 7 | Other Situations | UNCONFIRMED |
@@ -191,8 +227,13 @@ lets the site rewrite the value the user gave.
 **A county picker can appear after the address modal.** If the site cannot
 derive the county from the address, a dialog opens: heading "What county are
 you currently in?", a required `select#county`, and a "CONTINUE" button. Select
-the county by exact option text (confirmed: "Riverside"), then verify with
+the county by exact option text, then verify with
 `get text "#county option:checked"`.
+
+**Both dialogs return on every visit.** A second pass through this page, with
+the address unchanged and already accepted, opened the address modal and the
+county dialog again. Expect both dialogs on EVERY Next click on this page, not
+only the first.
 
 **Confirmed stop point (first pass):** a fill agent stopped on this page with
 the homelessness gate unanswered, and did not click Next. A second pass, after
@@ -329,14 +370,80 @@ page like this before other sensitive sections too (income, assets) — a page
 with no fields and a topic-announcement sentence is not a fill failure, it is
 this site's own section-transition pattern.
 
-## Field Table — Page `ABDOC` ("Citizenship") — CONFIRMED STOP POINT
+## Field Table — Page `ABDOC` ("Citizenship")
 
 | id | type | Label | Notes |
 |---|---|---|---|
 | `citizen_radio_0` (Y) | radio | Are you a U.S. citizen or national? — option Yes | FORBIDDEN DATA CATEGORY (citizenship/immigration status) — ask the user. |
 | `citizen_radio_1` (N) | radio | same question — option No | |
 
-Confirmed stop: neither radio touched, Next not clicked.
+The value mapping is confirmed through both label patterns on this page
+(`<label for=...>` and the `_inner_label` span) — the two agreed. A Yes answer
+opened no immigration follow-up page.
+
+## Field Tables — the Demographic Pages (`ABASX`, `ABGNR`, `ABSXO`, `ABHSP`, `ABRAE`)
+
+| Page | id | type | Label | Options |
+|---|---|---|---|---|
+| `ABASX` | `assignedSex_0` / `_1` / `_2` | radio | What's your gender? | Female / Male / I prefer not to answer |
+| `ABGNR` | `gender_0` … `gender_6` | radio | What's your gender identity? | Another Gender Identity / Female / Transgender: Female to Male / Male / Transgender: Male to Female / Non Binary / I prefer not to answer |
+| `ABSXO` | (radio group) | radio | Sexual orientation | Straight or Heterosexual / Gay or Lesbian / Bisexual / Queer / Another Sexual Orientation / Unknown / I prefer not to answer |
+| `ABHSP` | `person_0` (Y) / `_1` (N) / `_2` | radio | Are you of Hispanic, Latino, or Spanish origin? | Yes / No / I prefer not to answer |
+| `ABRAE` | dynamic id, `model="ABRAE.APP_INDV_Collection.race_cd"` | select | What is your race and ethnic origin? | -Select One-, American Indian or Alaskan Native, Asian, Black or African American, Native Hawaiian or Other Pacific Islander, Other or Mixed, White, I prefer not to answer |
+
+- `ABASX` and `ABGNR` are two separate questions (assigned sex, then gender
+  identity). A payload gender value answers `ABASX`. Ask the user before you
+  answer `ABGNR` with the same value — the two facts can differ.
+- `ABSXO` is optional: no `required` attribute, and Next works with no answer.
+  Leave it with no answer when no source states one.
+- **The site splits Hispanic origin from race** (the standard US census split).
+  An ethnicity value such as "Hispanic/Latino" answers `ABHSP` (Yes), and does
+  NOT map to any option in the `ABRAE` race list. `ABRAE` is optional — when no
+  source states a race, leave it at "-Select One-" and put race in the gap
+  analysis.
+
+## Field Tables — the People Section (`ABHSD`, `ABPLS`)
+
+| Page | id | type | Label | Notes |
+|---|---|---|---|---|
+| `ABHSD` | `hshld_radiogrp_0` (Y) / `_1` (N) | radio | Do you have other people living in your household? | The gate for the whole People section. A Yes answer is expected to open member-entry pages (UNCONFIRMED — only the No path is confirmed). |
+| `ABPLS` | none | — | People Summary | Read-only. Lists each household member with age. An "ADD ANOTHER" button is present. |
+
+## Field Tables — the Situational Checklists (`ABHGW`, `ABDEG`, `ABDWR`)
+
+Three checklist pages follow the People section. Each shows a list of
+situations plus a "None of these apply" checkbox.
+
+| Page | ids | Items |
+|---|---|---|
+| `ABHGW` | `govtaid`, `disability`, `college`, `food`, `living`, `breastfeeding`, `military`, `none` | Received public assistance in any state / person with a disability / enrolled in college or trade school / get food from somewhere other than at home / live in a facility, shelter or other living arrangement / breastfeeding a child / serving or served in the U.S. Military (or a dependent) / None of these apply |
+| `ABDEG` | dynamic ids `lift-ux-id-..._0` … `_11` | Health issue that makes work hard / personal issue that makes work hard / caring for a child under 14 / caring for a child under 6 / caring for a person who needs help / currently pregnant / in school at least half-time / getting or applied for unemployment benefits / getting or applied for disability benefits / Indian, Urban Indian, or Californian Indian / ORR Training Program at least half-time / None of these apply |
+| `ABDWR` | dynamic ids `..._0` … `_3` | Working / community service or volunteer work / work, education, or training program / None of these apply |
+
+Rules for these checklists:
+
+- Check "None of these apply" ONLY when a confirmed answer rules out every
+  listed item. When one item is not ruled out, stop and ask the user. On one
+  run, "no income" ruled out "Working" but not volunteering or a training
+  program — the agent stopped, and that was correct.
+- **`ABDWR` is a branch gate.** A check on the work/education/training item
+  opened a detail chain: `ABDWT` (hours for each week), then `ABDWP`
+  (organization name). Expect more detail pages after those (program pay and
+  start date are plausible, UNCONFIRMED). Warn the user about this chain in the
+  gap analysis before a work-program item is checked.
+- **The `ABDEG` checkbox inputs report `is visible` = false, and the checks
+  still work.** The visible element is a styled sibling, not the input. Use
+  `check` and `is checked` on the input id. Do not use `is visible` to validate
+  this page. Two of the twelve inputs (`_2` "child under 14", `_6` "school
+  half-time") are in the HTML but never appeared in the snapshot tree — read
+  this page's items from `get html`, not from the snapshot alone.
+
+## Field Tables — the Work-Program Detail Pages (`ABDWT`, `ABDWP`)
+
+| Page | id | type | Label | maxlength | Fill method |
+|---|---|---|---|---|---|
+| `ABDWT` | dynamic id, `model="ABDWT.CpAbawdDetails_Collection.workHours"` | text | Total hours for each week | 3 | plain `fill` — no mask |
+| `ABDWP` | `ABDWP_PrgmName1` (static) | text | Organization or Person's Name ("Where do you do your work program or education or training program?") | 60 | not filled — LAST CONFIRMED PAGE. A disabled "ADD ANOTHER" button is present (UNCONFIRMED — likely for a second program). |
 
 ## A Site-Wide Pattern: Individual-Status Gates Never Carry a `required` Attribute
 
@@ -348,38 +455,39 @@ question is unanswered. Do not read the absence of `required` or an enabled
 Next button as "this question is optional." Every one of these questions is a
 single-question page with two or three named radios (`..._0`/`..._1`, or a
 word pair) — that page shape, by itself, is the site's own signal that the
-question needs a real answer, HTML attribute or not. Expect more pages shaped
-like this later in the flow (examples: pregnancy status, citizenship, veteran
-status, striker status — none reached yet). Ask the user before you answer any
-of them; never leave one at a guessed default because the button did not
-block you.
+question needs a real answer, HTML attribute or not. Later pages confirmed the
+pattern: citizenship (`ABDOC`), the household gate (`ABHSD`), and the three
+situational checklists all follow it. Expect more pages shaped like this in the
+unconfirmed sections (veteran status and striker status are plausible). Ask the
+user before you answer any of them; never leave one at a guessed default
+because the button did not block you.
 
 ## Bot Checks
 
-None seen across the twenty-four pages reached so far (home page through
-`ABDOC`). Confirm this again if a fill agent reaches later sections — a
+None seen across the forty-one pages reached so far (home page through
+`ABDWP`). Confirm this again if a fill agent reaches later sections — a
 captcha can appear later in a multi-page flow even when the entry pages have
 none.
 
 ## Unreached Pages — Ask the User Before You Guess
 
-Everything after `ABDOC` is UNCONFIRMED. Expected but not yet seen in "Your
-Information": more citizenship/immigration sub-questions, gender/sex,
-ethnicity (the usual payload has values for both, but no page has asked for
-them yet), and more individual-status gate pages (see the pattern below —
-pregnancy, veteran, striker, work registration, and similar questions are
-plausible and untested). Expenses (rent/mortgage and utilities figures) and
-Assets (a savings amount) are now ALLOWED values once a fill agent reaches
-those pages — see the field tables above for the categories still forbidden
-inside those sections (bank name/account number, cash on hand, vehicles,
-property). Also UNCONFIRMED: the household/People section (the CalFresh
-application needs a name and birth date for every household member — this is
-a common stop point when a payload describes only the primary applicant),
-Household Details, Other Situations, Document Upload, and Review & Submit.
-This is a large state benefits application — expect 20 or more gaps once
-these sections open. Do not derive a household size or an income answer from
-an adjacent fact (see `references/gap-analysis-and-provenance.md`, "Values You
-Must Not Derive"). Ask the user.
+Everything after `ABDWP` is UNCONFIRMED: the pages after the organization-name
+question (program pay and program start date are plausible follow-ups), the
+rest of Household Details, and the Income, Expenses, Assets, Other Situations,
+Document Upload, and Review & Submit sections. Known question areas from the
+gap answers of one run, with no confirmed pages yet: income sources, rent or
+mortgage, utilities (the form can split them into categories — collect the
+categories when it does), and savings. Financial account identifiers (bank
+name, account number) stay forbidden — a form does not need them, and the gap
+analysis must not ask for them. The People section's multi-member path is also
+UNCONFIRMED (a household with more than one person needs a name and birth date
+for each member — a common stop point when a payload describes only the primary
+applicant). Expect 20 or more gaps for the full application. Do not derive a
+household size or an income answer from an adjacent fact (see
+`references/gap-analysis-and-provenance.md`, "Values You Must Not Derive").
+Ask the user. At Review & Submit, re-verify the name fields — a step-tracker
+review link can revert a corrected name split (see the back-navigation warning
+above).
 
 ## Forbidden and Sensitive Categories Seen So Far
 

--- a/.claude/skills/form-completion/playbooks/riversideihss.org.md
+++ b/.claude/skills/form-completion/playbooks/riversideihss.org.md
@@ -1,0 +1,285 @@
+# Playbook: riversideihss.org (Riverside County IHSS Application)
+
+Confirmed 2026-08-05 with agent-browser 0.33.2.
+
+**WARNING: This is a live government benefits form. Do not submit test data. Do not
+submit without explicit approval from the user.**
+
+**Freshness probe.** Each command below must return 1. If a command does not return 1,
+the site changed. Use the cold-start procedure. Write this file again.
+
+```bash
+agent-browser get count "#firstNameTxt"
+agent-browser get count "#ssnTxt"
+agent-browser get count "#btnSubmit"
+```
+
+## URL — Open the Form Directly
+
+```
+/Home/IHSSApply      landing page, 0 application fields ("Click here to apply online")
+/Home/IHSSIntakeApp  second page,  0 application fields ("Click here to continue")
+/IntakeApp           THE FORM:     128 inputs, 9 selects
+```
+
+Open `https://riversideihss.org/IntakeApp` directly. All the inputs on the first two
+pages belong to Google Translate (`goog-gt-*`). Snapshots of this site contain 60 to 98
+percent Google Translate lines (249 of 255 lines on the landing page). Use `#id`
+selectors. Do not use snapshots here.
+
+## Required Fields That the Usual Payload Does Not Contain — Ask First, in One Batch
+
+- SSN (`ssnTxt`). A CalWORKs id or a record id is not an SSN.
+- Living arrangement: `chkBxLIndependent`, `chkBxLAnyLFacility`, `chkBxLBoard`,
+  `chkBxLHome`.
+- Health history: six `chkBxHealthHistory` checkboxes.
+- IHSS service need: `chkBxIHSSService` checkboxes and `chkBxOther`.
+- SSI/SSP: `chkBxSSIYes` / `chkBxSSINo`.
+- Assistance available at home: `chkBxAssistanceYes` / `chkBxAssistanceNo`.
+- Lives alone: `chkBxLiveAloneYes` / `chkBxLiveAloneNo`.
+
+Also ask these path decisions: self or on-behalf (the master gate), mailing address the
+same as residential, real data or test data.
+
+## Fill Sequence — Answer the Master Gate First
+
+Set `chkBxApplyYourselfYes` when the applicant applies for the applicant. The
+representative block stays hidden. Do not fill it.
+
+Set `chkBxApplyYourselfNo` for an on-behalf or DPSS referral. This shows the
+representative block: `repFirstNameTxt`, `repLastNameTxt`, `repPhoneTxt` (masked, ten
+digits), `repEmailTxt`, `relToApplicantDrpDwn`, and the consent pair
+`chkBxApplicantAgreeYes` / `chkBxApplicantAgreeNo`.
+
+If you do not answer this gate, the consent checkbox stays hidden. A click on the
+hidden checkbox shows success but does nothing.
+
+The field `ticketId2Txt` stays hidden, also when the relationship is ASD Staff. Do not
+try to fill it.
+
+## Field Table (Section 1 and Confirmed Sections)
+
+| Field | id | Method | Notes |
+|---|---|---|---|
+| First/Last name | `firstNameTxt` / `lastNameTxt` | fill | max 25 |
+| Street + unit | `streetTxt` | fill | max 30, no separate unit field |
+| City | `cityTxt` | fill | max 25 |
+| State | `stateTxt` | **per-key** | masked, max 2 — use `CA`, not `California` |
+| Zip | `zipCodeTxt` | fill | max 10 |
+| SSN | `ssnTxt` | **per-key** | masked, 9 digits → `123-45-6789` |
+| Birthdate | `birthDateTxt` | **per-key** | masked, `MMDDYYYY` → `01/02/2000` |
+| Phone | `telephoneTxt` | **per-key** | masked, 10 digits |
+| Email | `emailTxt` | fill | max 50 |
+| Sex | `chkBxSexMale` / `chkBxSexFemale` | check | |
+| Adopted minor | `chkBxAdoptedChildYes/No` | check | |
+| Mailing same? | `chkBxMailAddressYes/No` | check | **"Yes" hides the mailing block. This is correct.** "No" shows `mailStreetTxt`, `mailCityTxt`, `mailStateTxt` (per-key), `mailZipCodeTxt` |
+| Veteran | `chkBxVeteranYes/No` | check | "Yes" shows `veteranNameTxt`, `veteranClaimNumberTxt` |
+| Health history | `healthHistoryTxt` | fill | max 125, required |
+| Other service | `otherServiceRequestedTxt` | fill | starts disabled, no accessible name — `check "#chkBxOther"` enables it |
+| Past IHSS | `chkBxPastIHSSYes/No` | check | "Yes" shows `pastIHSSDateTxt`, `pastIHSSCountyTxt`, `monthlyHoursTxt` |
+| Household member | `relationshipDrpDwn`, `nameHouseholdTxt`, `birthDateHouseholdTxt`, `ssnHouseholdTxt` | select/fill | a participant_type of "Parent" goes here, not in the applicant fields. The DOB and SSN labels say "(optional)". A participant_type alone is not a household member — it gives no name. Leave the whole block empty unless the user gives a name. Do not invent a person. |
+| Ethnicity | `ethnicDrpDwn` | select | **use "Hispanic" — "Hispanic/Latino" is not an option** |
+| Languages | `languagePrepareToReadDrpDwn` / `languagePrepareToSpeakDrpDwn` | select | Speak id is `languagePrepareToSpeakDrpDwn`, **not** `languageSpeakDrpDwn` (confirmed 2026-08-05). Spanish has two options (NOA in English / NOA in Spanish) — select with care |
+| Household DOB / SSN | `birthDateHouseholdTxt` / `ssnHouseholdTxt` | **per-key** | masked, same as the applicant equivalents |
+| Blind / vision | `chkBxBlindYes/No`, `chkBxVisImpairedYes/No` | check | "Yes" shows the related accommodation checkboxes |
+| Name used | `nameUsedTxt` | fill | optional, no `*` marker |
+| Gender identity | `genderIdentityDrpDwn` | select | separate from the sex checkboxes; Another gender identity / Decline to state / Female / Male / Non-Binary (neither male nor female) / Transgender: female to male / Transgender: male to female |
+| Sexual orientation | `sexualOrientationDrpDwn` | select | Another sexual orientation / Bisexual / Decline to state / Gay or lesbian / Queer / Straight/heterosexual / Unknown |
+| Sex at birth | `chkBxSexOrigMale` / `chkBxSexOrigFemale` | check | a SECOND sex pair, separate from `chkBxSexMale/Female` |
+| Veteran relative | `chkBxVeteranRelYes/No` | check | separate from `chkBxVeteranYes/No` |
+| Receives IHSS now | `chkBxRcvIHSSServicesYes/No` | check | separate from `chkBxPastIHSSYes/No` |
+
+### The Masks Add Their Own Format — Compare the Digits, Not the String
+
+Send digits only with the per-key method. The mask inserts the separators. The readback
+shows the formatted string, so a digit-for-digit comparison is the correct check
+(confirmed 2026-08-05):
+
+| Field | Keys you send | Value that `get value` returns |
+|---|---|---|
+| `ssnTxt` | nine digits | `123-45-6789` |
+| `birthDateTxt` | MMDDYYYY | `01/02/2000` |
+| `telephoneTxt` | ten digits | `(777) 777-7777` |
+| `stateTxt` | the 2-letter state code | the same two characters, no separator |
+
+A readback that differs from the keys you sent is not a failure here. A readback that
+shows `__/__/____` or an empty string is a failure.
+
+### There Are No `required` Attributes
+
+`get count "[required]"` and `get count "[aria-required='true']"` both return 0. The site
+marks the required fields with `*` in the label text and enforces them in JavaScript.
+Do not conclude that the form has no required fields.
+
+## No Middle-Name Field in Section 1
+
+The applicant block has `firstNameTxt` and `lastNameTxt` only. There is no
+`middleNameTxt`. A middle name in the payload has nowhere to go. Ask the user whether to
+append it to the first or the last name. Do not silently drop it.
+
+## IHSS Service-Need Checkboxes Share One id
+
+The four service checkboxes all carry `id="chkBxIHSSService"` (invalid HTML on the site).
+`get count "#chkBxIHSSService"` returns 4 and `#chkBxIHSSService` addresses only the
+first. Use the `value` attribute instead — these are stable:
+
+| value | Service |
+|---|---|
+| 80 | Domestic Services — household cleaning, meal preparation, laundry, food shopping |
+| 81 | Personal Care — bathing, bowel/bladder, dressing, feeding, grooming |
+| 82 | Transportation — medical appointments and health-related services |
+| 83 | Paramedical Care |
+| 84 | Other (separate id `#chkBxOther`; enables `otherServiceRequestedTxt`) |
+
+```bash
+agent-browser check "input[value='81']"
+agent-browser is checked "input[value='81']"
+```
+
+The `name` attribute on these is empty, so `[name=…]` does not work. `nth-of-type` also
+fails on this form because the matching inputs have different parents — it is a selector
+artifact, not a missing element.
+
+## Health-History Checkboxes Also Share One id
+
+Same pattern as the service checkboxes: six inputs all carry `id="chkBxHealthHistory"`.
+Address them by `value` (confirmed 2026-08-05). These are specific medical conditions,
+not a general history:
+
+| value | Condition |
+|---|---|
+| 95 | Unable to perform some activities of daily living (bathing, feeding, dressing, walking) |
+| 96 | Currently under hospice care |
+| 97 | Have a terminal illness likely to result in imminent death |
+| 98 | Have a pending/recent organ transplant |
+| 100 | Require around the clock use of supplemental oxygen |
+| 101 | Have cancer, currently being treated |
+
+Note the gap: there is no value 99. Do not scan value ranges with `get count` — the
+`FIELDS` helper in `scripts/fill-helpers.sh` gives the full value and label map for
+every group in one tool call.
+
+```bash
+agent-browser check "input[value='95']"
+```
+
+Do not put `[id='chkBxHealthHistory']` in the selector. A selector with `[id=…]`
+resolves to the FIRST element with that id only. The compound form works for value 95
+by accident and fails for 96 and above. Use `input[value='N']` alone, or check by the
+visible label: `find role checkbox check --name "Currently under hospice care"`.
+
+The separate free-text `#healthHistoryTxt` ("Briefly describe your health history") is
+required and independent of these boxes.
+
+## Read a Select With `option:checked`, Not `get value`
+
+`get value` on a select returns the option **index**, which cannot be checked against the
+intended text. Use the child selector instead (confirmed 2026-08-05):
+
+```bash
+agent-browser get text "#ethnicDrpDwn option:checked"   # -> "Hispanic"
+```
+
+Element-scoped `screenshot "#someSelect" out.png` captured an unrelated page region on
+this form — do not use it to verify a select.
+
+## Enumerating Labels Without `eval`
+
+`get attr` does not accept XPath — an XPath selector returns `✓ Done` with no value,
+which looks like success. To map same-id checkboxes to their human labels, use
+`screenshot out.png --annotate --full` and read the `[N] @eN role "name"` legend. Grepping
+that legend for `\*` also lists every required-marked field on the page.
+
+## The Affirmation Expander Toggles — Check the State, Do Not Count Clicks
+
+`click "div.header"` toggles. The section may already be open. One click can close
+it and leave `#btnSubmit` disabled, which reads like a different bug. Read the state after
+each click:
+
+- `"+ Expand : Please expand and read below information…"` → closed, submit disabled
+- `"- Collapse : Thank you for reading the important information."` → open, submit enabled
+
+**`get text` can return a stale string for one call after the click.** Observed
+2026-08-05: immediately after `click "div.header"`, `get text "div.header"` still returned
+the `+ Expand` string and `is enabled "#btnSubmit"` returned `false`, but
+`get html "div.header"` returned the `- Collapse` string in the same moment. One more read
+of both selectors then agreed on `- Collapse` and `enabled = true`.
+
+Use `get html "div.header"` for the authoritative state. If `get text` and `get html`
+disagree, read again before you start a diagnosis. Also confirm with the body element:
+
+```bash
+agent-browser get html "div.header"        # authoritative: "- Collapse : Thank you..."
+agent-browser is visible "div.content"     # true when the section is open
+agent-browser is enabled "#btnSubmit"
+```
+
+Note that `div.header span` returns count 0 — the header holds a bare text node. An
+earlier version of this file used `div.header.span`, which is a class selector and not a
+descendant selector. Use `div.header`.
+
+Select options (exact text):
+
+- `relToApplicantDrpDwn`: Adult Services Division (ASD) Staff / Community Agency / Family Member / Health Plan Provider / Other
+- `relationshipDrpDwn`: Child / Non-Relative / Other Relative / Parent / Spouse
+- `ethnicDrpDwn`: American Indian or Alaskan Native / Asian Indian / Black / Cambodian / Chinese / Filipino / Guamanian / Hawaiian / Hispanic / Japanese / Korean / Laotian / Mixed Ethnicity / Other / Other Asian or Pacific Islander / Samoan / Vietnamese / White
+
+## Section 9 and Submit
+
+Open the affirmation section with a click, then read the text back to confirm state:
+
+```bash
+agent-browser click "div.header"       # The element has no id. The class selector is stable.
+agent-browser get text "div.header"    # Expect "- Collapse : Thank you..."
+agent-browser is enabled "#btnSubmit"
+```
+
+Use `div.header`, **not** `div.header.span` (corrected 2026-08-05). Both match one
+element, but `get text "div.header.span"` returned the stale "+ Expand" string after the
+section was already open, which reads like a failed click. `div.header` reports the live
+text. Do not count clicks — the click toggles, so a second click closes the section again.
+
+The section closes on page reload. Reopen it after any navigation.
+
+### Turnstile — Read the Token, Do Not Count Iframes
+
+Cloudflare Turnstile is on this page. The widget div is present and the site key is
+`0x4AAAAAAAzaiJRgbzD5L2iV`:
+
+```bash
+agent-browser get count ".cf-turnstile"                        # 1 — widget div present
+agent-browser get count "iframe"                               # 0 — see below
+agent-browser get value "input[name='cf-turnstile-response']"  # the token, or "" 
+```
+
+**`get count "iframe"` returns 0 even when the challenge passed.** Confirmed 2026-08-05 on
+local Chrome: `iframe` count was 0 and `cf-turnstile-response` held a full token
+(approximately 700 characters), and `#btnSubmit` was enabled. The widget puts its iframe in
+a place that this selector does not reach. An iframe count of 0 proves nothing.
+
+**The token field is the only reliable signal.** A non-empty `cf-turnstile-response` means
+the challenge passed. An earlier version of this file recorded `iframes=0` plus an empty
+token as proof that the challenge never runs in this environment. The iframe half of that
+test is wrong; only the empty token is meaningful.
+
+If the token is empty and `#btnSubmit` stays disabled after the affirmation section is
+open, wait and read the token again — it arrives asynchronously. Do not attempt to bypass
+it. If it stays empty, stop and tell the user.
+
+**Then stop. Get approval from the user before the submit step.**
+
+## The Warm Path Is One Write Batch
+
+Confirmed 2026-08-05 for a self-application: one Bash call held every write (the master
+gate, ten applicant fields, the sex checkbox, the mailing gate, the three Yes/No pairs, the
+living arrangement, the health-history box and free text, the four service boxes, and the
+three selects). One readback pass then confirmed all of them. Every field was correct on
+the first pass. No field needed a second write, and no gate hid a field that the batch
+tried to fill, because the two gates (`chkBxApplyYourselfYes`, `chkBxMailAddressYes`) only
+hide blocks that a self-application leaves empty.
+
+Order the batch so the master gate comes first. Keep the per-key method for `stateTxt`,
+`ssnTxt`, `birthDateTxt`, and `telephoneTxt`.
+
+The unanswered Yes/No pairs stay clear, and both boxes read `false`. This is the correct
+result for a value that the user did not give. Report the field as empty.

--- a/.claude/skills/form-completion/playbooks/riversideihss.org.md
+++ b/.claude/skills/form-completion/playbooks/riversideihss.org.md
@@ -66,8 +66,8 @@ try to fill it.
 | City | `cityTxt` | fill | max 25 |
 | State | `stateTxt` | **per-key** | masked, max 2 — use `CA`, not `California` |
 | Zip | `zipCodeTxt` | fill | max 10 |
-| SSN | `ssnTxt` | **per-key** | masked, 9 digits → `123-45-6789` |
-| Birthdate | `birthDateTxt` | **per-key** | masked, `MMDDYYYY` → `01/02/2000` |
+| SSN | `ssnTxt` | **per-key** | masked, 9 digits → `NNN-NN-NNNN` |
+| Birthdate | `birthDateTxt` | **per-key** | masked, `MMDDYYYY` → `MM/DD/YYYY` |
 | Phone | `telephoneTxt` | **per-key** | masked, 10 digits |
 | Email | `emailTxt` | fill | max 50 |
 | Sex | `chkBxSexMale` / `chkBxSexFemale` | check | |
@@ -97,13 +97,40 @@ shows the formatted string, so a digit-for-digit comparison is the correct check
 
 | Field | Keys you send | Value that `get value` returns |
 |---|---|---|
-| `ssnTxt` | nine digits | `123-45-6789` |
-| `birthDateTxt` | MMDDYYYY | `01/02/2000` |
-| `telephoneTxt` | ten digits | `(777) 777-7777` |
+| `ssnTxt` | nine digits | `NNN-NN-NNNN` |
+| `birthDateTxt` | MMDDYYYY | `MM/DD/YYYY` |
+| `telephoneTxt` | ten digits | `(NNN) NNN-NNNN` |
 | `stateTxt` | the 2-letter state code | the same two characters, no separator |
 
 A readback that differs from the keys you sent is not a failure here. A readback that
 shows `__/__/____` or an empty string is a failure.
+
+### Never Use `eval` on the Masked Fields Here — the Per-Key Method Works
+
+**Confirmed 2026-08-05: `stateTxt`, `ssnTxt`, `birthDateTxt`, and `telephoneTxt` all
+accept the per-key `K` method correctly.** One fill agent reported the per-key method
+"ineffective" and switched to `eval` with a direct JavaScript assignment and a
+dispatched change event. This report was wrong. A second, independent check on the
+same fields with the same `K` helper produced correctly masked values for all four
+fields (`CA`, `NNN-NN-NNNN`, `MM/DD/YYYY`, `(NNN) NNN-NNNN`). Do not read one agent's
+"the documented method failed" as proof. Retry the documented method yourself before
+you conclude that it fails, and never use `eval` on a form that a government agency
+receives — see SKILL.md, "Tool Rules."
+
+**Proof that `eval` bypasses the mask on this site:** after the `eval` writes, `get
+value` returned the RAW digits with no separators (`NNNNNNNNN`, `MMDDYYYY`) instead of
+the masked format (`NNN-NN-NNNN`, `MM/DD/YYYY`). The mask inserts separators only when
+real keydown events reach it. A value with no separators is proof that the mask never
+ran, whether or not the raw digits look plausible on a screenshot.
+
+**If a field was previously written with `eval` or another non-keyboard method, the
+mask's internal buffer can be in a state that rejects the first `K` retry.** Confirmed
+on `ssnTxt`: the first `K "#ssnTxt" "NNNNNNNNN"` call after an `eval` write left the
+field EMPTY, not masked. A second attempt, using the same `K` helper again with no
+other change, produced the correct `NNN-NN-NNNN`. The field needed one extra clear
+pass to flush the leftover state before it accepted keys. If a per-key write returns
+empty right after a non-keyboard write to the same field, retry the same `K` call once
+more before you escalate to a different diagnosis.
 
 ### There Are No `required` Attributes
 

--- a/.claude/skills/form-completion/playbooks/www.ruhealth.org.md
+++ b/.claude/skills/form-completion/playbooks/www.ruhealth.org.md
@@ -1,0 +1,275 @@
+# Playbook: www.ruhealth.org (Riverside University Health System, New to WIC)
+
+Confirmed 2026-08-05 with agent-browser 0.33.2.
+
+**WARNING: This is a live government benefits form. Do not submit test data. Do not
+submit without explicit approval from the user.**
+
+**Freshness probe.** Each command below must return 1. If a command does not return 1,
+the site changed. Use the cold-start procedure. Write this file again.
+
+```bash
+agent-browser get count "#edit-name"
+agent-browser get count "#edit-please-choose-the-wic-clinic-closest-to-you"
+agent-browser get count "#edit-submit"
+```
+
+## URL — the Form Is on the Entry Page
+
+```
+https://www.ruhealth.org/appointments/apply-4-wic-form#
+```
+
+The form is on the entry page. There are no pages between the entry URL and the form.
+No apply link and no continue link is necessary.
+
+The form is a Drupal webform. It is INLINE in the page. It is not in an iframe. The
+page has 6 iframes: one reCAPTCHA anchor, one reCAPTCHA bframe, and ad trackers. Do
+not look for the fields in an iframe.
+
+The form element is `form.webform-submission-form`. Give this selector to the `FIELDS`
+helper to get the field inventory in one call.
+
+## Selector Rules for This Site
+
+Use `#id` selectors. Every field has a stable id with the `edit-` prefix.
+
+`iframe:nth-of-type(N)` and `form:nth-of-type(N)` FAIL for N greater than 1 on this
+page. The elements do not have the same parent, so `nth-of-type` does not count them
+as one group. Use `#id` selectors, or attribute selectors such as
+`iframe[src*='recaptcha/api2/anchor']`.
+
+## Required Fields
+
+Three fields have the HTML `required` attribute:
+
+- `#edit-date-of-birth`
+- `#edit-home-address`
+- `#edit-mobile`
+
+`#edit-name` and `#edit-email` are NOT HTML-required. To test this, use
+`get attr "#edit-name" required`. The command returns `✓ Done` when the attribute is
+absent, and `required` when the attribute is present. `✓ Done` is not a value.
+
+The usual payload contains a value for each required field. There is no gap question
+for the required fields on this site. Ask the participant instead for the decisions in
+the "Gates" section, because the payload does not contain those.
+
+## Field Table
+
+All the text fields have `maxlength 255`, except where the table gives another value.
+No field on this form has an input mask. `fill` works on every text field, including
+the date field.
+
+| id | type | maxLength | Mask | Fill method |
+|---|---|---|---|---|
+| `edit-name` | text | 255 | none | `fill` |
+| `edit-date-of-birth` | text | 255 | none | `fill` with `MM/DD/YYYY` |
+| `edit-home-address` | text | 255 | none | `fill` |
+| `edit-mailing-address-if-different-from-home-address-` | text | 255 | none | `fill`, or leave empty |
+| `edit-mobile` | tel | 128 | none | `fill` with `NNN-NNN-NNNN` |
+| `edit-email` | email | 254 | none | `fill` |
+| `edit-if-yes` | text | 255 | none | `fill`, or leave empty |
+| `edit-what-is-your-preferred-language` | select | — | — | `select` by option text |
+| `edit-please-choose-the-wic-clinic-closest-to-you` | select | — | — | `select` by option text |
+| `edit-can-you-receive-text-messages-yes` / `-no` | radio | — | — | `check` |
+| `edit-do-you-have-medical-yes` / `-no` / `-in-progress` | radio | — | — | `check` |
+| `edit-please-select-all-that-apply-*` | checkbox | — | — | `check` |
+| `edit-i-authorize-my-wic-appointments-select-all-that-apply-*` | checkbox | — | — | `check` |
+| `edit-url` | text | 255 | — | LEAVE EMPTY. Honeypot. |
+
+### The Date Field Accepts a Plain Fill
+
+`#edit-date-of-birth` is `type=text` with `maxlength 255`. It has no mask and no date
+picker that captures keys. Use `fill` with the `MM/DD/YYYY` format. The readback gives
+back the same string. The per-key `K` helper is not necessary on this field.
+
+## Gates and Their Polarity
+
+This form has no master gate. No answer hides or shows another block. Fill the fields
+in any sequence.
+
+Two radio groups are true radio groups, and not independent checkbox pairs. To set one
+member clears the other members of the group. Read EVERY member of the group again
+after the write, to confirm this.
+
+| Group | Members | Effect |
+|---|---|---|
+| Can you receive text messages | `-yes`, `-no` | To set one clears the other. |
+| Do you have MediCal | `-yes`, `-no`, `-in-progress` | To set one clears the other two. |
+
+`#edit-if-yes` is the "If yes - MediCal Case #" field. The label makes it conditional,
+but the field stays visible and enabled when the MediCal answer is No. The field does
+not become disabled. Leave it empty when the answer is No. A CalWORKs id is NOT a
+Medi-Cal case number. Do not put a CalWORKs id in this field.
+
+The two checkbox groups are independent checkboxes with "select all that apply"
+labels. Set only the members that the participant confirms. Leave the other members
+clear.
+
+- WIC category: `-pregnant`, `-post-partum`, `-infant-breastfeeding`,
+  `-infant-formula`, `-childrentoddler-0-5`
+- Appointment authorization: `-in-person`, `-virtual-phone`, `-telehealth-video`
+
+## Mailing Address — Leave Empty When It Is the Same
+
+The label of `#edit-mailing-address-if-different-from-home-address-` is "Mailing
+address (if different from home address)". When the mailing address is the same as the
+home address, an empty field is correct. Do not copy the home address into this field.
+
+The address is ONE free-text line. The form has no separate city, state, or ZIP field.
+Put the full address in one string.
+
+## Exact Select Option Text
+
+`#edit-what-is-your-preferred-language`:
+
+```
+- None -
+English
+Spanish
+Other
+```
+
+`#edit-please-choose-the-wic-clinic-closest-to-you`:
+
+```
+Arlanza Riverside WIC      <-- this option is DUPLICATED, see the warning
+Arlanza Riverside WIC      <-- duplicate
+Banning WIC
+Blythe WIC
+Cathedral City WIC
+Corona WIC
+Desert Hot Springs WIC
+Hemet WIC
+Indio WIC
+Jurupa WIC
+Lakeshore WIC
+Mecca WIC
+Moreno Valley WIC
+Riverside Neighborhood WIC
+North Riverside WIC
+Palm Springs WIC
+Perris WIC
+Rubidoux WIC
+Temecula WIC
+```
+
+**WARNING: "Arlanza Riverside WIC" is in the list TWICE.** This is a defect of the
+site. Select by option TEXT, and never by index. An index that a count gives can move
+to the wrong option because of the duplicate.
+
+`get value` on a select returns the option INDEX, and not the text. To read a select
+again, use:
+
+```bash
+agent-browser get text "#edit-what-is-your-preferred-language option:checked"
+agent-browser get text "#edit-please-choose-the-wic-clinic-closest-to-you option:checked"
+```
+
+## The Honeypot Field
+
+`#edit-url` has the label "Leave this field blank". It is a spam honeypot. LEAVE IT
+EMPTY. A value in this field identifies the submission as a bot submission, and the
+site can reject the application without a message.
+
+## The CAPTCHA
+
+The form has a Google reCAPTCHA v2 checkbox.
+
+- Sitekey: `6LdjsCcdAAAAAEZAN7mpCoyarPt_fZCpcJXlIGhk`
+- Container: `.g-recaptcha`, with `data-sitekey`
+- Token target: `#g-recaptcha-response`, a textarea. It is present but NOT visible.
+  This is normal for reCAPTCHA v2.
+- The visible checkbox is `iframe[src*='recaptcha/api2/anchor']`, with `size=normal`
+  and `type=image`. The challenge popup is `iframe[src*='bframe']`.
+
+An empty `get value "#g-recaptcha-response"` means there is no token, so nobody solved
+the challenge.
+
+Do not solve the challenge. Do not bypass the challenge. Do not script the challenge.
+Report the state only:
+
+```bash
+agent-browser get count "iframe"
+agent-browser get value "#g-recaptcha-response"
+agent-browser is visible "iframe[src*='recaptcha/api2/anchor']"
+```
+
+## The Submit Condition
+
+`#edit-submit` is a submit input with the value "Submit".
+
+**`#edit-submit` is ENABLED when the form is empty, and it stays enabled when there is
+no captcha token.** The button is never disabled. Do not use the state of the button
+as proof that the form is complete, and do not use it as proof that the captcha is
+complete. Drupal validates the captcha on the server after the submit step.
+
+A human must solve the captcha before the submit step. Then get the approval of the
+user. Then click `#edit-submit`.
+
+## Screenshot Artifacts on This Page
+
+Two elements are absent from a `screenshot --full` capture, but they ARE on the page.
+Do not diagnose these as fill failures:
+
+1. The sticky site header covers the Date of Birth row in the stitched full-page
+   image. `get value "#edit-date-of-birth"` gives the correct value.
+2. The reCAPTCHA widget does not show in the stitched image. The CAPTCHA heading
+   shows, and the widget area looks empty. The anchor iframe is present and visible.
+
+Confirm both with `get value` and `is visible`, and not with a screenshot.
+
+## Payload Values With No Field on This Form
+
+This form is short. The usual payload contains many values that have no field. Report
+these as unused. Do not force them into a field that looks similar:
+
+`record_id`, `file_open_date`, `dpss_referral_date`, `verbal_consent_provided`,
+`funding_source`, `calworks_id`, `ethnicity`, `gender`, `special_needs`,
+`farm_worker`, `marital_status`, the home phone, the work phone, the main phone,
+`county`, the separate city, state, and ZIP fields (the address is one free-text
+line), and the mailing address when it is the same as the home address.
+
+## Warm-Path Fill
+
+```bash
+source .claude/skills/form-completion/scripts/fill-helpers.sh
+SESSION=<session>
+
+S fill "#edit-name" "<full name, with the middle name>"
+S fill "#edit-date-of-birth" "<MM/DD/YYYY>"
+S fill "#edit-home-address" "<street, city, state, ZIP on one line>"
+S fill "#edit-mobile" "<NNN-NNN-NNNN>"
+S fill "#edit-email" "<email>"
+S select "#edit-what-is-your-preferred-language" "<English|Spanish|Other>"
+S select "#edit-please-choose-the-wic-clinic-closest-to-you" "<exact clinic text>"
+C "#edit-can-you-receive-text-messages-<yes|no>"
+C "#edit-do-you-have-medical-<yes|no|in-progress>"
+C "#edit-please-select-all-that-apply-<category>"
+C "#edit-i-authorize-my-wic-appointments-select-all-that-apply-<mode>"
+```
+
+There is ONE Name field. Put the full name, INCLUDING the middle name, in it.
+
+Readback. Do all of it. Read every member of the two radio groups:
+
+```bash
+V edit-name edit-date-of-birth edit-home-address edit-mobile edit-email
+agent-browser get text "#edit-what-is-your-preferred-language option:checked"
+agent-browser get text "#edit-please-choose-the-wic-clinic-closest-to-you option:checked"
+agent-browser is checked "#edit-can-you-receive-text-messages-yes"
+agent-browser is checked "#edit-can-you-receive-text-messages-no"
+agent-browser is checked "#edit-do-you-have-medical-yes"
+agent-browser is checked "#edit-do-you-have-medical-no"
+agent-browser is checked "#edit-do-you-have-medical-in-progress"
+```
+
+## Exceptions Solved in the Cold-Start Session
+
+- No field on this form needed the per-key `K` helper. Every `fill` was correct on the
+  first attempt, and the date field also was correct.
+- The empty widget area in the full-page screenshot is not a defect of the captcha.
+  The anchor iframe is present and visible.
+- The empty Date of Birth row in the full-page screenshot is not a fill failure. The
+  sticky header covers the row.

--- a/.claude/skills/form-completion/references/gap-analysis-and-provenance.md
+++ b/.claude/skills/form-completion/references/gap-analysis-and-provenance.md
@@ -84,6 +84,41 @@ the report.
 One question holds a maximum of four options. If a checkbox group has more than
 four items, split the group across two questions in the same call.
 
+### Large Forms (20 or More Gaps)
+
+A large application (a state benefits portal, a multi-page application) can have 20
+to 30 gaps. The count does not change the rules. It changes the presentation:
+
+- Show the FULL gap-analysis table first, in one message. The user must see the
+  full scope of the questions before the first question call. Do not show the
+  gaps in small parts.
+- Then ask with question calls in sequence. Group each call by a section of the
+  form. Put the application name and the section name in each header (example:
+  "SNAP — Income", "SNAP — Household").
+- Thirty gaps take approximately eight question calls. That is correct. Do not
+  remove a gap to make the list short.
+- A conditional field depends on an answer (example: due date applies only when
+  the person is pregnant). Ask the controlling question first. Ask the dependent
+  question only when the answer makes the field applicable.
+
+### Values You Must Not Derive
+
+A fact next to a field is not the value of the field. Do not derive these values.
+Ask for them:
+
+- **A status from an address.** An address on file does not show that the person
+  has stable housing. Many people without housing have a mailing address or a
+  shelter address. Use only an explicit status value. When none exists, ask.
+- **A contact preference from the available contacts.** A phone number on file
+  does not show that the person prefers phone contact. When the form asks for a
+  preferred contact method and no source states one, ask.
+- **A household answer from a marital status.** "Single" does not show that the
+  person lives alone.
+
+The pattern is the same in each example: the form asks for a statement from the
+person, and the record holds an adjacent fact. The fact does not answer the
+question. These fields go in the MISSING group.
+
 ### How to Write the Questions
 
 The user is a person who wants to complete a form. The user is not a developer.

--- a/.claude/skills/form-completion/references/gap-analysis-and-provenance.md
+++ b/.claude/skills/form-completion/references/gap-analysis-and-provenance.md
@@ -1,0 +1,170 @@
+# Gap Analysis and Provenance
+
+Two reports are mandatory in each form run. Show the gap analysis before you fill.
+Show the provenance report after you fill. This file gives the format and the rules
+for both.
+
+## Part 1 — the Gap Analysis (Before the Fill)
+
+Show the user a gap-analysis table before the first write. Do not fill a field before
+the user answers all the required gaps. Put each field in one of these groups:
+
+| Group | Meaning | Action |
+|---|---|---|
+| READY | The payload or the user gave the value. | Fill it. No question. |
+| DERIVED | A rule changes the value to the form format. | Show the rule in the table. Fill it. |
+| GAP-REQUIRED | The form requires the field. No source has the value. | Ask. Do not fill before the answer. |
+| GAP-DECISION | The answer changes the fill procedure. | Ask. Examples: self or on-behalf, mailing address the same as residential. |
+| NO-FIELD | The payload has the value. The form has no field for it. | Show it in the final report as unused. |
+
+Example table to show the user:
+
+```
+GAP ANALYSIS — <the application name>
+READY (12):      first name, last name, street, city, zip, date of birth, phone, ...
+CHANGED (3):     "California" becomes "CA" — the form wants 2 letters
+                 "Spanish (Mexico)" becomes "Spanish" — the form's own list
+                 street and apartment go on one line — the form has one box
+MISSING (6):     Social Security Number, living arrangement, income,
+                 household size, health information, service needs
+DECISIONS (2):   applying for herself or with help; mail goes to the same address?
+NO PLACE (5):    middle name, work/cell phones, case numbers, ...
+```
+
+The table goes to the user. Use the plain group names above (CHANGED, MISSING,
+DECISIONS, NO PLACE). Keep the technical group names (DERIVED, GAP-REQUIRED,
+GAP-DECISION, NO-FIELD) in the transcript and in the agent reports.
+
+### Rules for the Questions
+
+- Ask all the gap questions in the same phase, before the fill.
+- One `AskUserQuestion` call holds a maximum of four questions. If there are more
+  than four gaps, use two or more calls in sequence. Do not remove gaps to fit one
+  call. **Do not guess the answers that did not fit.**
+- If the user does not give an answer for a required gap, keep the field empty. Show
+  the empty field in the final report. An empty field is correct. An invented value
+  is not correct.
+- Treat all data as real data. Do not ask if the data is real or test data. The
+  submit step always needs approval, and that approval is the protection.
+- **Each session is a new participant.** Ask for each missing required value in each
+  session. Do not keep participant answers between sessions. Do not write
+  participant values or decisions to any file that lives after the session. Site
+  facts go in the playbook. Participant data does not.
+
+### Ask for the Value, Not for Instructions
+
+A gap question collects data for one field. Ask for the missing value directly. Do
+not ask the user what to do about a missing value.
+
+Bad (a process question):
+
+> The payload has no SSN. Required field `ssnTxt`. How should I handle it?
+> 1. Leave empty, report it
+> 2. Use a test SSN
+
+Good (a data question):
+
+> What is Maria's Social Security Number? You can type it, or choose an option.
+> 1. Leave it empty for now
+> 2. She does not have one
+
+The user types the value through the free-text option of the question. Ask for the
+value one time. If the user leaves it empty, keep the field empty and show it in
+the report.
+
+### Match the Question Type to the Field Type
+
+| Field type | Question format |
+|---|---|
+| Typed value (SSN, name, date) | A direct question. Give two options: "Leave it empty for now" and one real alternative (example: "She does not have one"). The user types the value in the free-text option. |
+| Binary (Yes/No, lives alone) | Two plain options. Example: "Yes, she lives alone" / "No, other people live there". |
+| One choice from a list (living arrangement) | One option for each choice, in plain words. |
+| Check-all-that-apply (health history, service needs) | Set `multiSelect: true`. One option for each checkbox. Add "None of these apply" when that is a valid answer. |
+
+One question holds a maximum of four options. If a checkbox group has more than
+four items, split the group across two questions in the same call.
+
+### How to Write the Questions
+
+The user is a person who wants to complete a form. The user is not a developer.
+Write each question at an easy reading level (approximately grade 6).
+
+- Use the words that the form shows to the user. Use the person's name.
+- Do not put element ids, selectors, attribute names, character limits, ref numbers,
+  or browser terms in a question or in its options.
+- Ask about one decision in each question.
+- Give the effect of each option in plain words.
+- Keep the technical detail in the transcript and in the playbook. It has value
+  there, not in the question.
+
+Bad question (too technical):
+
+> The record shows a referral with verbal consent — that suggests someone is
+> applying on the participant's behalf. Which path?
+> 1. Maria is applying for herself — Sets chkBxSelfApplyYes. No representative
+>    block.
+> 2. On behalf — Sets chkBxSelfApplyNo, opening the representative block…
+
+Good question (plain):
+
+> Is Maria filling out this application herself, or is someone helping her apply?
+> 1. She is applying herself.
+> 2. Someone is helping her. (I will then ask for the helper's name and phone
+>    number.)
+
+Bad option (too technical):
+
+> Append to first name — nameFirstTxt = "Maria LEE" (9 chars, fits the 25 limit)
+
+Good option (plain):
+
+> Put it with her first name, as "Maria LEE"
+
+**WARNING: Do not fill a required field with an assumption. A form sent to a
+government agency with invented data can cause legal and eligibility problems for a
+real person. This rule has no exceptions. A "common baseline" or a "reasonable
+default" is an assumption.**
+
+## Part 2 — the Provenance Report (After the Fill)
+
+After the readback in Phase 4, show the user a table of each value and its source.
+Use these source categories:
+
+| Source | Meaning | Example |
+|---|---|---|
+| USER | The user gave the value in this session. | The SSN from an answer to a question. |
+| PAYLOAD | The value is in the source record, unchanged. | `"city": "<city>"` → `<city>`. |
+| DERIVED | A stated rule changed a payload or user value. | The state name → the 2-letter code. `YYYY-MM-DD` → `MMDDYYYY`. |
+| EMPTY | The field has no value. Give the reason. | SSN: the user gave no value. |
+
+There is no ASSUMED category. An assumed value must not be in the form. If you find
+an assumed value at report time, remove it from the form and mark the field EMPTY.
+
+Report format:
+
+The report goes to the user. Write the Field and Detail columns in plain words —
+the words on the form, not selectors or attribute names.
+
+```
+| Field | Value in form | Source | Detail |
+|---|---|---|---|
+| First name | Maria | RECORD | from her record |
+| State | CA | CHANGED | "California" written as "CA" — the form wants 2 letters |
+| Social Security Number | (empty) | EMPTY | you did not give one; the form asks for it |
+| Living arrangement | Own home | YOU | your answer |
+```
+
+The plain source words for the user: YOU (USER), RECORD (PAYLOAD), CHANGED
+(DERIVED), EMPTY. Keep the technical category names in the transcript and in the
+fill-agent reports; show the plain words to the user.
+
+After the table, show these four items:
+
+1. Payload values with no form field (the NO-FIELD group).
+2. Required fields that are empty, with the reason for each.
+3. New site facts that you added to the playbook in this session.
+4. The approximate count of tool calls and question rounds in the run. The user
+   tracks the cost of each run.
+
+Show this report before the submit approval. The user must see the provenance of
+each value before the user approves the submit step.

--- a/.claude/skills/form-completion/references/knowledge-scribe.md
+++ b/.claude/skills/form-completion/references/knowledge-scribe.md
@@ -100,13 +100,17 @@ Skill directory: <skill-dir>   (contains playbooks/, references/, scripts/)
 ## Multi-Application Runs
 
 In a multi-application run (`multi-application.md`), the scribe is the only writer
-of ALL knowledge files, and this includes the playbooks. Fill agents write no files.
-Each fill-agent report arrives in the orchestrator transcript with a SITE FACTS
-section: the URL chain, the field table, masks, gates, option texts, and the submit
-condition. The scribe writes the playbook for each domain from that section, and
-merges the findings about tool behavior into the references. The scribe stop
-condition changes in this mode: stop after the LAST fill-agent report is in the
-transcript, not after the first.
+of ALL knowledge files, and this includes the playbooks. Fill agents and scouts
+write no files. Each scout report and each fill-agent report arrives in the
+orchestrator transcript with a SITE FACTS section: the URL chain, the field table,
+masks, gates, option texts, and the submit condition. The scribe writes the first
+playbook for a cold-start domain from the SCOUT report — the URL chain, the account
+requirement, the field tables, and the unreached sections (keep the UNCONFIRMED
+marks). When the fill-agent report for that domain arrives, merge it into the same
+playbook: confirmed methods replace UNCONFIRMED entries. The scribe also merges the
+findings about tool behavior into the references. The scribe stop condition changes
+in this mode: stop after the LAST fill-agent report is in the transcript, not after
+the first.
 
 ## Failure Behavior
 

--- a/.claude/skills/form-completion/references/knowledge-scribe.md
+++ b/.claude/skills/form-completion/references/knowledge-scribe.md
@@ -12,7 +12,12 @@ Claude Code writes each session to a transcript file on disk, live:
 The main agent does not send findings to the scribe. This costs the main agent zero
 tokens and zero turns.
 
-## How the Main Agent Starts the Scribe (Phase 0, Cold Start Only)
+## How the Main Agent Starts the Scribe (Phase 0 — Cold Start or Partial Playbook)
+
+Start the scribe when there is no playbook for the domain, and also when the
+playbook marks parts of the flow UNCONFIRMED and the fill will enter them. A run
+through unconfirmed territory makes new site facts. Do not start the scribe for a
+run that a complete playbook covers — it has nothing to write.
 
 1. Find the transcript path. The current session file is the newest `.jsonl` in the
    project directory:

--- a/.claude/skills/form-completion/references/knowledge-scribe.md
+++ b/.claude/skills/form-completion/references/knowledge-scribe.md
@@ -36,6 +36,12 @@ matches the working directory.
 4. When the scribe completes, its report arrives as a task notification. Relay the
    list of written files in your final report (report item 3).
 
+5. After the submit decision (Phase 6), send the scribe ONE message that contains
+   the word FINALIZE (SendMessage, with the scribe's agent id). This is the
+   scribe's stop signal. Without it, the scribe guesses the end of the run from
+   stall timeouts, and it guesses badly: a fill can pause for many minutes while
+   the user answers questions.
+
 ## Scribe Prompt Template
 
 ```
@@ -47,17 +53,46 @@ to the user.
 Transcript: <transcript>
 Skill directory: <skill-dir>   (contains playbooks/, references/, scripts/)
 
-## Loop
+## Loop — Wake on Markers, Not on Minutes
 
-1. Read the new transcript bytes since your last pass:
-   OFFSET=0 at start; then: tail -c +$((OFFSET+1)) "<transcript>"; update OFFSET
-   with: wc -c < "<transcript>".
-2. Distill findings from the tool calls and results (see "What to Extract").
-3. Write or update the files.
-4. Wait approximately 60 seconds. Then repeat.
-5. Stop when one of these is true: the transcript shows the provenance report or a
-   submit decision; or the file has no new bytes for 5 minutes. Do one final pass,
-   then return your report.
+Each of your turns reads your full conversation again. A 60-second poll loop in one
+run made 606 turns and read 125 million cached tokens. Your budget for the full run
+is approximately 40 turns. Obey these rules:
+
+1. NEVER call a tool to pass the time. No sleep, no "echo waiting", no size checks
+   while you wait. When there is no new marker, END YOUR TURN. The Monitor
+   notification starts your next turn.
+2. Load the Monitor tool (ToolSearch "select:Monitor"). Start ONE Monitor with the
+   script below, non-persistent. The script is silent until the new bytes hold a
+   marker, then it prints one line and exits. One notification for each wake.
+3. On a wake: read the new bytes ONCE (tail -c +$((OFFSET+1)); update OFFSET with
+   wc -c). Extract. Write the files. Start the Monitor again with the new offset.
+   End the turn.
+4. The Monitor's byte count and your own read can differ. A partial line write
+   causes this. Do NOT investigate the difference. Parse complete JSON lines only
+   and continue.
+5. Finalize when a message with the word FINALIZE arrives from the main agent, or
+   when the Monitor prints STALL (the backstop). Then do ONE final pass: the leak
+   check (Hard Rules), then your report.
+
+Monitor script (replace <transcript> and <offset>):
+
+   F="<transcript>"; OFF=<offset>; CYCLES=0
+   while true; do
+     sleep 30
+     CUR=$(wc -c < "$F")
+     if [ "$CUR" -gt "$OFF" ]; then
+       if tail -c +$((OFF+1)) "$F" | grep -qE "SITE FACTS|task-notification|FINALIZE"; then
+         echo "MARKER"; exit 0
+       fi
+       OFF=$CUR
+     fi
+     CYCLES=$((CYCLES+1))
+     [ "$CYCLES" -ge 40 ] && { echo "STALL"; exit 0; }
+   done
+
+Growth without a marker is intake dialogue — participant answers, not site facts.
+The script skips it without a wake. Your read on the next wake covers those bytes.
 
 ## What to Extract, and Where It Goes
 
@@ -84,7 +119,12 @@ Skill directory: <skill-dir>   (contains playbooks/, references/, scripts/)
 - NEVER write participant data into any file. The transcript contains names, phone
   numbers, addresses, and possibly an SSN. Playbook examples use placeholders
   ("MMDDYYYY", "the 2-letter state code", "input[value='N']"), never the
-  participant's values.
+  participant's values. A value that equals a participant value from the transcript
+  IS participant data, also when it looks like an example: the 9 digits that the
+  transcript shows in an SSN fill are the participant's entry — write "NNN-NN-NNNN"
+  in the file. Before your final report, run the leak check: grep every knowledge
+  file for the participant's names, numbers, dates, and address parts that you saw
+  in the transcript. Remove each hit. Your report includes the leak-check result.
 - Record a finding when the transcript CONFIRMS it (a readback, an is-check, a
   count). Do not record a finding when the main agent only tries something. A failed
   try is a finding only when the transcript shows the correct alternative with it.
@@ -108,9 +148,10 @@ playbook for a cold-start domain from the SCOUT report — the URL chain, the ac
 requirement, the field tables, and the unreached sections (keep the UNCONFIRMED
 marks). When the fill-agent report for that domain arrives, merge it into the same
 playbook: confirmed methods replace UNCONFIRMED entries. The scribe also merges the
-findings about tool behavior into the references. The scribe stop condition changes
-in this mode: stop after the LAST fill-agent report is in the transcript, not after
-the first.
+findings about tool behavior into the references. The stop signal does not change:
+the orchestrator sends FINALIZE after the last submit decision. Do not stop on a
+fill-agent report — a BLOCKED application continues after the user answers, and one
+application can report five or more times.
 
 ## Failure Behavior
 
@@ -122,7 +163,9 @@ the first.
 
 ## Cost
 
-The scribe is one background agent that reads a local file each minute. It reads
-only the new bytes in each pass, not the full file. The cost is approximately the
-tokens of one more short session. The main run spends no turns on documentation,
-and the playbook is complete when the run ends.
+The content the scribe ingests is small. The turns are the cost: each turn reads
+the scribe's full conversation again at cache-read prices. A poll-loop scribe in
+one run made 606 turns and read 125 million cached tokens — more than the fill
+agents that did the work. The marker-wake loop above makes approximately one turn
+for each report, near 40 turns for a three-application run. The main run still
+spends no turns on documentation, and the playbook is complete when the run ends.

--- a/.claude/skills/form-completion/references/knowledge-scribe.md
+++ b/.claude/skills/form-completion/references/knowledge-scribe.md
@@ -71,11 +71,18 @@ is approximately 40 turns. Obey these rules:
 4. The Monitor's byte count and your own read can differ. A partial line write
    causes this. Do NOT investigate the difference. Parse complete JSON lines only
    and continue.
-5. Finalize when a message with the word FINALIZE arrives from the main agent, or
-   when the Monitor prints STALL (the backstop). Then do ONE final pass: the leak
-   check (Hard Rules), then your report.
+5. Finalize ONLY on a message with the word FINALIZE from the main agent. On
+   FINALIZE: read ALL the transcript bytes after your offset, extract, write,
+   then the leak check (Hard Rules), then your report.
+6. STALL is NOT a stop signal. A run pauses for many minutes while the user
+   answers questions, and one scribe that stopped on a stall missed the last
+   three reports of the run. On a STALL wake: do one pass over any new bytes,
+   start the Monitor again, and end the turn. Stop without FINALIZE only after
+   THREE STALL wakes in sequence with zero new bytes (that is more than one hour
+   of silence).
 
-Monitor script (replace <transcript> and <offset>):
+Monitor script (replace <transcript> and <offset>; the counter resets when the
+file grows, so STALL means 20 minutes with no growth at all):
 
    F="<transcript>"; OFF=<offset>; CYCLES=0
    while true; do
@@ -85,9 +92,10 @@ Monitor script (replace <transcript> and <offset>):
        if tail -c +$((OFF+1)) "$F" | grep -qE "SITE FACTS|task-notification|FINALIZE"; then
          echo "MARKER"; exit 0
        fi
-       OFF=$CUR
+       OFF=$CUR; CYCLES=0
+     else
+       CYCLES=$((CYCLES+1))
      fi
-     CYCLES=$((CYCLES+1))
      [ "$CYCLES" -ge 40 ] && { echo "STALL"; exit 0; }
    done
 

--- a/.claude/skills/form-completion/references/knowledge-scribe.md
+++ b/.claude/skills/form-completion/references/knowledge-scribe.md
@@ -1,0 +1,124 @@
+# The Knowledge Scribe — a Parallel Agent That Writes the Playbook
+
+On a cold start, the main agent must not stop to write documentation. A second agent —
+the scribe — runs in the background, reads the live session transcript from disk, and
+writes the knowledge files in real time. The main agent fills the form. The scribe
+writes the playbook.
+
+## Why the Transcript, Not Messages
+
+Claude Code writes each session to a transcript file on disk, live:
+`~/.claude/projects/<project-slug>/<session-id>.jsonl`. The scribe reads this file.
+The main agent does not send findings to the scribe. This costs the main agent zero
+tokens and zero turns.
+
+## How the Main Agent Starts the Scribe (Phase 0, Cold Start Only)
+
+1. Find the transcript path. The current session file is the newest `.jsonl` in the
+   project directory:
+
+```bash
+ls -t ~/.claude/projects/$(pwd | tr '/.' '--')/*.jsonl | head -1
+```
+
+If the directory is not found, list `~/.claude/projects/` and select the entry that
+matches the working directory.
+
+2. Start the scribe with the Agent tool. Run it in the background (the default). Set
+   `model: "sonnet"` — the scribe reads large transcript deltas, and the smaller model
+   costs approximately one third of the orchestrator model for each input token. Use
+   the prompt template below. Replace `<transcript>`, `<domain>`, and `<skill-dir>`.
+
+3. Continue with Phase 1 immediately. Do not wait for the scribe. Do not write the
+   playbook, scripts, or references yourself during the run — the scribe owns those
+   files while it runs. This prevents write conflicts.
+
+4. When the scribe completes, its report arrives as a task notification. Relay the
+   list of written files in your final report (report item 3).
+
+## Scribe Prompt Template
+
+```
+You are the knowledge scribe for a live form-completion session. The main agent
+fills a web form for <domain>. Your task is to read the transcript of the main
+agent and to write the knowledge files. You do not fill the form. You do not talk
+to the user.
+
+Transcript: <transcript>
+Skill directory: <skill-dir>   (contains playbooks/, references/, scripts/)
+
+## Loop
+
+1. Read the new transcript bytes since your last pass:
+   OFFSET=0 at start; then: tail -c +$((OFFSET+1)) "<transcript>"; update OFFSET
+   with: wc -c < "<transcript>".
+2. Distill findings from the tool calls and results (see "What to Extract").
+3. Write or update the files.
+4. Wait approximately 60 seconds. Then repeat.
+5. Stop when one of these is true: the transcript shows the provenance report or a
+   submit decision; or the file has no new bytes for 5 minutes. Do one final pass,
+   then return your report.
+
+## What to Extract, and Where It Goes
+
+- SITE FACTS -> <skill-dir>/playbooks/<domain>.md
+  The URL chain to the real form. Field ids, types, maxLength values, mask methods.
+  Gates, their polarity, and the fill sequence. Exact select option text. Duplicate-id
+  groups with their value/label maps. The submit enablement condition. Two or three
+  stable ids for the freshness probe. Follow the playbook structure in SKILL.md
+  Phase 0. Write in ASD-STE100 Simplified Technical English.
+- REUSABLE SHELL PATTERNS -> <skill-dir>/scripts/
+  If the main agent improvises the same shell pattern two or more times, write it as
+  a helper function with STE comments. Check the syntax with `bash -n`. Do not add a
+  helper for a pattern seen one time on one site.
+- TOOL SEMANTICS -> append to <skill-dir>/references/silent-failures.md General Rules
+  Only behaviors of agent-browser itself (a flag that no-ops, a selector class that
+  fails). These are site-independent. Site behaviors NEVER go in references — they go
+  in the playbook. This is the anti-overfitting rule in SKILL.md.
+
+## Hard Rules
+
+- NEVER run agent-browser commands. The browser session belongs to the main agent.
+  A command from you can change the form state during the fill. You read the
+  transcript and you write files. Do nothing else.
+- NEVER write participant data into any file. The transcript contains names, phone
+  numbers, addresses, and possibly an SSN. Playbook examples use placeholders
+  ("MMDDYYYY", "the 2-letter state code", "input[value='N']"), never the
+  participant's values.
+- Record a finding when the transcript CONFIRMS it (a readback, an is-check, a
+  count). Do not record a finding when the main agent only tries something. A failed
+  try is a finding only when the transcript shows the correct alternative with it.
+- Update, do not duplicate: if the playbook file exists, merge into it.
+
+## Your Report (returned when you stop)
+
+- Files written or updated, one line each with what changed
+- Findings you saw but did NOT record, with the reason (unconfirmed, participant
+  data, single-site pattern)
+```
+
+## Multi-Application Runs
+
+In a multi-application run (`multi-application.md`), the scribe is the only writer
+of ALL knowledge files, and this includes the playbooks. Fill agents write no files.
+Each fill-agent report arrives in the orchestrator transcript with a SITE FACTS
+section: the URL chain, the field table, masks, gates, option texts, and the submit
+condition. The scribe writes the playbook for each domain from that section, and
+merges the findings about tool behavior into the references. The scribe stop
+condition changes in this mode: stop after the LAST fill-agent report is in the
+transcript, not after the first.
+
+## Failure Behavior
+
+- If the scribe stops or does not start, the fill continues with no damage. The main
+  agent completes the fill. The playbook is written on the next cold start. Do not
+  stop the fill because of a scribe problem.
+- If the scribe and the main agent find the same fact, the scribe writes it. The
+  main agent does not write files during the run, so a conflict is not possible.
+
+## Cost
+
+The scribe is one background agent that reads a local file each minute. It reads
+only the new bytes in each pass, not the full file. The cost is approximately the
+tokens of one more short session. The main run spends no turns on documentation,
+and the playbook is complete when the run ends.

--- a/.claude/skills/form-completion/references/multi-application.md
+++ b/.claude/skills/form-completion/references/multi-application.md
@@ -10,6 +10,7 @@ parallel. Sections of one form share one page, so they cannot.
 | Role | Count | Job |
 |---|---|---|
 | Orchestrator | 1 (the main session) | All user conversation. Consolidated intake. Dispatch. The consolidated final report. Submit approvals. |
+| Scout | 1 for each cold-start application | Find the real form. Return the field inventory. No fills. No account creation. No user conversation. No file writes. |
 | Fill agent | 1 for each application | Fill and verify ONE application in its own browser. No user conversation. No file writes. |
 | Scribe | 1 (background) | Reads the orchestrator transcript. Writes ALL knowledge files: `playbooks/`, `scripts/`, `references/`. See `knowledge-scribe.md`. |
 
@@ -22,11 +23,17 @@ parallel. Sections of one form share one page, so they cannot.
   session name and its own browser instance.
 - **Only the orchestrator talks to the user.** A fill agent that needs an answer
   stops and returns a BLOCKED report. It never waits for a user.
-- **The scribe is the only writer of knowledge files.** Fill agents write no files.
-  A fill agent returns its findings in the SITE FACTS section of its report. The
-  report arrives in the orchestrator transcript, and the scribe writes the playbook
-  from it. One writer keeps the language rules, the no-bias rule, and the
+- **The scribe is the only writer of knowledge files.** Fill agents and scouts write
+  no files. They return their findings in the SITE FACTS section of their reports. The
+  reports arrive in the orchestrator transcript, and the scribe writes the playbook
+  from them. One writer keeps the language rules, the no-bias rule, and the
   no-participant-data rule in one place.
+- **The orchestrator does not survey a site.** After the tab setup and the freshness
+  probes, the orchestrator sends no agent-browser commands. A survey by the
+  orchestrator stops the intake: the user waits, and the gap analysis for the ready
+  applications does not start. This occurred on 2026-08-05: the orchestrator followed
+  a large portal's apply links itself, and the gap analysis for two applications with
+  fresh playbooks did not start. A scout does the survey.
 
 ## Procedure
 
@@ -34,32 +41,82 @@ parallel. Sections of one form share one page, so they cannot.
 
 1. For each application: find the playbook, do the freshness probe (Phase 0 of
    SKILL.md).
-2. For an application with NO playbook, do the field inventory yourself, now, before
-   the gap analysis. You cannot make a correct gap analysis for a form that you did
-   not read. Open the page in the session that the fill agent will use, then:
-   - `get count` for `input`, `select`, `textarea`, `iframe`, `form` — this gives the
-     size of the form and shows if an iframe can hold it.
-   - `FIELDS "body"` (see `scripts/fill-helpers.sh`) — the full field map in one call.
-   - Read the `src` of each iframe. Many iframes are reCAPTCHA and ad trackers. Do
-     not assume that the form is inside an iframe. On the WIC form, all 6 iframes
-     were noise and the form was inline.
-   - Probe `required` and `maxlength` on the fields that you plan to fill.
-   Put this map in the fill-agent prompt. The fill agent then starts with a plan, not
-   with discovery. The scribe writes the playbook from the reports at the end.
-3. Build ONE gap analysis that covers all the applications. Group the gaps by
-   application.
-4. Ask the user all the gap questions now, grouped by application, in plain language
-   (the rules in `gap-analysis-and-provenance.md` apply). Tell the user which
-   application each question group belongs to. Put the application name in the header
-   of each question (example: "IHSS: SSN", "WIC: clinic"). The user answers questions
-   for two forms in one list, so the header is the only signal of which form a
-   question belongs to.
-5. Report a submit blocker in the gap analysis, with the gaps. Example: a reCAPTCHA on
-   the form. The fill can finish, but the submit needs the user. The user must know
-   this before the fill starts, not after.
-6. Do not start a fill agent before its application has all its required answers.
-   Start the applications that are ready. Ask the user about the other applications
-   while the started agents run.
+2. For an application with NO playbook, start a scout agent in the background, now
+   (see "The Scout" below). Do not survey the site yourself — the hard rule above.
+   You cannot make a correct gap analysis for a form that no agent read, so the
+   scout reads it while you talk to the user.
+3. Build the gap analysis for the applications WITH playbooks, from their playbook
+   field tables. Show it and ask the questions NOW. Do not wait for the scouts.
+4. Ask the gap questions grouped by application, in plain language (the rules in
+   `gap-analysis-and-provenance.md` apply). Put the application name in the header
+   of each question (example: "IHSS: SSN", "WIC: clinic"). The user answers
+   questions for two or more forms in one list, so the header is the only signal of
+   which form a question belongs to. For a scouted application, tell the user what
+   comes next (example: "The food-assistance application needs more answers — I
+   will ask them when the survey of that site is complete"). Do not ask a question
+   that the scout did not confirm.
+5. When a scout report arrives, build the gap analysis for that application from
+   the report, and ask a second round of questions. A large application can have
+   20 or more gaps — obey "Large Forms" in `gap-analysis-and-provenance.md`: show
+   the full table first, then ask in groups that follow the sections of the form.
+6. Report a submit blocker in the gap analysis, with the gaps. Examples: a reCAPTCHA
+   on the form, or an account wall from a scout report. The fill can finish, but the
+   submit needs the user. The user must know this before the fill starts, not after.
+7. Do not start a fill agent before its application has all its required answers.
+   Start the applications that are ready. The warm applications usually start while
+   the scouts run.
+
+#### The Scout (Cold-Start Discovery)
+
+A scout is a background agent that reads ONE application site and returns the field
+inventory. Start it with the Agent tool, `model: "sonnet"` (it must find the real
+form behind menus and interstitial pages, and that needs judgment). The scout uses
+the session name and the tab that the fill agent will use later, so the browser is
+already on the form when the fill agent starts. Scout prompt template:
+
+```
+Survey ONE application site for a form fill that a different agent will do later.
+Do not fill any field. Do not enter any data. Do not create an account. Do not
+talk to a user. Do not write files.
+
+- Application: <url>
+- Browser: from <client dir> run `./node_modules/.bin/agent-browser --session
+  <name> <cmd>`. The session is ALREADY connected and the tab is ALREADY open.
+  Your FIRST command is `tab <label>`; then `get url` to confirm the selection.
+  Do NOT run `connect`. Do NOT run `tab new`.
+- Helpers: `source <skill-dir>/scripts/fill-helpers.sh; SESSION=<name>` gives
+  SURVEY, FIELDS, IFRAMES, and OPTIONS.
+
+Procedure:
+1. Find the real form. Follow the apply or start links through the interstitial
+   pages. Record the URL chain.
+2. If the site asks for an account or a login before the form, stop there. Report
+   it. Do not make an account.
+3. On each form page that you can reach: run SURVEY, then FIELDS. Record the ids,
+   the types, the labels, the required marks, the maxlength values, and the exact
+   select option texts.
+4. A multi-page form hides the later pages until data goes in. Do not enter data
+   to reach them. Report the pages that you reached. When the page shows its own
+   section list (a progress bar, a menu, a table of contents), record the section
+   names and mark each unreached section UNCONFIRMED.
+5. Leave the browser on the first form page (or on the account wall). The fill
+   agent continues from there.
+
+Return SITE FACTS only (this report is for the orchestrator and the scribe, not
+for a user):
+- STATUS: FORM-REACHED, ACCOUNT-WALL, or NOT-FOUND
+- The URL chain
+- The account or login requirement, if one exists
+- The field table for each page that you reached
+- The section names for the pages that you did not reach, each marked UNCONFIRMED
+- Bot checks that you saw (do not try to pass one)
+- Approximate tool call count
+```
+
+The scout report arrives as a task notification. It also lands in the orchestrator
+transcript, so the scribe writes the first playbook for the domain from it
+(`knowledge-scribe.md`). The fill-agent prompt for that application then contains
+the scout's field table as its field map.
 
 ### 2. Browser Isolation
 
@@ -121,6 +178,7 @@ model choice controls most of the run cost.
 |---|---|---|
 | Fill agent with a playbook (warm path) | `haiku` | The playbook gives the exact selectors and methods. The fill is checklist work. |
 | Fill agent with no playbook (cold start) | `sonnet` | Discovery needs judgment: label mapping, gate polarity. |
+| Scout | `sonnet` | It must find the real form behind menus and interstitial pages. |
 | Scribe | `sonnet` | It writes the knowledge files that later runs depend on. |
 
 A small-model fill agent stays safe because of the BLOCKED rule: when the playbook
@@ -143,8 +201,9 @@ Fill ONE application. Do not talk to a user. Follow the form-completion skill
   Do NOT run `connect` again. Do NOT use port <M> — another agent owns it.
 - Helpers: `source <skill-dir>/scripts/fill-helpers.sh; SESSION=<name>` gives
   S/K/C/U/V/FIELDS. Use K for each masked field. Use FIELDS for a same-id group.
-- Field map (cold start only): <the inventory from step 1.2, plus the fields that
-  the agent must NOT fill and why>
+- Field map (cold start only): <the field table from the scout report, plus the
+  fields that the agent must NOT fill and why. The browser is already ON the form
+  page — the scout left it there.>
 - Answered gap table: <the values and decisions from intake, for this application.
   Give the exact selector and the exact value for each field. Say which checkbox
   values stay clear.>
@@ -213,6 +272,8 @@ tool calls, and no silent failure on the first readback pass. The warm applicati
 
 ## Failure Behavior
 
+- A scout dies or finds no form: report it to the user with the scout's last known
+  state. The other applications continue. Do not survey the site yourself.
 - A fill agent dies: report that application as failed with its last known state.
   The other applications continue. Offer the user a restart of the failed one.
 - The scribe dies: no effect on the fills (see `knowledge-scribe.md`).

--- a/.claude/skills/form-completion/references/multi-application.md
+++ b/.claude/skills/form-completion/references/multi-application.md
@@ -272,6 +272,14 @@ tool calls, and no silent failure on the first readback pass. The warm applicati
   fill agent — the running agent holds the browser session and the context.
 - One failed application does not stop the others. Show the partial results in the
   report.
+- **A scribe report that arrives while a fill agent still runs is an early stop.**
+  Do not accept it. Resume THE SAME scribe with SendMessage: tell it that the run
+  continues, and to wait for FINALIZE. In one run, a scribe stopped fourteen
+  minutes early and the last three SITE FACTS reports never reached the playbook.
+  If the scribe cannot resume, send the missed reports to it in the FINALIZE
+  message, or write the playbook update yourself at the end of the run — SITE
+  FACTS in the transcript must reach the playbook before the run ends, with the
+  scribe or without it.
 
 ### 5. Consolidated Report and Submit Gates (Orchestrator)
 

--- a/.claude/skills/form-completion/references/multi-application.md
+++ b/.claude/skills/form-completion/references/multi-application.md
@@ -1,0 +1,200 @@
+# Multi-Application Runs — One Orchestrator, One Fill Agent for Each Application
+
+Use this procedure when one session must complete two or more applications (example:
+a county program plus a state program). The unit of parallel work is the APPLICATION,
+not the form section. Applications have independent browsers, so they can run in
+parallel. Sections of one form share one page, so they cannot.
+
+## Roles
+
+| Role | Count | Job |
+|---|---|---|
+| Orchestrator | 1 (the main session) | All user conversation. Consolidated intake. Dispatch. The consolidated final report. Submit approvals. |
+| Fill agent | 1 for each application | Fill and verify ONE application in its own browser. No user conversation. No file writes. |
+| Scribe | 1 (background) | Reads the orchestrator transcript. Writes ALL knowledge files: `playbooks/`, `scripts/`, `references/`. See `knowledge-scribe.md`. |
+
+## Hard Rules
+
+- **One writer for each page. This rule has no exceptions.** When two agents write
+  to one tab, each agent moves the keyboard focus. Keystrokes from one agent land in
+  the field that the other agent selected, and every command shows success
+  (confirmed by test on 2026-08-05). Each fill agent gets its own agent-browser
+  session name and its own browser instance.
+- **Only the orchestrator talks to the user.** A fill agent that needs an answer
+  stops and returns a BLOCKED report. It never waits for a user.
+- **The scribe is the only writer of knowledge files.** Fill agents write no files.
+  A fill agent returns its findings in the SITE FACTS section of its report. The
+  report arrives in the orchestrator transcript, and the scribe writes the playbook
+  from it. One writer keeps the language rules, the no-bias rule, and the
+  no-participant-data rule in one place.
+
+## Procedure
+
+### 1. Consolidated Intake (Orchestrator)
+
+1. For each application: find the playbook, do the freshness probe (Phase 0 of
+   SKILL.md).
+2. For an application with NO playbook, do the field inventory yourself, now, before
+   the gap analysis. You cannot make a correct gap analysis for a form that you did
+   not read. Open the page in the session that the fill agent will use, then:
+   - `get count` for `input`, `select`, `textarea`, `iframe`, `form` — this gives the
+     size of the form and shows if an iframe can hold it.
+   - `FIELDS "body"` (see `scripts/fill-helpers.sh`) — the full field map in one call.
+   - Read the `src` of each iframe. Many iframes are reCAPTCHA and ad trackers. Do
+     not assume that the form is inside an iframe. On the WIC form, all 6 iframes
+     were noise and the form was inline.
+   - Probe `required` and `maxlength` on the fields that you plan to fill.
+   Put this map in the fill-agent prompt. The fill agent then starts with a plan, not
+   with discovery. The scribe writes the playbook from the reports at the end.
+3. Build ONE gap analysis that covers all the applications. Group the gaps by
+   application.
+4. Ask the user all the gap questions now, grouped by application, in plain language
+   (the rules in `gap-analysis-and-provenance.md` apply). Tell the user which
+   application each question group belongs to. Put the application name in the header
+   of each question (example: "IHSS: SSN", "WIC: clinic"). The user answers questions
+   for two forms in one list, so the header is the only signal of which form a
+   question belongs to.
+5. Report a submit blocker in the gap analysis, with the gaps. Example: a reCAPTCHA on
+   the form. The fill can finish, but the submit needs the user. The user must know
+   this before the fill starts, not after.
+6. Do not start a fill agent before its application has all its required answers.
+   Start the applications that are ready. Ask the user about the other applications
+   while the started agents run.
+
+### 2. Browser Isolation
+
+Give each fill agent its own session name. Use the domain as the name
+(`--session forms-example-org`, `--session apply-example-gov`).
+
+- Default mode: each fill agent opens its own browser with `open <url>`. Each
+  agent-browser session starts its own browser. The browsers share no state.
+- Watchable local mode — use this when the user wants to see the fills live. Start
+  one debug Chrome for each application, each with its own port and its own profile:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=<9222+N> --user-data-dir=/tmp/ab-debug-profile-<N> \
+  --no-first-run --no-default-browser-check &
+# then: agent-browser --session <name> connect <9222+N>
+```
+
+Do not connect two writer sessions to one port. Two sessions on one browser attach
+to the same active tab (confirmed by test). Do not put two applications in two tabs
+of one browser: the applications share the browser cookies, and a portal that
+permits one session for each login can cancel tab 1 when tab 2 sends a request.
+
+### 3. Dispatch (Orchestrator)
+
+**Select the model for each fill agent.** The Agent tool takes a `model` parameter.
+Without it, the agent inherits the orchestrator model, which costs approximately ten
+times more for each input token. The fill agents read the large DOM outputs, so the
+model choice controls most of the run cost.
+
+| Agent | Model parameter | Reason |
+|---|---|---|
+| Fill agent with a playbook (warm path) | `haiku` | The playbook gives the exact selectors and methods. The fill is checklist work. |
+| Fill agent with no playbook (cold start) | `sonnet` | Discovery needs judgment: label mapping, gate polarity. |
+| Scribe | `sonnet` | It writes the knowledge files that later runs depend on. |
+
+A small-model fill agent stays safe because of the BLOCKED rule: when the playbook
+does not cover a situation, the agent returns BLOCKED and does not improvise. The
+orchestrator supplies the judgment. If a small-model agent returns wrong fills or
+invented values, record it and use `sonnet` for that path.
+
+Start all the ready fill agents in ONE message (parallel tool calls). Each fill
+agent prompt contains:
+
+```
+Fill ONE application. Do not talk to a user. Follow the form-completion skill
+(.claude/skills/form-completion/SKILL.md), phases 1, 3, 4, and 6, with these inputs:
+
+- Application: <url — the DIRECT form url, not a landing page>
+- Playbook: <path — "read it first, the freshness probe passed, obey it" — or
+  "none, cold start">
+- Browser: from <client dir> run `./node_modules/.bin/agent-browser --session <name>
+  <cmd>`. The session is ALREADY connected to port <N> and the page is ALREADY open.
+  Do NOT run `connect` again. Do NOT use port <M> — another agent owns it.
+- Helpers: `source <skill-dir>/scripts/fill-helpers.sh; SESSION=<name>` gives
+  S/K/C/U/V/FIELDS. Use K for each masked field. Use FIELDS for a same-id group.
+- Field map (cold start only): <the inventory from step 1.2, plus the fields that
+  the agent must NOT fill and why>
+- Answered gap table: <the values and decisions from intake, for this application.
+  Give the exact selector and the exact value for each field. Say which checkbox
+  values stay clear.>
+- Payload values with no form field: <the list> — report these as unused. Do not
+  force them into a field that looks similar.
+- Skill directory: <path>
+
+Rules:
+- Phase 2 is complete. Do not ask questions. If you find a NEW gap during the fill,
+  leave the field empty, mark the application BLOCKED on that field, and continue
+  with the other fields.
+- Do not guess a value. A field with no value in the table above stays empty and goes
+  in the report as EMPTY. This includes a Yes/No pair: leave both boxes clear.
+- Verify every write (Phase 4). Do not submit (Phase 6 approval happens in the main
+  session).
+- Batch the writes: many write commands in ONE Bash call, then ONE readback pass. Do
+  not use one tool call for each field.
+- Write NO files. The scribe writes the playbook from your report.
+
+Return this report, in two sections:
+
+FOR THE USER (plain language, easy reading level, two to four sentences):
+- What is complete, what is empty, and what needs the user. Use the person's name
+  and the words on the form. No selectors, no ids, no browser terms, no counts of
+  tool calls.
+
+SITE FACTS (technical, for the scribe):
+- STATUS: COMPLETE or BLOCKED
+- The provenance table for this application (format: gap-analysis-and-provenance.md)
+- The fields that you left empty, with the reason for each
+- The submit-gate state: the button state, the bot-check token state, and if a human
+  must do a step before the submit
+- BLOCKED fields with the question the user must answer, in plain language
+- Site facts found (corrections to an existing playbook are also site facts): the
+  URL chain, the field table, masks, gates, option texts, duplicate-id groups, the
+  submit condition, freshness-probe ids
+- Approximate tool call count
+```
+
+Do not put the paths of the knowledge files in the prompt. Fill agents write no
+files, so they do not need the paths.
+
+Result of one run with this prompt shape: two applications, in parallel, with 10 and 13
+tool calls, and no silent failure on the first readback pass. The warm application (a
+128-input form with a playbook) did all 25 writes in ONE Bash call.
+
+### 4. Collect, Resolve, Continue (Orchestrator)
+
+- Fill agent reports arrive as task notifications. Show the user the FOR THE USER
+  section of each report, without change. Do not show the SITE FACTS section — the
+  scribe consumes it.
+- BLOCKED report: ask the user the returned questions (plain language, grouped),
+  then continue THE SAME agent with SendMessage and the answers. Do not start a new
+  fill agent — the running agent holds the browser session and the context.
+- One failed application does not stop the others. Show the partial results in the
+  report.
+
+### 5. Consolidated Report and Submit Gates (Orchestrator)
+
+- Show one provenance report for each application (the format in
+  `gap-analysis-and-provenance.md`), plus the total tool calls across all agents.
+- **Each application has its own submit gate.** Ask for approval one application at
+  a time. Approval for one application is not approval for the others. On approval,
+  tell the fill agent to submit with SendMessage; it verifies the submit result and
+  reports back.
+
+## Failure Behavior
+
+- A fill agent dies: report that application as failed with its last known state.
+  The other applications continue. Offer the user a restart of the failed one.
+- The scribe dies: no effect on the fills (see `knowledge-scribe.md`).
+- A browser stops during a fill: the fill agent reports BLOCKED with the list of
+  verified fields. A new fill agent uses the playbook and does the fill again with
+  few steps.
+
+## What This Does Not Cover
+
+Parallel agents on the SECTIONS of one form. Sections share one page and one
+keyboard focus. That fan-out gains no time and can corrupt the fill. See the
+single-application procedure in SKILL.md.

--- a/.claude/skills/form-completion/references/multi-application.md
+++ b/.claude/skills/form-completion/references/multi-application.md
@@ -80,9 +80,9 @@ Give each fill agent its own session name. Use the domain as the name
 
 - Watchable one-window mode — use this when the user wants ONE window with one tab
   for each application. Two sessions can share one debug Chrome when each session
-  owns its own tab (confirmed by test on 2026-08-05: interleaved keystrokes and
-  fills landed in the correct tabs with no cross-contamination). The procedure has
-  strict order rules:
+  owns its own tab. This is confirmed by test on 2026-08-05: the two sessions sent
+  keystrokes and fills in alternation, and each value landed in the correct tab. No
+  value landed in the wrong tab. Do the steps in this sequence:
 
 ```bash
 # SETUP PHASE — the orchestrator does ALL tab creation, before any fill starts.
@@ -93,22 +93,22 @@ agent-browser --session <app1> tab new --label <app1> <url1>
 agent-browser --session <app2> connect 9222
 agent-browser --session <app2> tab new --label <app2> <url2>
 
-# FILL PHASE — the FIRST command of each fill agent pins its own tab:
+# FILL PHASE — the FIRST command of each fill agent selects its own tab:
 agent-browser --session <app1> tab <app1>
-agent-browser --session <app1> get url        # make sure the pin is correct
+agent-browser --session <app1> get url        # make sure that the selection is correct
 ```
 
-  Rules for this mode: no agent runs `tab new` after the fills start. Each fill
-  agent pins its tab by label as its first command and checks the URL. One writer
-  for each TAB — the one-writer rule applies to the tab, not to the window. The
-  applications share the browser cookies: this is acceptable for applications on
-  different domains, and not acceptable for two applications on one portal that
-  permits one session for each login. Clean up with `tab close <label>`, not with
-  `close`.
+  Obey these rules in this mode. No agent runs `tab new` after the fills start.
+  Each fill agent selects its tab by label as its first command, and reads the URL
+  to confirm the selection. The one-writer rule applies to the TAB, not to the
+  window. The applications share the browser cookies. This is acceptable for
+  applications on different domains. It is not acceptable for two applications on
+  one portal that permits one session for each login. Close each tab with
+  `tab close <label>`. Do not use `close`.
 
 Do not connect two writer sessions to one port without the tab procedure above.
 Two sessions that connect to one port attach to the same active tab (confirmed by
-test), and two writers on one tab corrupt each other's fills.
+test), and two writers on one tab put text in each other's fields.
 
 ### 3. Dispatch (Orchestrator)
 

--- a/.claude/skills/form-completion/references/multi-application.md
+++ b/.claude/skills/form-completion/references/multi-application.md
@@ -45,6 +45,12 @@ parallel. Sections of one form share one page, so they cannot.
    (see "The Scout" below). Do not survey the site yourself — the hard rule above.
    You cannot make a correct gap analysis for a form that no agent read, so the
    scout reads it while you talk to the user.
+   **Start the scribe when any application is cold OR has a partial playbook**
+   (the playbook contains the word UNCONFIRMED and the fill will enter those
+   parts). A partial playbook does not need a new scout — the playbook already
+   maps the path to the frontier — but it does need the scribe, because the fill
+   agent's reports from the unconfirmed territory are new site facts. When every
+   application has a complete playbook, start no scribe.
 3. Build the gap analysis for the applications WITH playbooks, from their playbook
    field tables. Show it and ask the questions NOW. Do not wait for the scouts.
 4. Ask the gap questions grouped by application, in plain language (the rules in

--- a/.claude/skills/form-completion/references/multi-application.md
+++ b/.claude/skills/form-completion/references/multi-application.md
@@ -78,10 +78,37 @@ Give each fill agent its own session name. Use the domain as the name
 # then: agent-browser --session <name> connect <9222+N>
 ```
 
-Do not connect two writer sessions to one port. Two sessions on one browser attach
-to the same active tab (confirmed by test). Do not put two applications in two tabs
-of one browser: the applications share the browser cookies, and a portal that
-permits one session for each login can cancel tab 1 when tab 2 sends a request.
+- Watchable one-window mode — use this when the user wants ONE window with one tab
+  for each application. Two sessions can share one debug Chrome when each session
+  owns its own tab (confirmed by test on 2026-08-05: interleaved keystrokes and
+  fills landed in the correct tabs with no cross-contamination). The procedure has
+  strict order rules:
+
+```bash
+# SETUP PHASE — the orchestrator does ALL tab creation, before any fill starts.
+# The `tab new` command moves the tab pointer of EVERY session in the window.
+# A `tab new` during a fill sends the next keystrokes into the wrong application.
+agent-browser --session <app1> connect 9222
+agent-browser --session <app1> tab new --label <app1> <url1>
+agent-browser --session <app2> connect 9222
+agent-browser --session <app2> tab new --label <app2> <url2>
+
+# FILL PHASE — the FIRST command of each fill agent pins its own tab:
+agent-browser --session <app1> tab <app1>
+agent-browser --session <app1> get url        # make sure the pin is correct
+```
+
+  Rules for this mode: no agent runs `tab new` after the fills start. Each fill
+  agent pins its tab by label as its first command and checks the URL. One writer
+  for each TAB — the one-writer rule applies to the tab, not to the window. The
+  applications share the browser cookies: this is acceptable for applications on
+  different domains, and not acceptable for two applications on one portal that
+  permits one session for each login. Clean up with `tab close <label>`, not with
+  `close`.
+
+Do not connect two writer sessions to one port without the tab procedure above.
+Two sessions that connect to one port attach to the same active tab (confirmed by
+test), and two writers on one tab corrupt each other's fills.
 
 ### 3. Dispatch (Orchestrator)
 

--- a/.claude/skills/form-completion/references/multi-application.md
+++ b/.claude/skills/form-completion/references/multi-application.md
@@ -53,12 +53,24 @@ parallel. Sections of one form share one page, so they cannot.
    questions for two or more forms in one list, so the header is the only signal of
    which form a question belongs to. For a scouted application, tell the user what
    comes next (example: "The food-assistance application needs more answers — I
-   will ask them when the survey of that site is complete"). Do not ask a question
-   that the scout did not confirm.
+   will ask them when the survey of that site is complete"). In this round, ask
+   only the questions that a playbook confirms. Expected questions for a scouted
+   application come in the second round (the next step).
 5. When a scout report arrives, build the gap analysis for that application from
    the report, and ask a second round of questions. A large application can have
    20 or more gaps — obey "Large Forms" in `gap-analysis-and-provenance.md`: show
    the full table first, then ask in groups that follow the sections of the form.
+   **A sequential portal needs an EXPECTED round.** Some portals show one question
+   for each page and hide the later pages. The scout's field table then covers
+   only the first pages. Do not dispatch with only those answers — each hidden
+   question later stops the fill agent for a full user round trip, and one run
+   took six round trips this way. Build the expected questions from the scout's
+   UNCONFIRMED section names and from the usual topics of that program type
+   (household, income, expenses, assets, disability, student status, citizenship,
+   work). Tell the user which questions are expected, and that you discard an
+   answer the form never asks for. The do-not-derive rules still apply. The costs
+   are not equal: an unneeded answer costs nothing, and a missing answer costs a
+   stopped agent and a round trip.
 6. Report a submit blocker in the gap analysis, with the gaps. Examples: a reCAPTCHA
    on the form, or an account wall from a scout report. The fill can finish, but the
    submit needs the user. The user must know this before the fill starts, not after.
@@ -269,6 +281,9 @@ tool calls, and no silent failure on the first readback pass. The warm applicati
   a time. Approval for one application is not approval for the others. On approval,
   tell the fill agent to submit with SendMessage; it verifies the submit result and
   reports back.
+- **After the last submit decision, send the scribe ONE message with the word
+  FINALIZE** (SendMessage). This is the scribe's stop signal (`knowledge-scribe.md`).
+  Without it, the scribe waits on stall timeouts and makes many turns with no work.
 
 ## Failure Behavior
 

--- a/.claude/skills/form-completion/references/silent-failures.md
+++ b/.claude/skills/form-completion/references/silent-failures.md
@@ -1,0 +1,197 @@
+# Silent-Failure Diagnosis
+
+Each failure type below gives the same output: `✓ Done` and an empty field. Do the
+checks in this sequence. Each check is one typed command. Do not use `eval`.
+
+## 1. Disabled — a Control Is the Gate
+
+```bash
+agent-browser is enabled "#field"
+```
+
+If the result is false, find the gate control. Set the gate. Then fill the field
+again.
+
+Some fields are conditional. A gate checkbox or a gate select enables them. These
+fields frequently have no accessible name in the snapshot. Use `check "#gate"`. The
+`disabled` attribute changes from true to false. Then `fill` operates correctly. Read
+the question text near the field to find the gate.
+
+## 2. Hidden — an Upstream Question Has No Answer, or the Field Is Correctly Hidden
+
+```bash
+agent-browser is visible "#field"
+```
+
+If the result is false, a parent element has `display:none`. The input itself shows
+`disabled=false`. This failure looks the same as the mask failure. It is not the same.
+There are two possible causes:
+
+- An upstream master gate has no answer. Answer the gate first. Fill from the top of
+  the form to the bottom.
+- The block is correctly hidden. Example: "Mailing address the same as residential?"
+  with the answer "Yes" hides the mailing block. An empty hidden block is correct. Do
+  not fill it. Read the text of the gate question before you decide.
+
+## 3. Masked — the Value Shows `__/__/____` or `(___) ___-____`
+
+The mask JavaScript monitors real keydown and keypress events. The `fill` and `type`
+commands make synthetic events. The mask ignores these events or changes their
+sequence. Then the mask removes the value. The command shows success.
+
+Do the steps below in sequence. Use `get value` after each step.
+
+1. Use `fill "#field" "01152000"`. Use only characters, with no separators. The mask
+   adds the separators.
+2. If the field is empty, use `fill "#field" ""` and then `type "#field" "…"`.
+   CAUTION: some masks move the caret after each keystroke. On these masks, `type`
+   reverses the input. Example: a 5-digit ZIP `ABCDE` becomes `EDCBA`.
+3. If the field is empty or the value is reversed, use one `key` command for each
+   character. This is the only method that all keydown masks accept:
+
+```bash
+agent-browser click "#field"          # Set the focus first
+agent-browser key "Meta+a"            # Use "Control+a" when not on macOS
+agent-browser key "Backspace"        
+agent-browser key "Home"             
+agent-browser key "0"                 # One key command for each character
+agent-browser key "1"
+agent-browser get value "#field"      # Expect the value in the mask format
+```
+
+The select-all, delete, and Home steps clear the field with real keystrokes. The
+`fill ""` command can put the internal buffer of a mask in a bad state. Then the field
+ignores keys, or the caret stops at the end and only the last position gets a
+character. The keyboard clear steps correct this state. The steps cause no damage on a
+clean field. Always include them.
+
+**A mask reformats the value. Compare the digits, not the strings.** You send digits
+only. The readback gives the mask format. Examples confirmed in one run: nine digits
+came back as `NNN-NN-NNNN`, `MMDDYYYY` came back as `MM/DD/YYYY`, and ten digits came
+back as `(NNN) NNN-NNNN`. A string comparison of the sent value and the readback shows
+a false failure. Remove the non-digit characters from both, then compare.
+
+Not every text field has a mask. A field with `type=text` and a large `maxlength` (for
+example 255) frequently accepts a plain `fill` with the separators included. Try
+`fill` first and read the value back. Use the per-key method only after the readback
+fails.
+
+Mask sizes give the format. A date field with `maxLength=8` accepts `MMDDYYYY`. A
+telephone field with `maxLength=10` accepts ten digits. An SSN field with `maxLength=9`
+accepts nine digits. A state field with `maxLength=2` accepts the two-letter
+abbreviation.
+
+## 4. maxLength — the Field Refused or Cut the Value
+
+```bash
+agent-browser get attr "#field" maxlength
+```
+
+A value longer than `maxLength` can be refused as one unit, not cut. Example:
+"California" in a two-character field gives an empty field. Make the value shorter.
+Use "CA" for the state. Add the unit or apartment to the street line, within its
+limit.
+
+## General Rules
+
+- **XPath is not supported.** A command with an XPath selector (`//input[@id=…]`) can
+  show `✓ Done` and do nothing. This is a silent no-op, in the same class as the mask
+  failure. Use CSS selectors only.
+- **A selector with `[id=X]` finds only the first element with that id.** Some sites
+  give one id to a full checkbox group (invalid HTML). Then `get count` shows 1,
+  probes for the other members show "not found", and a compound selector such as
+  `input[id='X'][value='96']` fails for all members after the first. Use the `FIELDS`
+  helper in `scripts/fill-helpers.sh` to get the full group map in one call. Set a
+  member with `input[value='N']` alone, or by its visible label:
+  `find role checkbox check --name "<label>"`. Put the flags AFTER the action —
+  `find role checkbox --name "…" check` fails with an "unknown action" error.
+
+- The `click` command changes a checkbox state each time. Use `check` and `uncheck`.
+  These commands are idempotent. After you write a Yes/No pair, read both checkboxes
+  again. The two are independent. Both can become unchecked.
+- An old snapshot becomes incorrect after the DOM changes. Do not read the old
+  snapshot output again.
+- **`get text` can return a stale string for one call after a click that changes the
+  DOM.** Confirmed on an expander: immediately after `click "div.header"`,
+  `get text` still gave "+ Expand" and `is enabled "#submit"` still gave false, while
+  `get html "div.header"` already gave "- Collapse". A second read of both agreed. Use
+  `get html` as the authoritative read after a click. Corroborate with
+  `is visible` on the content that the click shows. Do not report a bug from one
+  `get text` result after a click: read it two times.
+- The `get value` command on a `<select>` returns the option index, not the text.
+- **`get attr` prints `✓ Done` and no value when the attribute is absent.** The
+  command found the element. The attribute does not exist. Do not read `✓ Done` as
+  the value of the attribute. Example from a probe of nine fields: four fields gave
+  `required=required`, and five gave `required=✓ Done`, which means "not required".
+  A `maxlength` probe on a `<select>` gives `✓ Done` for the same reason. To get a
+  count of the elements that have the attribute, use `get count "#field[required]"`
+  instead.
+- **`:nth-of-type(N)` fails for N greater than 1 when the matched elements have
+  different parents.** The `:nth-of-type` pseudo-class counts inside one parent, not
+  across the document. On a page where `get count "iframe"` gave 6 and
+  `get count "form"` gave 4, only `iframe:nth-of-type(1)` and `form:nth-of-type(1)`
+  returned a result. Elements 2 to 6 gave "Element not found". Do not use
+  `:nth-of-type` to make a list of the elements on a page. Use `get html` on the
+  container and parse the output (see the `FIELDS` helper in
+  `scripts/fill-helpers.sh`), or use `find role`.
+- To get all the options of a `<select>`, use `get html` on the select and extract the
+  `<option>` tags. Do not use `get text`: the options come out as one text block that
+  is difficult to separate.
+- The `connect <port>` command prints `[agent-browser] launched browser` when it
+  attaches to a Chrome that already runs. It prints `[agent-browser] relaunched
+  browser` when the session had a browser before. Both messages can occur on a
+  correct attachment. Use `get cdp-url` to make sure that the attachment is correct:
+  the URL must contain the port that you gave.
+
+## The Screenshot Is Not Evidence
+
+A screenshot can show a false failure. Use `get value`, `is checked`, and `is visible`
+to verify a write. Use the screenshot only to find a control that you cannot find in
+the field map.
+
+- **A sticky site header covers the fields under it.** In `screenshot --full`, the
+  header stays at the top of the image and hides one or more rows of the form. A
+  correctly filled field can look empty. This was confirmed on one form: the Date of
+  Birth row was behind the header, and `get value` gave the correct value.
+- **A reCAPTCHA widget frequently does not appear in the screenshot.** The widget is in
+  an iframe. The absence of the widget in the image is not proof that the page has no
+  captcha. Use `get count "iframe"` and read the iframe `src`, or
+  `is visible "#g-recaptcha-response"`.
+- **The state of the submit button proves nothing about validation.** A server-side
+  validated form (example: a Drupal webform with a captcha) keeps the submit button
+  enabled with an empty form and no captcha token. `is enabled "#submit"` returns true
+  in both a valid and an invalid state.
+- **The token field is the only reliable bot-check signal. The iframe count is not.**
+  Read the value of the hidden token input:
+  - reCAPTCHA: `get value "#g-recaptcha-response"`
+  - Cloudflare Turnstile: `get value "[name='cf-turnstile-response']"`
+
+  An empty value means no token: a human must complete the challenge before the
+  submit. A long value (several hundred characters) means the challenge passed.
+  `get count "iframe"` gave 0 on one page at the same time that a valid ~750-character
+  Turnstile token was present. Do not use the iframe count to decide if a challenge
+  ran or failed.
+
+## Fields You Must Not Fill
+
+The field inventory shows more fields than the user must answer. Remove these before
+you make the gap analysis. A field in this group that has a value is an error, not
+progress.
+
+- **A honeypot.** A field with the label "Leave this field blank", or a hidden field
+  with a name such as `url`, is an anti-spam trap. A value in this field marks the
+  submission as a robot. Leave it empty. Example seen: `#edit-url` on a Drupal
+  webform.
+- **The site search box.** The header and the mobile menu each have a search input.
+  These inputs are in the `FIELDS "body"` output, but they are not part of the
+  application. Example ids: `header-search-input`, `mobile-search-keys`.
+- **A field in an advertisement iframe or a reCAPTCHA iframe.** Read the `src`
+  attribute of each iframe before you go inside one. A `google.com/recaptcha` src or
+  an ad-tracker src has no application field. On one page, 6 iframes were all
+  reCAPTCHA and ad trackers, and the application form was inline in the page.
+- **A "if different from…" field when the two values are the same.** Example: a
+  mailing address field with the label "if different from home address". An empty
+  field is the correct answer. Do not repeat the home address.
+- **reCAPTCHA is a submit blocker, not a field.** Report it in the gap analysis as a
+  blocker. Do not attempt to solve it. The user must complete it, or the user must
+  submit the form.

--- a/.claude/skills/form-completion/scripts/fill-helpers.sh
+++ b/.claude/skills/form-completion/scripts/fill-helpers.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Batch helpers for form fills with agent-browser.
+# Source this file. Set SESSION. Put all the write calls in one Bash invocation.
+# Then do one readback with V. Do not skip the readback.
+#
+#   source .claude/skills/form-completion/scripts/fill-helpers.sh
+#   SESSION=localchrome
+#   S fill "#firstName" "Maria"
+#   K "#birthDate" "01022000"           # Masked field: one key for each character
+#   C "#agreeYes"                       # Idempotent check
+#   V firstName birthDate               # Readback. Always do this.
+#
+# Cold-start survey (read-only, no writes):
+#   SURVEY                              # Count of input/select/textarea/iframe/form
+#   IFRAMES                             # The src of each iframe
+#   FIELDS "body"                       # Full field map: type, id, value, label
+#   ATTRS "required maxlength" id1 id2   # Attribute probe. Prints "-" when absent.
+#   OPTIONS "#someSelect"               # All the option texts
+
+AB="${AGENT_BROWSER_BIN:-./node_modules/.bin/agent-browser}"
+SESSION="${SESSION:-form-fill}"
+
+# One command, with the output removed
+S() { "$AB" --session "$SESSION" "$@" >/dev/null 2>&1; }
+
+# Fill a masked field with one keypress for each character: K "#selector" "chars"
+# Use fold, not `read -n1`. The `read -n1` option fails in zsh.
+# The first three keys clear the field with real keystrokes. The `fill ""` command
+# can put the mask buffer in a bad state. Then the field ignores keys, or the caret
+# stops at the end. The keyboard clear corrects this. It causes no damage on a clean
+# field. Always keep these three keys.
+case "$(uname)" in Darwin) _SELALL="Meta+a";; *) _SELALL="Control+a";; esac
+K() {
+  local sel="$1" chars="$2" c
+  S click "$sel"
+  S key "$_SELALL"; S key "Backspace"; S key "Home"
+  for c in $(printf '%s' "$chars" | fold -w1); do S key "$c"; done
+}
+
+# Set a checkbox (idempotent)
+C() { S check "$1"; }
+U() { S uncheck "$1"; }
+
+# Readback of field values by id, without the leading "#": V id1 id2 id3 ...
+V() {
+  local f
+  for f in "$@"; do
+    printf '%s = ' "$f"
+    "$AB" --session "$SESSION" get value "#$f" 2>&1 | tail -1
+  done
+}
+
+# Page survey in ONE tool call: SURVEY
+# Prints the count of each element class. Use this first on a cold start.
+# A high iframe count does NOT mean that the form is in an iframe. Use IFRAMES next.
+SURVEY() {
+  local s
+  for s in input select textarea iframe form button; do
+    printf '%-10s = ' "$s"
+    "$AB" --session "$SESSION" get count "$s" 2>&1 | tail -1
+  done
+}
+
+# List the src of each iframe: IFRAMES
+# Do NOT use iframe:nth-of-type(N) for this. The pseudo-class counts inside one
+# parent, so N greater than 1 gives "Element not found" when the iframes have
+# different parents. Parse the page HTML instead.
+# reCAPTCHA and ad-tracker srcs hold no application field. Skip them.
+IFRAMES() {
+  "$AB" --session "$SESSION" get html "body" 2>/dev/null |
+    grep -o '<iframe[^>]*src="[^"]*"' | sed 's/.*src="//;s/"$//' | cut -c1-120
+}
+
+# Attribute probe for a list of ids: ATTRS "attr1 attr2" id1 id2 id3 ...
+# CAUTION: agent-browser prints "✓ Done" and no value when the attribute is ABSENT.
+# This helper prints "-" in that case, so an absent attribute cannot look like a value.
+ATTRS() {
+  local attrs="$1"; shift
+  local f a v
+  for f in "$@"; do
+    printf '%-50s' "$f"
+    for a in $attrs; do
+      v=$("$AB" --session "$SESSION" get attr "#$f" "$a" 2>&1 | tail -1)
+      case "$v" in *"Done"*|"") v="-";; esac
+      printf ' %s=%-6s' "$a" "$v"
+    done
+    printf '\n'
+  done
+}
+
+# List all the options of a select: OPTIONS "#selector"
+# Do not use `get text`: it gives one text block. Parse the HTML.
+# CAUTION: an option text can occur two times in one select. Match by text, not by
+# index.
+OPTIONS() {
+  "$AB" --session "$SESSION" get html "$1" 2>/dev/null |
+    grep -o '<option[^>]*>[^<]*' | sed 's/<option[^>]*>//'
+}
+
+# Field inventory in ONE tool call: FIELDS [container-css]
+# Prints one line for each input/select/textarea: type, id, name, value, label text.
+# Use this for the cold-start field map and for groups that share one id
+# (example: checkboxes with id=chkBxHealthHistory and different value attributes).
+# Do not scan with get count in a loop. Do not use eval.
+FIELDS() {
+  local sel="${1:-form}"
+  "$AB" --session "$SESSION" get html "$sel" 2>/dev/null | python3 -c '
+import sys, html.parser
+
+class P(html.parser.HTMLParser):
+    # Checkbox and radio labels FOLLOW the input. Text and select labels COME BEFORE.
+    def __init__(self):
+        super().__init__(); self.out=[]; self.pending=[]; self.intag=None; self.last=""
+    def handle_starttag(self, tag, attrs):
+        a=dict(attrs)
+        if tag in ("input","select","textarea"):
+            t=a.get("type",tag)
+            row={"tag":tag,"type":t,"id":a.get("id",""),
+                 "name":a.get("name",""),"value":a.get("value",""),"label":""}
+            if t in ("checkbox","radio"):
+                self.pending.append(row)      # label is the next text node
+            else:
+                row["label"]=self.last        # label is the previous text node
+            self.out.append(row)
+        if tag=="option" and self.out and self.out[-1]["tag"]=="select":
+            self.intag="option"
+    def handle_data(self, data):
+        t=" ".join(data.split())
+        if not t: return
+        if self.intag=="option":
+            self.out[-1]["label"]=(self.out[-1]["label"]+" / "+t).strip(" /")[:200]
+            return
+        for row in self.pending:
+            if not row["label"]: row["label"]=t[:80]
+        self.pending=[]; self.last=t[:80]
+    def handle_endtag(self, tag):
+        if tag=="option": self.intag=None
+
+p=P(); p.feed(sys.stdin.read())
+for r in p.out:
+    if r["id"].startswith("goog-gt") or r["name"] in ("sl","tl","query","gtrans","vote"):
+        continue  # Google Translate widget noise
+    t=r["type"]; i=r["id"] or "-"; v=r["value"] or "-"; l=r["label"] or "-"
+    print("%-12s id=%-28s value=%-6s label=%s" % (t,i,v,l))
+'
+}

--- a/.claude/skills/form-completion/scripts/fill-helpers.sh
+++ b/.claude/skills/form-completion/scripts/fill-helpers.sh
@@ -6,7 +6,7 @@
 #   source .claude/skills/form-completion/scripts/fill-helpers.sh
 #   SESSION=localchrome
 #   S fill "#firstName" "Maria"
-#   K "#birthDate" "01022000"           # Masked field: one key for each character
+#   K "#birthDate" "MMDDYYYY"           # Masked field: one key for each character
 #   C "#agreeYes"                       # Idempotent check
 #   V firstName birthDate               # Readback. Always do this.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,9 @@ yarn-error.log*
 .mastra/
 vertex-ai-credentials.json
 
-.claude/
+# Ignore personal Claude Code settings, but track shared skills
+.claude/*
+!.claude/skills/
 docs/superpowers/
 
 # Terraform


### PR DESCRIPTION
## Summary

Adds a Claude Code **form-completion skill** (`.claude/skills/form-completion/`) and fixes the agent-browser prompt references, built and validated across six live test runs against real government application forms.

### The skill

Phased protocol: playbook lookup → gap analysis with one upfront question batch → gate-ordered fill → verify every write → provenance report → human submit gate.

- **Playbooks** — per-site cache entries (field maps, mask methods, gates, submit conditions) with freshness probes; two sites included from test runs
- **Knowledge scribe** — background agent that tails the session transcript and owns all knowledge-file writes, so the fill never stops for documentation
- **Multi-application orchestration** — one fill agent per application in isolated browsers (one writer per page — two writers on one tab steal keyboard focus from each other, confirmed by test), BLOCKED escalation instead of mid-fill user questions, per-application submit gates
- **Model tiering** — haiku for warm-path fills, sonnet for cold starts and the scribe; the DOM-heavy token consumption moves off the frontier model (~10x cheaper input on that class)
- **Provenance discipline** — every filled value traces to USER / PAYLOAD / DERIVED / EMPTY; invented values are prohibited and removed at report time
- Docs in ASD-STE100 Simplified Technical English; program names confined to playbooks (generic docs stay neutral for a 100+-site product)

### The prompt fix (`lib/ai/prompts/`)

`field-patterns.md` previously said **'fill first, always — including masked fields'** (aebd5e4). Live testing showed `fill` **and** `type` both fail silently on keydown-listening masks — the command reports success while the mask wipes the value. Replaced with a three-step escalation ladder ending in per-character key presses with a keyboard clear. Also adds `form-protocol.md` (site-agnostic fill procedure) wired into `readReference`, and removes site-specific ids from generic examples.

### .gitignore

Narrowed `.claude/` → `.claude/*` + `!.claude/skills/` so shared skills are tracked while personal settings stay ignored.

## Test evidence

Six live runs against real forms (sessions on the dev machine): cold-start discovery ~45 tool calls → warm-path fill 10–13 calls per application; two applications filled in parallel with zero silent failures on first readback; scribe self-updated playbooks and helpers mid-run.

## Not included

- Root-repo edit to `labs-asp/.claude/skills/tweakcn-design/SKILL.md` (separate repo)
- Pre-existing untracked `app/*-diagram`, `app/logo-wall`, `app/skills-demo`, `public/images/*` (not part of this work)