### PR TITLE
feat(observability): attach Kernel browser telemetry to agent traces

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -14,6 +14,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { registerTelemetry } from 'ai';
 import { OpenTelemetry } from '@ai-sdk/otel';
+import { TRACER_NAME as BROWSER_TRACER } from '@/lib/observability/browser-telemetry';
 
 /**
  * Cloud Trace over OTLP. Replaces the deprecated cloud-trace-exporter, which
@@ -58,7 +59,16 @@ export function register() {
 
   if (process.env.BRAINTRUST_API_KEY) {
     spanProcessors.push(
-      new BatchSpanProcessor(new BraintrustExporter({ filterAISpans: true })),
+      new BatchSpanProcessor(
+        new BraintrustExporter({
+          // Keep AI spans and our browser tracer's spans; drop HTTP/RSC noise.
+          filterAISpans: true,
+          customFilter: (span) =>
+            span.instrumentationScope?.name === BROWSER_TRACER
+              ? true
+              : undefined,
+        }),
+      ),
     );
     enabled.push('braintrust');
   }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -61,7 +61,7 @@ export function register() {
     spanProcessors.push(
       new BatchSpanProcessor(
         new BraintrustExporter({
-          // Keep AI spans and our browser tracer's spans; drop HTTP/RSC noise.
+          // Keep the AI spans and the browser tracer's spans. Drop the rest.
           filterAISpans: true,
           customFilter: (span) =>
             span.instrumentationScope?.name === BROWSER_TRACER

--- a/lib/ai/tools/browser.ts
+++ b/lib/ai/tools/browser.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import { getOrCreateBrowser } from '@/lib/kernel/browser';
 import { runCommand } from '@/lib/kernel/cli';
+import { kernelTimelineCollector } from '@/lib/kernel/telemetry';
 import { cliSessionName } from '@/lib/kernel/session-store';
 
 const COMMAND_TIMEOUT_MS = 120_000; // 2 minutes
@@ -111,6 +112,7 @@ NEVER navigate away from the target application domain. Do NOT click social medi
             cdpUrl: session.cdpWsUrl,
             timeoutMs: COMMAND_TIMEOUT_MS,
             signal: abortSignal,
+            collectTimeline: kernelTimelineCollector(session.kernelSessionId),
           });
 
           if (response.success) {

--- a/lib/kernel/browser.ts
+++ b/lib/kernel/browser.ts
@@ -60,8 +60,7 @@ async function archiveReplayVideo(
     const videoBuffer = await videoResponse.arrayBuffer();
     const url = await uploadReplayVideo(chatId, kernelSessionId, videoBuffer);
     await upsertSessionMapping({ chatId, userId, kernelReplayUrl: url });
-    // Archival runs inside a request (standby/delete), so when a span is
-    // active the archived video becomes reachable from the trace too.
+    // When a span is active, the archived video is reachable from the trace.
     annotateActiveSpan({ 'kernel.replay_url': url });
   } catch (err) {
     console.error('[Kernel] Failed to archive replay video:', err);
@@ -221,9 +220,8 @@ export async function getOrCreateBrowser(
             timeout_seconds: KERNEL_TIMEOUT_SECONDS,
             kiosk_mode: false,
             stealth: true,
-            // Kernel Browser Telemetry: the default operational set (control,
-            // connection, system, captcha) plus console errors/logs. `network`
-            // stays off — headers and bodies carry applicant PII.
+            // Capture the default operational set plus console. Do not
+            // capture network data: it contains applicant PII.
             telemetry: {
               enabled: true,
               browser: { console: { enabled: true } },
@@ -265,8 +263,8 @@ export async function getOrCreateBrowser(
 
       sessions.set(key, session);
 
-      // Put the Kernel ids and live-view URL on the enclosing tool span, so
-      // the session (and its recording) is reachable from the trace.
+      // Put the Kernel ids and the live-view URL on the active tool span.
+      // The session and its recording are then reachable from the trace.
       annotateActiveSpan({
         'kernel.session_id': browser.session_id,
         'kernel.live_view_url': browser.browser_live_view_url,
@@ -473,7 +471,7 @@ export async function reconnectBrowser(
     session: cliSessionName(userId, sessionId),
     cdpUrl: session.cdpWsUrl,
     timeoutMs: RECONNECT_TIMEOUT_MS,
-    // Reconnects are where CDP connect/disconnect events matter most.
+    // CDP connect and disconnect events are most important at reconnect.
     collectTimeline: kernelTimelineCollector(session.kernelSessionId),
   }).catch((err: unknown) => {
     console.error('[Kernel] CDP reconnect probe failed to run:', err);

--- a/lib/kernel/browser.ts
+++ b/lib/kernel/browser.ts
@@ -2,8 +2,12 @@ import Kernel from '@onkernel/sdk';
 import { upsertSessionMapping } from '@/lib/db/queries';
 import { uploadReplayVideo } from '@/lib/storage/gcs';
 import { KERNEL_TIMEOUT_SECONDS } from './session-config';
-import { withKernelSpan } from '@/lib/observability/browser-telemetry';
+import {
+  annotateActiveSpan,
+  withKernelSpan,
+} from '@/lib/observability/browser-telemetry';
 import { runCommand } from './cli';
+import { kernelTimelineCollector } from './telemetry';
 import {
   buildSessionStatus,
   cacheKey,
@@ -56,6 +60,9 @@ async function archiveReplayVideo(
     const videoBuffer = await videoResponse.arrayBuffer();
     const url = await uploadReplayVideo(chatId, kernelSessionId, videoBuffer);
     await upsertSessionMapping({ chatId, userId, kernelReplayUrl: url });
+    // Archival runs inside a request (standby/delete), so when a span is
+    // active the archived video becomes reachable from the trace too.
+    annotateActiveSpan({ 'kernel.replay_url': url });
   } catch (err) {
     console.error('[Kernel] Failed to archive replay video:', err);
   }
@@ -207,13 +214,20 @@ export async function getOrCreateBrowser(
 
       const browser = (await withKernelSpan(
         'browsers.create',
-        { 'kernel.has_profile': hasProfile, 'kernel.session_id': sessionId },
+        { 'kernel.has_profile': hasProfile, 'app.session_id': sessionId },
         () =>
           kernel.browsers.create({
             viewport,
             timeout_seconds: KERNEL_TIMEOUT_SECONDS,
             kiosk_mode: false,
             stealth: true,
+            // Kernel Browser Telemetry: the default operational set (control,
+            // connection, system, captcha) plus console errors/logs. `network`
+            // stays off — headers and bodies carry applicant PII.
+            telemetry: {
+              enabled: true,
+              browser: { console: { enabled: true } },
+            },
             ...(hasProfile
               ? { profile: { name: profileName, save_changes: true } }
               : {}),
@@ -250,6 +264,14 @@ export async function getOrCreateBrowser(
       };
 
       sessions.set(key, session);
+
+      // Put the Kernel ids and live-view URL on the enclosing tool span, so
+      // the session (and its recording) is reachable from the trace.
+      annotateActiveSpan({
+        'kernel.session_id': browser.session_id,
+        'kernel.live_view_url': browser.browser_live_view_url,
+        ...(replayId ? { 'kernel.replay_id': replayId } : {}),
+      });
 
       // Record the kernel session/replay ids against the chat so they can be
       // correlated with the PostHog session (reported from the client). The
@@ -451,6 +473,8 @@ export async function reconnectBrowser(
     session: cliSessionName(userId, sessionId),
     cdpUrl: session.cdpWsUrl,
     timeoutMs: RECONNECT_TIMEOUT_MS,
+    // Reconnects are where CDP connect/disconnect events matter most.
+    collectTimeline: kernelTimelineCollector(session.kernelSessionId),
   }).catch((err: unknown) => {
     console.error('[Kernel] CDP reconnect probe failed to run:', err);
     return { success: false, error: String(err) };

--- a/lib/kernel/cli.ts
+++ b/lib/kernel/cli.ts
@@ -14,7 +14,10 @@
  */
 
 import { execFile } from 'node:child_process';
-import { startCommandTelemetry } from '@/lib/observability/browser-telemetry';
+import {
+  startCommandTelemetry,
+  type TimelineCollector,
+} from '@/lib/observability/browser-telemetry';
 
 /** The JSON envelope every `--json` invocation prints on stdout. */
 export interface CliResponse {
@@ -30,6 +33,11 @@ export interface CliOptions {
   session: string;
   timeoutMs?: number;
   signal?: AbortSignal;
+  /**
+   * When set, the browser-internal events that occurred during this command
+   * (from Kernel Browser Telemetry) are attached to the trace as a child span.
+   */
+  collectTimeline?: TimelineCollector;
 }
 
 /** Resolved from PATH — the Docker image symlinks the native binary there. */
@@ -140,6 +148,7 @@ export async function runCommand(
     session: options.session,
     remote: Boolean(options.cdpUrl),
     timeoutMs,
+    collectTimeline: options.collectTimeline,
   });
 
   return new Promise<CliResponse>((resolve, reject) => {

--- a/lib/kernel/cli.ts
+++ b/lib/kernel/cli.ts
@@ -34,8 +34,8 @@ export interface CliOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
   /**
-   * When set, the browser-internal events that occurred during this command
-   * (from Kernel Browser Telemetry) are attached to the trace as a child span.
+   * When set, the Kernel browser events from this command's window are
+   * attached to the trace as a child span.
    */
   collectTimeline?: TimelineCollector;
 }

--- a/lib/kernel/telemetry.ts
+++ b/lib/kernel/telemetry.ts
@@ -1,0 +1,111 @@
+/**
+ * Kernel Browser Telemetry → OpenTelemetry bridge.
+ *
+ * Kernel records what happens *inside* the browser VM — console errors, CDP
+ * connects/disconnects, captcha outcomes, OOM kills — on a durable timeline
+ * keyed by browser session. This module reads the slice of that timeline
+ * matching one agent-browser command so the span layer can attach it to the
+ * trace: a failed click then carries the page's own evidence.
+ *
+ * Capture is opt-in per category at browser creation (see
+ * `getOrCreateBrowser`). `network` stays off: request/response headers and
+ * bodies carry applicant PII.
+ */
+
+import Kernel from '@onkernel/sdk';
+import type {
+  TimelineCollector,
+  TimelineEvent,
+} from '@/lib/observability/browser-telemetry';
+
+// Lazy: the SDK constructor throws without KERNEL_API_KEY, and this module's
+// pure mapping half must stay importable (tests, environments without Kernel).
+let client: Kernel | undefined;
+function kernelClient(): Kernel {
+  client ??= new Kernel();
+  return client;
+}
+
+/**
+ * Payload strings are page-controlled (console text, URLs); keep them short
+ * enough for a span event and mark the cut.
+ */
+const MAX_ATTR_STRING = 500;
+
+/** Payload fields can be arbitrary; a span event should stay skimmable. */
+const MAX_ATTRS_PER_EVENT = 16;
+
+/** Shape shared by every member of Kernel's telemetry event union. */
+interface KernelEvent {
+  category: string;
+  type: string;
+  /** Unix microseconds. */
+  ts: number;
+  data?: Record<string, unknown>;
+  truncated?: boolean;
+}
+
+/**
+ * Map one Kernel event to a span event: `kernel.<type>` named, stamped with
+ * the event's own timestamp, carrying the primitive payload fields. Nested
+ * objects (call stacks, header maps) are dropped — the durable timeline keeps
+ * the full record, the trace needs the headline.
+ *
+ * Exported for tests.
+ */
+export function toTimelineEvent(
+  event: KernelEvent,
+  seq: number,
+): TimelineEvent {
+  const attributes: Record<string, string | number | boolean> = {
+    'kernel.category': event.category,
+    'kernel.seq': seq,
+  };
+  if (event.truncated) attributes['kernel.truncated'] = true;
+
+  let count = 0;
+  for (const [key, value] of Object.entries(event.data ?? {})) {
+    if (count >= MAX_ATTRS_PER_EVENT) break;
+    if (typeof value === 'string') {
+      attributes[`kernel.${key}`] =
+        value.length > MAX_ATTR_STRING
+          ? `${value.slice(0, MAX_ATTR_STRING)}…`
+          : value;
+      count++;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      attributes[`kernel.${key}`] = value;
+      count++;
+    }
+  }
+
+  return {
+    name: `kernel.${event.type}`,
+    timestamp: new Date(event.ts / 1000),
+    attributes,
+  };
+}
+
+/**
+ * Build a collector that reads a Kernel browser session's telemetry events
+ * for a time window. The SDK paginates transparently; the caller caps volume.
+ */
+export function kernelTimelineCollector(
+  kernelSessionId: string,
+): TimelineCollector {
+  return async ({ sinceIso, untilIso }) => {
+    const events: TimelineEvent[] = [];
+    const page = await kernelClient().browsers.telemetry.events(
+      kernelSessionId,
+      {
+        since: sinceIso,
+        until: untilIso,
+      },
+    );
+    for await (const item of page) {
+      events.push(toTimelineEvent(item.event as KernelEvent, item.seq));
+      // Bound pagination; the span layer trims further for legibility.
+      if (events.length >= 200) break;
+    }
+    return events;
+  };
+}

--- a/lib/kernel/telemetry.ts
+++ b/lib/kernel/telemetry.ts
@@ -1,15 +1,15 @@
 /**
- * Kernel Browser Telemetry → OpenTelemetry bridge.
+ * Bridge from Kernel Browser Telemetry to OpenTelemetry.
  *
- * Kernel records what happens *inside* the browser VM — console errors, CDP
- * connects/disconnects, captcha outcomes, OOM kills — on a durable timeline
- * keyed by browser session. This module reads the slice of that timeline
- * matching one agent-browser command so the span layer can attach it to the
- * trace: a failed click then carries the page's own evidence.
+ * Kernel records the events that occur in the browser VM: console errors,
+ * CDP connects and disconnects, captcha results, and OOM kills. This module
+ * reads the events that match one agent-browser command. The span layer
+ * attaches them to the trace, so a failed click shows the browser's own
+ * evidence.
  *
- * Capture is opt-in per category at browser creation (see
- * `getOrCreateBrowser`). `network` stays off: request/response headers and
- * bodies carry applicant PII.
+ * Capture is set for each category when the browser is created (see
+ * `getOrCreateBrowser`). The `network` category stays off because request
+ * data contains applicant PII.
  */
 
 import Kernel from '@onkernel/sdk';
@@ -18,24 +18,21 @@ import type {
   TimelineEvent,
 } from '@/lib/observability/browser-telemetry';
 
-// Lazy: the SDK constructor throws without KERNEL_API_KEY, and this module's
-// pure mapping half must stay importable (tests, environments without Kernel).
+// Create the client on first use. The SDK constructor fails when
+// KERNEL_API_KEY is not set, and tests import the pure functions here.
 let client: Kernel | undefined;
 function kernelClient(): Kernel {
   client ??= new Kernel();
   return client;
 }
 
-/**
- * Payload strings are page-controlled (console text, URLs); keep them short
- * enough for a span event and mark the cut.
- */
+/** The page controls payload strings. Keep them short and mark the cut. */
 const MAX_ATTR_STRING = 500;
 
-/** Payload fields can be arbitrary; a span event should stay skimmable. */
+/** Keep span events small so they are easy to read. */
 const MAX_ATTRS_PER_EVENT = 16;
 
-/** Shape shared by every member of Kernel's telemetry event union. */
+/** The fields that all members of Kernel's telemetry event union share. */
 interface KernelEvent {
   category: string;
   type: string;
@@ -46,10 +43,9 @@ interface KernelEvent {
 }
 
 /**
- * Map one Kernel event to a span event: `kernel.<type>` named, stamped with
- * the event's own timestamp, carrying the primitive payload fields. Nested
- * objects (call stacks, header maps) are dropped — the durable timeline keeps
- * the full record, the trace needs the headline.
+ * Map one Kernel event to a span event named `kernel.<type>`, with the
+ * event's own timestamp and its primitive payload fields. Nested objects are
+ * dropped: Kernel's durable timeline keeps the full record.
  *
  * Exported for tests.
  */
@@ -86,8 +82,8 @@ export function toTimelineEvent(
 }
 
 /**
- * Build a collector that reads a Kernel browser session's telemetry events
- * for a time window. The SDK paginates transparently; the caller caps volume.
+ * Make a collector that reads one Kernel browser session's telemetry events
+ * for a time window.
  */
 export function kernelTimelineCollector(
   kernelSessionId: string,
@@ -103,7 +99,7 @@ export function kernelTimelineCollector(
     );
     for await (const item of page) {
       events.push(toTimelineEvent(item.event as KernelEvent, item.seq));
-      // Bound pagination; the span layer trims further for legibility.
+      // Stop after 200 events. The span layer applies a lower limit.
       if (events.length >= 200) break;
     }
     return events;

--- a/lib/observability/browser-telemetry.ts
+++ b/lib/observability/browser-telemetry.ts
@@ -98,17 +98,17 @@ export interface CommandTelemetry {
   end(result: { outcome: CommandOutcome; error?: string | null }): void;
 }
 
-/** One event from an external timeline (e.g. Kernel Browser Telemetry). */
+/** One event from an external timeline, for example Kernel Browser Telemetry. */
 export interface TimelineEvent {
-  /** Span-event name, e.g. `kernel.console_error`. */
+  /** Span-event name, for example `kernel.console_error`. */
   name: string;
   timestamp: Date;
   attributes?: Record<string, string | number | boolean>;
 }
 
 /**
- * Fetches external timeline events for a time window. Kept as an injected
- * callback so this module stays free of vendor SDK dependencies.
+ * Reads external timeline events for a time window. The callback is injected
+ * so this module does not import vendor SDKs.
  */
 export type TimelineCollector = (window: {
   sinceIso: string;
@@ -116,9 +116,9 @@ export type TimelineCollector = (window: {
 }) => Promise<TimelineEvent[]>;
 
 /**
- * Stamp attributes onto whatever span is currently active (no-op without one).
- * Used to put Kernel session ids and replay URLs on the enclosing tool span so
- * the recording is one click away from the trace.
+ * Set attributes on the span that is active now. Do nothing when no span is
+ * active. Callers use this to put Kernel session ids and replay URLs on the
+ * tool span, which makes the recording reachable from the trace.
  */
 export function annotateActiveSpan(
   attributes: Record<string, string | number | boolean>,
@@ -215,7 +215,7 @@ export function startCommandTelemetry(
     session: string;
     remote: boolean;
     timeoutMs: number;
-    /** When set, the command's window of external events becomes a child span. */
+    /** When set, external events from the command window become a child span. */
     collectTimeline?: TimelineCollector;
   },
 ): CommandTelemetry {
@@ -234,8 +234,8 @@ export function startCommandTelemetry(
     .getTracer(TRACER_NAME)
     .startSpan(`agent-browser ${command}`, { attributes });
 
-  // Captured now: end() runs from a subprocess callback, where the active
-  // context that should parent the timeline span is long gone.
+  // Capture the parent context now. end() runs from a subprocess callback,
+  // where the active context is gone.
   const parentContext = trace.setSpan(context.active(), span);
 
   log(
@@ -298,22 +298,20 @@ export function startCommandTelemetry(
 }
 
 /**
- * How long to wait before reading the timeline. Kernel archives events to a
- * durable log as they happen, but a click's consequences (console errors, CDP
- * disconnects) can land just after the command returns.
+ * Wait time before the timeline read. The events that a command causes can
+ * arrive after the command returns.
  */
 const TIMELINE_SETTLE_MS = 1_500;
 
-/** A page can fire hundreds of events a second; the span stays legible. */
+/** A page can send hundreds of events each second. Keep the span readable. */
 const TIMELINE_MAX_EVENTS = 100;
 
 /**
- * Fetch the external events that occurred during one command's window and emit
- * them as a child span with explicit timestamps. A separate span (rather than
- * events on the command span itself) keeps the command's duration honest: the
- * fetch happens after the command span has already ended.
+ * Read the external events from one command's window and emit them as a child
+ * span with explicit timestamps. A separate span keeps the command duration
+ * correct, because the read occurs after the command span ends.
  *
- * Fire-and-forget by design — the agent loop must never wait on this.
+ * Callers do not await this function. The agent loop must not wait for it.
  */
 async function emitTimelineSpan(args: {
   collect: TimelineCollector;
@@ -349,7 +347,7 @@ async function emitTimelineSpan(args: {
     }
     span.end(new Date(endedAtMs + TIMELINE_SETTLE_MS));
   } catch (error: unknown) {
-    // Best-effort enrichment; the command span and logs already exist.
+    // The command span and logs already exist. Do not fail the command.
     log('WARNING', 'kernel.timeline.error', {
       command,
       error: error instanceof Error ? error.message : String(error),

--- a/lib/observability/browser-telemetry.ts
+++ b/lib/observability/browser-telemetry.ts
@@ -17,7 +17,8 @@
 
 import { SpanStatusCode, context, trace, type Span } from '@opentelemetry/api';
 
-const TRACER_NAME = 'labs-asp.agent-browser';
+/** Scope name on every span this module creates; exporters filter on it. */
+export const TRACER_NAME = 'labs-asp.agent-browser';
 
 /** Attribute keys, named once so spans and logs cannot disagree. */
 export const ATTR = {

--- a/lib/observability/browser-telemetry.ts
+++ b/lib/observability/browser-telemetry.ts
@@ -15,7 +15,7 @@
  * without a translation layer.
  */
 
-import { SpanStatusCode, trace, type Span } from '@opentelemetry/api';
+import { SpanStatusCode, context, trace, type Span } from '@opentelemetry/api';
 
 const TRACER_NAME = 'labs-asp.agent-browser';
 
@@ -95,6 +95,34 @@ function traceCorrelation(
 export interface CommandTelemetry {
   /** Record the result and close the span. */
   end(result: { outcome: CommandOutcome; error?: string | null }): void;
+}
+
+/** One event from an external timeline (e.g. Kernel Browser Telemetry). */
+export interface TimelineEvent {
+  /** Span-event name, e.g. `kernel.console_error`. */
+  name: string;
+  timestamp: Date;
+  attributes?: Record<string, string | number | boolean>;
+}
+
+/**
+ * Fetches external timeline events for a time window. Kept as an injected
+ * callback so this module stays free of vendor SDK dependencies.
+ */
+export type TimelineCollector = (window: {
+  sinceIso: string;
+  untilIso: string;
+}) => Promise<TimelineEvent[]>;
+
+/**
+ * Stamp attributes onto whatever span is currently active (no-op without one).
+ * Used to put Kernel session ids and replay URLs on the enclosing tool span so
+ * the recording is one click away from the trace.
+ */
+export function annotateActiveSpan(
+  attributes: Record<string, string | number | boolean>,
+): void {
+  trace.getActiveSpan()?.setAttributes(attributes);
 }
 
 /**
@@ -186,6 +214,8 @@ export function startCommandTelemetry(
     session: string;
     remote: boolean;
     timeoutMs: number;
+    /** When set, the command's window of external events becomes a child span. */
+    collectTimeline?: TimelineCollector;
   },
 ): CommandTelemetry {
   const command = argv[0] ?? 'unknown';
@@ -202,6 +232,10 @@ export function startCommandTelemetry(
   const span: Span = trace
     .getTracer(TRACER_NAME)
     .startSpan(`agent-browser ${command}`, { attributes });
+
+  // Captured now: end() runs from a subprocess callback, where the active
+  // context that should parent the timeline span is long gone.
+  const parentContext = trace.setSpan(context.active(), span);
 
   log(
     'INFO',
@@ -248,6 +282,76 @@ export function startCommandTelemetry(
         },
         span,
       );
+
+      if (meta.collectTimeline) {
+        void emitTimelineSpan({
+          collect: meta.collectTimeline,
+          parentContext,
+          command,
+          startedAtMs: startedAt,
+          endedAtMs: startedAt + durationMs,
+        });
+      }
     },
   };
+}
+
+/**
+ * How long to wait before reading the timeline. Kernel archives events to a
+ * durable log as they happen, but a click's consequences (console errors, CDP
+ * disconnects) can land just after the command returns.
+ */
+const TIMELINE_SETTLE_MS = 1_500;
+
+/** A page can fire hundreds of events a second; the span stays legible. */
+const TIMELINE_MAX_EVENTS = 100;
+
+/**
+ * Fetch the external events that occurred during one command's window and emit
+ * them as a child span with explicit timestamps. A separate span (rather than
+ * events on the command span itself) keeps the command's duration honest: the
+ * fetch happens after the command span has already ended.
+ *
+ * Fire-and-forget by design — the agent loop must never wait on this.
+ */
+async function emitTimelineSpan(args: {
+  collect: TimelineCollector;
+  parentContext: ReturnType<typeof trace.setSpan>;
+  command: string;
+  startedAtMs: number;
+  endedAtMs: number;
+}): Promise<void> {
+  const { collect, parentContext, command, startedAtMs, endedAtMs } = args;
+  try {
+    await new Promise((resolve) => setTimeout(resolve, TIMELINE_SETTLE_MS));
+    const events = (
+      await collect({
+        sinceIso: new Date(startedAtMs).toISOString(),
+        untilIso: new Date(endedAtMs + TIMELINE_SETTLE_MS).toISOString(),
+      })
+    ).slice(0, TIMELINE_MAX_EVENTS);
+    if (events.length === 0) return;
+
+    const span = trace.getTracer(TRACER_NAME).startSpan(
+      `kernel timeline ${command}`,
+      {
+        startTime: new Date(startedAtMs),
+        attributes: {
+          [ATTR.command]: command,
+          'kernel.event_count': events.length,
+        },
+      },
+      parentContext,
+    );
+    for (const event of events) {
+      span.addEvent(event.name, event.attributes, event.timestamp);
+    }
+    span.end(new Date(endedAtMs + TIMELINE_SETTLE_MS));
+  } catch (error: unknown) {
+    // Best-effort enrichment; the command span and logs already exist.
+    log('WARNING', 'kernel.timeline.error', {
+      command,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }

--- a/tests/client/browser-telemetry.node.test.ts
+++ b/tests/client/browser-telemetry.node.test.ts
@@ -118,6 +118,51 @@ test('withKernelSpan logs and rethrows a failure', async () => {
   });
 });
 
+test('a failing timeline collector logs a warning and never throws', async () => {
+  vi.useFakeTimers();
+  const t = startCommandTelemetry(['click', '@e1'], {
+    session: 'u:c',
+    remote: true,
+    timeoutMs: 1000,
+    collectTimeline: async () => {
+      throw new Error('kernel events unavailable');
+    },
+  });
+  t.end({ outcome: 'success' });
+  await vi.runAllTimersAsync();
+  vi.useRealTimers();
+
+  const warning = parsed(err).find((e) => e.event === 'kernel.timeline.error');
+  expect(warning).toMatchObject({
+    severity: 'WARNING',
+    command: 'click',
+    error: 'kernel events unavailable',
+  });
+});
+
+test('the timeline collector receives a window covering the command', async () => {
+  vi.useFakeTimers();
+  const windows: Array<{ sinceIso: string; untilIso: string }> = [];
+  const t = startCommandTelemetry(['open', 'https://example.com'], {
+    session: 'u:c',
+    remote: true,
+    timeoutMs: 1000,
+    collectTimeline: async (window) => {
+      windows.push(window);
+      return [];
+    },
+  });
+  t.end({ outcome: 'success' });
+  await vi.runAllTimersAsync();
+  vi.useRealTimers();
+
+  expect(windows).toHaveLength(1);
+  const { sinceIso, untilIso } = windows[0];
+  expect(new Date(sinceIso).getTime()).toBeLessThanOrEqual(
+    new Date(untilIso).getTime(),
+  );
+});
+
 test('agent step events record tool names but never arguments', () => {
   logAgentStep({
     index: 3,

--- a/tests/client/kernel-telemetry.node.test.ts
+++ b/tests/client/kernel-telemetry.node.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest';
+import { toTimelineEvent } from '@/lib/kernel/telemetry';
+
+test('maps a kernel event to a named, timestamped span event', () => {
+  const event = toTimelineEvent(
+    {
+      category: 'console',
+      type: 'console_error',
+      ts: 1_755_100_000_000_000, // unix microseconds
+      data: { message: 'Uncaught TypeError: x is not a function' },
+    },
+    42,
+  );
+
+  expect(event.name).toBe('kernel.console_error');
+  expect(event.timestamp.getTime()).toBe(1_755_100_000_000);
+  expect(event.attributes).toMatchObject({
+    'kernel.category': 'console',
+    'kernel.seq': 42,
+    'kernel.message': 'Uncaught TypeError: x is not a function',
+  });
+});
+
+test('drops nested payload fields and keeps primitives', () => {
+  const event = toTimelineEvent(
+    {
+      category: 'system',
+      type: 'system_oom_kill',
+      ts: 1_755_100_000_000_000,
+      data: {
+        victim_rss_bytes: 4_800_000_000,
+        fatal: true,
+        report: { lines: ['...'] }, // nested — must not become an attribute
+      },
+    },
+    1,
+  );
+
+  expect(event.attributes).toMatchObject({
+    'kernel.victim_rss_bytes': 4_800_000_000,
+    'kernel.fatal': true,
+  });
+  expect(event.attributes).not.toHaveProperty('kernel.report');
+});
+
+test('truncates long page-controlled strings', () => {
+  const event = toTimelineEvent(
+    {
+      category: 'console',
+      type: 'console_error',
+      ts: 1_755_100_000_000_000,
+      data: { message: 'x'.repeat(2_000) },
+    },
+    1,
+  );
+
+  const message = event.attributes?.['kernel.message'] as string;
+  expect(message.length).toBeLessThanOrEqual(501); // 500 + ellipsis
+  expect(message.endsWith('…')).toBe(true);
+});
+
+test('flags events kernel itself truncated', () => {
+  const event = toTimelineEvent(
+    {
+      category: 'console',
+      type: 'console_log',
+      ts: 1_755_100_000_000_000,
+      truncated: true,
+    },
+    1,
+  );
+
+  expect(event.attributes).toMatchObject({ 'kernel.truncated': true });
+});


### PR DESCRIPTION
## What

Completes the third leg of trace correlation (after #283): Kernel's browser-internal events now land in the same Cloud Trace waterfall as the LLM/agent spans and agent-browser command spans.

- **Capture** — `browsers.create` enables Kernel Browser Telemetry: the default operational set (`control`, `connection`, `system`, `captcha`) plus `console`. `network` stays off — headers/bodies carry applicant PII.
- **Correlation** — after each agent-browser command, the matching window of Kernel events is pulled (`browsers.telemetry.events`, since/until = the command's own span window) and emitted as a `kernel timeline <command>` child span with one span event per Kernel event. Fire-and-forget with a 1.5s settle delay; the agent loop never waits on it.
- **Reachability** — `kernel.session_id`, `kernel.live_view_url`, `kernel.replay_id` are stamped on the enclosing tool span at session creation, and `kernel.replay_url` at archival, so the recording is one click from the trace.

## Why

A failed click previously showed only the CLI's error. Now the trace shows the page's own evidence for that window — a 500 in the console, a CDP disconnect, an OOM kill with its memory numbers — interleaved with the agent's timeline.

## Notes

- `lib/kernel/telemetry.ts` keeps the Kernel SDK dependency out of the span layer (`browser-telemetry.ts` takes an injected collector).
- Payloads are guarded: primitives only, strings truncated at 500 chars, 16 attrs/event, 100 events/span.
- The Kernel client is lazy — the module stays importable without `KERNEL_API_KEY` (tests, local dev).

## Testing

- `pnpm exec vitest run tests/client/kernel-telemetry.node.test.ts tests/client/browser-telemetry.node.test.ts tests/client/agent-browser-cli.node.test.ts` — 27 passed.
- Needs a preview-deploy form run to verify events appear in Cloud Trace (telemetry config takes effect on newly created Kernel browsers).