### PR TITLE
docs(skills): add README for installing the form-completion skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "ai-chatbot",
+  "owner": {
+    "name": "Nava PBC",
+    "url": "https://www.navapbc.com"
+  },
+  "plugins": [
+    {
+      "name": "form-completion",
+      "source": "./",
+      "description": "Complete, test, or debug a web form with agent-browser: application, benefits, or government forms, multi-step apply flows, or any site form filling.",
+      "version": "1.0.0",
+      "strict": false,
+      "author": {
+        "name": "Nava PBC"
+      },
+      "skills": "./.claude/skills/"
+    }
+  ]
+}

--- a/.claude/skills/form-completion/README.md
+++ b/.claude/skills/form-completion/README.md
@@ -1,0 +1,119 @@
+# Form Completion Skill
+
+This skill gives Claude Code a tested procedure to complete web forms with
+[agent-browser](https://www.npmjs.com/package/agent-browser). It covers
+application forms, benefits forms, and multi-step apply flows. Each rule in the
+procedure comes from a failure that occurred in a real session — silent fill
+failures, masked date fields, gated sections, and checkbox polarity traps.
+
+## What You Get
+
+- `SKILL.md` — the six-phase fill procedure (find playbook → find form → gap
+  analysis → fill → verify → submit with approval)
+- `references/` — deep guides for silent-failure diagnosis, gap-analysis and
+  provenance reports, the knowledge-scribe background agent, and
+  multi-application orchestration
+- `playbooks/` — one file per site with confirmed selectors and gates; the
+  skill writes a new playbook for each new site it completes
+- `scripts/fill-helpers.sh` — bash helpers for batch fill, masked-field
+  keypress fill, and value readback in one tool call
+
+## Install the Skill
+
+The fastest path is the [skills CLI](https://github.com/vercel-labs/skills). It
+works with Claude Code and 70+ other agents:
+
+```bash
+npx skills add navapbc/ai-chatbot --skill form-completion
+```
+
+Or install manually. Copy this directory into your project or user skills
+directory:
+
+```bash
+# Project scope (this project only)
+git clone --depth 1 https://github.com/navapbc/ai-chatbot /tmp/ai-chatbot
+cp -r /tmp/ai-chatbot/.claude/skills/form-completion .claude/skills/
+
+# User scope (all your projects)
+cp -r /tmp/ai-chatbot/.claude/skills/form-completion ~/.claude/skills/
+```
+
+Claude Code loads the skill automatically when a task matches its
+description. You can also invoke it directly with `/form-completion`.
+
+## Dependency: agent-browser
+
+The skill does not work without the `agent-browser` CLI. It is a native Rust
+binary distributed through npm. Install it in one of two ways:
+
+```bash
+# Global — the binary is on your PATH
+npm install -g agent-browser
+
+# Project-local — the binary is at ./node_modules/.bin/agent-browser
+npm install agent-browser
+```
+
+The skill and its helpers look for the binary at
+`./node_modules/.bin/agent-browser` by default. If you installed it globally
+or somewhere else, point the helpers at it:
+
+```bash
+export AGENT_BROWSER_BIN=agent-browser
+```
+
+Version `0.33` or later is required. Earlier versions do not have the daemon
+`--session` flag that keeps element refs valid across CLI calls.
+
+## Dependency: a Browser to Drive
+
+agent-browser attaches to a Chromium browser over CDP. Pick one:
+
+**Local Chrome (recommended for watching the fill).** Start Chrome with remote
+debugging, then attach:
+
+```bash
+# macOS
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 --user-data-dir="$HOME/.chrome-debug" &
+
+agent-browser --session form-fill --cdp http://localhost:9222 open https://example.org
+```
+
+**Bundled browser.** With no `--cdp` flag, agent-browser launches its own
+browser. Add `--headed` to watch it.
+
+**Remote browser provider** (Kernel.sh, Browserbase, etc.). Pass the
+provider's CDP WebSocket URL with `--cdp <ws_url>`.
+
+Use one `--session <name>` value for the whole run. The daemon holds the CDP
+connection between calls, so element refs (`@e1`) stay valid across commands.
+
+## Quick Start
+
+1. Install the skill and agent-browser (above).
+2. Start Claude Code in your project.
+3. Ask: *"Fill out the application at https://forms.example.org for Maria
+   Garcia"* — include the applicant data in the message or point at a file.
+
+The skill then:
+
+1. Checks `playbooks/` for the target domain and probes that it is fresh
+2. Navigates from the landing page to the actual form
+3. Shows you a **gap-analysis table** — what data it has, what it derived, and
+   what it needs from you — and asks for missing values before it fills
+4. Fills in gate order, then reads every field back to catch silent failures
+5. Shows a **provenance report** (every value and its source) and **stops for
+   your explicit approval before it submits**
+
+The skill never clicks submit on its own, never invents values for required
+fields, and never attempts to defeat a bot challenge.
+
+## Notes for Maintainers
+
+- General patterns confirmed on two or more sites go in `SKILL.md` or
+  `references/`. Single-site facts go in that site's playbook only. See "Rules
+  for New Findings" in `SKILL.md`.
+- `scripts/fill-helpers.sh` is bash. On Windows, run it through WSL or Git
+  Bash.

--- a/.claude/skills/form-completion/README.md
+++ b/.claude/skills/form-completion/README.md
@@ -43,23 +43,7 @@ export AGENT_BROWSER_BIN=agent-browser
 
 ### A browser
 
-agent-browser attaches to a Chromium browser through CDP. Use one of these options:
-
-Local Chrome. This option lets you watch the fill. Start Chrome with remote debugging, then attach:
-
-```bash
-# macOS
-"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-  --remote-debugging-port=9222 --user-data-dir="$HOME/.chrome-debug" &
-
-agent-browser --session form-fill --cdp http://localhost:9222 open https://example.org
-```
-
-Bundled browser. With no `--cdp` flag, agent-browser starts its own browser. Add `--headed` to watch it.
-
-Remote browser provider (Kernel, Browserbase, and others). Pass the provider CDP WebSocket URL with `--cdp <ws_url>`.
-
-Use one `--session <name>` value for the full run. The daemon holds the CDP connection between calls, so element refs such as `@e1` stay valid across commands.
+You do not set up a browser. The agent starts and controls the browser itself. By default agent-browser starts its own browser. If you want to watch the fill, tell the agent to show the browser window or to attach to your own Chrome. The agent can also attach to a remote browser provider such as Kernel or Browserbase.
 
 ## Use
 

--- a/.claude/skills/form-completion/README.md
+++ b/.claude/skills/form-completion/README.md
@@ -1,77 +1,51 @@
-# Form Completion Skill
+[![skills.sh](https://skills.sh/b/navapbc/ai-chatbot)](https://skills.sh/navapbc/ai-chatbot)
 
-This skill gives Claude Code a tested procedure to complete web forms with
-[agent-browser](https://www.npmjs.com/package/agent-browser). It covers
-application forms, benefits forms, and multi-step apply flows. Each rule in the
-procedure comes from a failure that occurred in a real session — silent fill
-failures, masked date fields, gated sections, and checkbox polarity traps.
+An agent skill that completes web forms with [agent-browser](https://github.com/vercel-labs/agent-browser). It covers application forms, benefits forms, and multi-step apply flows. Each rule in the procedure comes from a failure that occurred in a real session.
 
-## What You Get
+## Skills
 
-- `SKILL.md` — the six-phase fill procedure (find playbook → find form → gap
-  analysis → fill → verify → submit with approval)
-- `references/` — deep guides for silent-failure diagnosis, gap-analysis and
-  provenance reports, the knowledge-scribe background agent, and
-  multi-application orchestration
-- `playbooks/` — one file per site with confirmed selectors and gates; the
-  skill writes a new playbook for each new site it completes
-- `scripts/fill-helpers.sh` — bash helpers for batch fill, masked-field
-  keypress fill, and value readback in one tool call
+- [**form-completion**](SKILL.md): A six-phase procedure to complete a web form. The skill finds the form, shows a gap analysis, asks the user for missing data, fills the fields, verifies each write, and waits for approval from the user before it submits. It includes references for silent-failure diagnosis, site playbooks with confirmed selectors, and bash helpers for batch fill and readback.
 
-## Install the Skill
+## Install
 
-The fastest path is the [skills CLI](https://github.com/vercel-labs/skills). It
-works with Claude Code and 70+ other agents:
+### CLI
+
+Works in Claude Code, Codex, Opencode and other agents.
 
 ```bash
-npx skills add navapbc/ai-chatbot --skill form-completion
+npx skills add navapbc/ai-chatbot
 ```
 
-Or install manually. Copy this directory into your project or user skills
-directory:
+### Claude Code plugin
 
-```bash
-# Project scope (this project only)
-git clone --depth 1 https://github.com/navapbc/ai-chatbot /tmp/ai-chatbot
-cp -r /tmp/ai-chatbot/.claude/skills/form-completion .claude/skills/
+Installs the skill and updates in place. Run these inside Claude Code:
 
-# User scope (all your projects)
-cp -r /tmp/ai-chatbot/.claude/skills/form-completion ~/.claude/skills/
+```text
+/plugin marketplace add navapbc/ai-chatbot
+/plugin install form-completion@ai-chatbot
 ```
 
-Claude Code loads the skill automatically when a task matches its
-description. You can also invoke it directly with `/form-completion`.
+## Requirements
 
-## Dependency: agent-browser
+### agent-browser
 
-The skill does not work without the `agent-browser` CLI. It is a native Rust
-binary distributed through npm. Install it in one of two ways:
+The skill does not work without the agent-browser CLI, version 0.33 or later. It is a native Rust binary on npm.
 
 ```bash
-# Global — the binary is on your PATH
 npm install -g agent-browser
-
-# Project-local — the binary is at ./node_modules/.bin/agent-browser
-npm install agent-browser
 ```
 
-The skill and its helpers look for the binary at
-`./node_modules/.bin/agent-browser` by default. If you installed it globally
-or somewhere else, point the helpers at it:
+A project-local installation also works. The helper scripts look for the binary at `./node_modules/.bin/agent-browser`. If the binary is at a different location, set the path:
 
 ```bash
 export AGENT_BROWSER_BIN=agent-browser
 ```
 
-Version `0.33` or later is required. Earlier versions do not have the daemon
-`--session` flag that keeps element refs valid across CLI calls.
+### A browser
 
-## Dependency: a Browser to Drive
+agent-browser attaches to a Chromium browser through CDP. Use one of these options:
 
-agent-browser attaches to a Chromium browser over CDP. Pick one:
-
-**Local Chrome (recommended for watching the fill).** Start Chrome with remote
-debugging, then attach:
+Local Chrome. This option lets you watch the fill. Start Chrome with remote debugging, then attach:
 
 ```bash
 # macOS
@@ -81,39 +55,31 @@ debugging, then attach:
 agent-browser --session form-fill --cdp http://localhost:9222 open https://example.org
 ```
 
-**Bundled browser.** With no `--cdp` flag, agent-browser launches its own
-browser. Add `--headed` to watch it.
+Bundled browser. With no `--cdp` flag, agent-browser starts its own browser. Add `--headed` to watch it.
 
-**Remote browser provider** (Kernel.sh, Browserbase, etc.). Pass the
-provider's CDP WebSocket URL with `--cdp <ws_url>`.
+Remote browser provider (Kernel, Browserbase, and others). Pass the provider CDP WebSocket URL with `--cdp <ws_url>`.
 
-Use one `--session <name>` value for the whole run. The daemon holds the CDP
-connection between calls, so element refs (`@e1`) stay valid across commands.
+Use one `--session <name>` value for the full run. The daemon holds the CDP connection between calls, so element refs such as `@e1` stay valid across commands.
 
-## Quick Start
+## Use
 
-1. Install the skill and agent-browser (above).
-2. Start Claude Code in your project.
-3. Ask: *"Fill out the application at https://forms.example.org for Maria
-   Garcia"* — include the applicant data in the message or point at a file.
+Ask your agent to fill a form and give it the applicant data:
 
-The skill then:
+```text
+Fill out the application at https://forms.example.org for Maria Garcia.
+```
 
-1. Checks `playbooks/` for the target domain and probes that it is fresh
-2. Navigates from the landing page to the actual form
-3. Shows you a **gap-analysis table** — what data it has, what it derived, and
-   what it needs from you — and asks for missing values before it fills
-4. Fills in gate order, then reads every field back to catch silent failures
-5. Shows a **provenance report** (every value and its source) and **stops for
-   your explicit approval before it submits**
+The skill then does these steps:
 
-The skill never clicks submit on its own, never invents values for required
-fields, and never attempts to defeat a bot challenge.
+1. Checks `playbooks/` for the target domain and makes sure the playbook is fresh
+2. Navigates from the landing page to the form
+3. Shows a gap-analysis table with the data it has, the data it derived, and the data it needs, then asks for the missing values before it fills
+4. Fills the fields in gate order, then reads each field again to catch silent failures
+5. Shows a provenance report with the source of each value and stops for explicit approval before it submits
+
+The skill never clicks submit on its own, never invents values for required fields, and never tries to defeat a bot challenge.
 
 ## Notes for Maintainers
 
-- General patterns confirmed on two or more sites go in `SKILL.md` or
-  `references/`. Single-site facts go in that site's playbook only. See "Rules
-  for New Findings" in `SKILL.md`.
-- `scripts/fill-helpers.sh` is bash. On Windows, run it through WSL or Git
-  Bash.
+- General patterns confirmed on two or more sites go in `SKILL.md` or `references/`. Facts from one site go in the playbook of that site only. See "Rules for New Findings" in `SKILL.md`.
+- `scripts/fill-helpers.sh` is bash. On Windows, run it through WSL or Git Bash.

--- a/.claude/skills/form-completion/SKILL.md
+++ b/.claude/skills/form-completion/SKILL.md
@@ -11,9 +11,13 @@ sequence. Each rule comes from a failure that occurred in a real session.
 The most dangerous failure is the silent success. The tool shows `✓ Done`, but the
 field stays empty. Phase 4 finds these failures. Do not skip Phase 4.
 
-Use the binary `./node_modules/.bin/agent-browser` from the `client/` directory. There
-is no global installation. To attach to a local Chrome, read the
-`agent-browser-local-cdp-setup` memory.
+Find the binary in this sequence: `$AGENT_BROWSER_BIN`, then
+`./node_modules/.bin/agent-browser`, then `agent-browser` on the PATH. You start and
+control the browser — do not ask the user to do it. With no `--cdp` flag the CLI
+starts its own browser; add `--headed` when the user wants to watch. To attach to the
+user's own Chrome instead, start Chrome with `--remote-debugging-port=9222` and a
+dedicated `--user-data-dir`, then pass `--cdp http://localhost:9222`. A remote
+provider (Kernel, Browserbase) gives a CDP WebSocket URL for `--cdp`.
 
 **When one run has two or more applications**, read `references/multi-application.md`
 first. The main session becomes the orchestrator: it does the intake for all the


### PR DESCRIPTION
## Summary

Adds a README to `.claude/skills/form-completion/` and a plugin marketplace manifest so external users can install the skill with a one-liner, in the same format as skills repos such as jakubkrehel/skills.

### Install paths

CLI (Claude Code, Codex, Opencode and other agents):

```bash
npx skills add navapbc/ai-chatbot
```

Claude Code plugin (enabled by the new `.claude-plugin/marketplace.json`):

```text
/plugin marketplace add navapbc/ai-chatbot
/plugin install form-completion@ai-chatbot
```

### Contents

- `README.md`: skill description, install one-liners, and the agent-browser dependency (>=0.33, `AGENT_BROWSER_BIN` override). Browser startup is the agent's job, so the README only tells users they can ask to watch the fill. Written in ASD-STE100 style.
- `SKILL.md`: the browser attach instructions (bundled vs local Chrome CDP vs remote provider) now live here, replacing a pointer to a user-local Claude memory that external installs would not have. Binary resolution order is `$AGENT_BROWSER_BIN`, then `./node_modules/.bin/agent-browser`, then PATH.
- `.claude-plugin/marketplace.json`: marketplace `ai-chatbot` with one plugin, `form-completion`. The plugin entry uses `strict: false` and points `skills` at `./.claude/skills/`, so no repo restructure is needed.

Documentation and metadata only, no code changes.

### Notes

- The plugin `source` is the repo root, so a plugin install copies the repo into the local plugin cache. If cache size becomes a concern, a later PR can move the plugin to a subdirectory source.
