### PR TITLE
ci: cache the Playwright browser in the Test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,28 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      # Cache key comes from the resolved playwright version in the lockfile, so a
+      # dependency bump invalidates it and any other change reuses the browser.
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browser
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
       # Vitest runs in browser mode (Playwright Chromium), so the browser and its
-      # system deps must be present in CI.
+      # system deps must be present in CI. The download is the slowest step in this
+      # job and has hung on Microsoft's CDN, so skip it when the cache hit.
       - name: Install Playwright Chromium
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
+      # apt-installed system libs live outside the cached path, so they are still
+      # needed on a cache hit.
+      - name: Install Playwright system dependencies
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
       # Non-blocking: a failing test reports here but must not block merging.
       # Remove `continue-on-error` once the suite is stable enough to gate on.
       - name: Run tests


### PR DESCRIPTION
## Problem

Downloading Chromium is the slowest step in `Test` and it hangs when Microsoft's CDN is slow.

- Last successful run: **4m39s** on `Install Playwright Chromium` (16:38:46 → 16:43:25) out of a ~6m job
- Run [32304420752](https://github.com/navapbc/ai-chatbot/actions/runs/32304420752) sat on that step for **11+ minutes** without ever reaching step 7 (`Run tests`)

Every `Test` run re-downloads the browser; there's no cache. External downloads are the main flake surface here right now — a `Deploy Infrastructure` run failed earlier the same day with `releases.hashicorp.com: read: connection reset by peer` during `terraform init`.

## Change

Cache `~/.cache/ms-playwright`, keyed on the resolved `playwright` version (currently 1.58.1) read from the installed package. A dependency bump invalidates the cache; any other change reuses the browser.

The install step is split because the apt packages from `--with-deps` live **outside** the cached directory:

- **cache miss** → `playwright install --with-deps chromium` (unchanged behaviour)
- **cache hit** → `playwright install-deps chromium` only (system libs still needed)

## Verification

`yamllint` passes under the repo's exact CI config (`line-length`, `trailing-spaces`, `new-line-at-end-of-file`, `document-start` disabled). The one remaining `truthy` warning is on the pre-existing `on:` line and is unchanged by this PR.

The real test is the run on this PR: expect a cache miss (full download, same as today), then a hit on the following run.

## Note

This does not change what the tests do or whether they gate merges — `continue-on-error: true` on `Run tests` is untouched.