### PR TITLE
fix(observability): keep root spans and runtime-context attrs in Braintrust

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -5,7 +5,7 @@ import {
   DiagLogLevel,
   trace,
 } from '@opentelemetry/api';
-import { BraintrustExporter } from '@braintrust/otel';
+import { BraintrustExporter, isRootSpan } from '@braintrust/otel';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { Compute } from 'google-auth-library';
 import {
@@ -61,12 +61,14 @@ export function register() {
     spanProcessors.push(
       new BatchSpanProcessor(
         new BraintrustExporter({
-          // Keep the AI spans and the browser tracer's spans. Drop the rest.
+          // Keep the AI spans, the browser tracer's spans, and the root span
+          // that parents them. Drop the rest.
           filterAISpans: true,
-          customFilter: (span) =>
-            span.instrumentationScope?.name === BROWSER_TRACER
-              ? true
-              : undefined,
+          customFilter: (span) => {
+            if (span.instrumentationScope?.name === BROWSER_TRACER) return true;
+            if (isRootSpan(span)) return true;
+            return undefined;
+          },
         }),
       ),
     );
@@ -102,7 +104,8 @@ export function register() {
 
   // AI SDK 7 emits no model spans until an integration is registered. Must
   // follow registerOTel — it binds the tracer from that provider.
-  registerTelemetry(new OpenTelemetry());
+  // runtimeContext defaults to false, dropping the route's join keys.
+  registerTelemetry(new OpenTelemetry({ runtimeContext: true }));
 
   // All-zero trace id here means the bundler split @opentelemetry/api and this
   // provider is not the one route handlers see.


### PR DESCRIPTION
Braintrust traces from `labs-asp-dev` are missing their root spans and all correlation metadata, which blocks online scoring. Two independent causes, both in `instrumentation.ts`.

## No root spans

`filterAISpans: true` installs an `AISpanProcessor` that keeps a span only when `customFilter` returns a boolean or `isAISpan` matches. `isAISpan` tests the span name and attribute names against `gen_ai.`, `ai.`, `llm.`, `braintrust.`, `traceloop.`.

The Next.js request span carries `http.*` attributes, so it matched nothing and was dropped — while the `invoke_agent` spans beneath it kept a `span_parents` pointer to it. Every trace arrived parented to a span Braintrust never received.

Measured in `labs-asp-dev`: **`is_root=true` on 0 of 54 spans.**

Trace-scope online scoring attaches its score to the root span, so it had nothing to bind to. `@braintrust/otel` already exports `isRootSpan` for exactly this case; the filter just never called it.

## No join keys

The chat route sets `chatId` / `userId` / `sessionId` / `environment` / `model` via `runtimeContext` and opts into them with `telemetry.includeRuntimeContext` (`app/(chat)/api/chat/route.ts:298-312`). That opt-in controls which values reach the telemetry integration.

Separately, `@ai-sdk/otel` gates whether the integration *writes* them to the span behind its own `runtimeContext` option, which defaults to `false` in `disabledSupplementalAttributes`. Both are required; only one was set.

Measured: **all five absent from every span** (only `gen_ai.*` and `model` present). They now emit as `ai.settings.context.*`.

## Testing

- `tsc --noEmit`: 14 errors before, 14 after, none in `instrumentation.ts` (pre-existing, unrelated files)
- `biome check instrumentation.ts`: clean
- Runtime verification needs a preview deploy — see below

## Verifying on preview

Once deployed, run a chat that reaches `gapAnalysis` and confirm against the preview's Braintrust project:

1. At least one span with `is_root=true`
2. `ai.settings.context.chatId` / `.sessionId` present on agent spans
3. The logs table shows a proper root row per turn rather than orphaned fragments

## Known follow-up (not in this PR)

One conversation still produces **N traces, one per turn**. `gapAnalysis` ends the agent's turn by design, so each turn is a separate `POST /api/chat` and OTel scopes a trace per request — this is the "two rows per conversation" symptom in the logs table.

This PR does not merge them, and HTTP-request-scoped tracing won't. Now that `chatId` reaches the spans, Braintrust **group-scope** scoring can join the turns of one conversation. That's the intended path and it's unblocked by this change.