### PR TITLE
feat(evals): add online eval for gap-analysis asking quality

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -283,6 +283,30 @@ jobs:
         working-directory: ./terraform
         run: terraform apply -auto-approve tfplan
 
+      # Reconciles the Braintrust online-scoring rules with evals/online/.
+      # Same env -> project mapping as BRAINTRUST_PARENT in cloud_run.tf.
+      - name: Set up Node
+        if: needs.setup.outputs.should_deploy == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Apply Braintrust online evals
+        if: needs.setup.outputs.should_deploy == 'true'
+        env:
+          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+          ENVIRONMENT: ${{ needs.setup.outputs.environment }}
+        run: |
+          if [ -z "$BRAINTRUST_API_KEY" ]; then
+            echo "::warning::BRAINTRUST_API_KEY is not configured — skipping online evals."
+            exit 0
+          fi
+          case "$ENVIRONMENT" in
+            preview-pr-*) BT_ENV=preview ;;
+            *) BT_ENV="$ENVIRONMENT" ;;
+          esac
+          npx -y tsx evals/online/apply.ts "$BT_ENV" --activate
+
       - name: Get Terraform Outputs
         if: needs.setup.outputs.should_deploy == 'true'
         working-directory: ./terraform

--- a/evals/online/apply.ts
+++ b/evals/online/apply.ts
@@ -25,17 +25,21 @@ if (!apiKey) {
 }
 
 const args = process.argv.slice(2);
-const env = args.find((a) => !a.startsWith('--')) as Environment | undefined;
+const target = args.find((a) => !a.startsWith('--'));
 const activate = args.includes('--activate');
 const dryRun = args.includes('--dry-run');
 
-if (!env || !ENVIRONMENTS.includes(env)) {
+if (
+  !target ||
+  (target !== 'all' && !ENVIRONMENTS.includes(target as Environment))
+) {
   throw new Error(
-    `Usage: apply.ts <${ENVIRONMENTS.join('|')}> [--activate] [--dry-run]`,
+    `Usage: apply.ts <${ENVIRONMENTS.join('|')}|all> [--activate] [--dry-run]`,
   );
 }
 
-const projectName = `labs-asp-${env}`;
+const targets: Environment[] =
+  target === 'all' ? [...ENVIRONMENTS] : [target as Environment];
 
 const request = async (
   method: string,
@@ -58,7 +62,9 @@ const request = async (
   return res.json();
 };
 
-const main = async () => {
+const applyEnv = async (env: Environment) => {
+  const projectName = `labs-asp-${env}`;
+
   // Braintrust creates projects on first trace, so prod may not exist yet.
   const { objects: projects } = await request(
     'GET',
@@ -66,27 +72,20 @@ const main = async () => {
   );
   const project = projects?.[0];
   if (!project) {
-    throw new Error(
-      `Project "${projectName}" does not exist. Braintrust creates it on the ` +
-        `first exported trace — deploy ${env} and send one request first.`,
-    );
+    return {
+      project: projectName,
+      skipped: `does not exist yet — send one trace from ${env} first`,
+    };
   }
 
   if (dryRun) {
-    console.log(
-      JSON.stringify(
-        {
-          project: projectName,
-          project_id: project.id,
-          evaluator: EVALUATOR_SLUG,
-          rule: RULE_NAME,
-          status: activate ? 'active' : 'paused',
-        },
-        null,
-        2,
-      ),
-    );
-    return;
+    return {
+      project: projectName,
+      project_id: project.id,
+      evaluator: EVALUATOR_SLUG,
+      rule: RULE_NAME,
+      status: activate ? 'active' : 'paused',
+    };
   }
 
   // Upsert by slug.
@@ -113,18 +112,20 @@ const main = async () => {
     },
   });
 
-  console.log(
-    JSON.stringify(
-      {
-        project: projectName,
-        evaluator_id: evaluator.id,
-        rule_id: rule.id,
-        status: activate ? 'active' : 'paused',
-      },
-      null,
-      2,
-    ),
-  );
+  return {
+    project: projectName,
+    evaluator_id: evaluator.id,
+    rule_id: rule.id,
+    status: activate ? 'active' : 'paused',
+  };
+};
+
+const main = async () => {
+  const results = [];
+  for (const env of targets) {
+    results.push(await applyEnv(env));
+  }
+  console.log(JSON.stringify(results, null, 2));
 };
 
 main().catch((error) => {

--- a/evals/online/apply.ts
+++ b/evals/online/apply.ts
@@ -1,0 +1,133 @@
+// Applies the online-eval config to one environment's Braintrust project.
+// Idempotent; rules stay paused unless --activate.
+//
+//   pnpm eval:online:apply dev [--activate] [--dry-run]
+//
+// Project names mirror BRAINTRUST_PARENT in terraform/cloud_run.tf. Keep in
+// sync with terraform's `environments` map.
+
+import {
+  BTQL_FILTER,
+  EVALUATOR_DEFINITION,
+  EVALUATOR_SLUG,
+  RULE_NAME,
+  RULE_SCOPE,
+} from './gap-analysis-asking';
+
+const ENVIRONMENTS = ['dev', 'preview', 'prod'] as const;
+type Environment = (typeof ENVIRONMENTS)[number];
+
+const API = 'https://api.braintrust.dev';
+
+const apiKey = process.env.BRAINTRUST_API_KEY;
+if (!apiKey) {
+  throw new Error('BRAINTRUST_API_KEY is not set');
+}
+
+const args = process.argv.slice(2);
+const env = args.find((a) => !a.startsWith('--')) as Environment | undefined;
+const activate = args.includes('--activate');
+const dryRun = args.includes('--dry-run');
+
+if (!env || !ENVIRONMENTS.includes(env)) {
+  throw new Error(
+    `Usage: apply.ts <${ENVIRONMENTS.join('|')}> [--activate] [--dry-run]`,
+  );
+}
+
+const projectName = `labs-asp-${env}`;
+
+const request = async (
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<any> => {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${path} failed (${res.status}): ${await res.text()}`,
+    );
+  }
+  return res.json();
+};
+
+const main = async () => {
+  // Braintrust creates projects on first trace, so prod may not exist yet.
+  const { objects: projects } = await request(
+    'GET',
+    `/v1/project?project_name=${encodeURIComponent(projectName)}`,
+  );
+  const project = projects?.[0];
+  if (!project) {
+    throw new Error(
+      `Project "${projectName}" does not exist. Braintrust creates it on the ` +
+        `first exported trace — deploy ${env} and send one request first.`,
+    );
+  }
+
+  if (dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          project: projectName,
+          project_id: project.id,
+          evaluator: EVALUATOR_SLUG,
+          rule: RULE_NAME,
+          status: activate ? 'active' : 'paused',
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  // Upsert by slug.
+  const evaluator = await request('PUT', '/v1/function', {
+    project_id: project.id,
+    function_type: 'scorer',
+    ...EVALUATOR_DEFINITION,
+  });
+
+  // PUT replaces by name; POST no-ops on an existing rule and leaves it stale.
+  const rule = await request('PUT', '/v1/project_score', {
+    project_id: project.id,
+    name: RULE_NAME,
+    score_type: 'online',
+    description: `Scores caseworker-facing gapAnalysis quality on ${env} traffic.`,
+    config: {
+      online: {
+        sampling_rate: 1,
+        scorers: [{ type: 'function', id: evaluator.id }],
+        btql_filter: BTQL_FILTER,
+        scope: RULE_SCOPE,
+        status: activate ? 'active' : 'paused',
+      },
+    },
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        project: projectName,
+        evaluator_id: evaluator.id,
+        rule_id: rule.id,
+        status: activate ? 'active' : 'paused',
+      },
+      null,
+      2,
+    ),
+  );
+};
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/evals/online/gap-analysis-asking.ts
+++ b/evals/online/gap-analysis-asking.ts
@@ -1,0 +1,127 @@
+// Online variant of evals/scorers/ask-questions.ts. Ground truth comes from the
+// participant JSON in the caseworker's opening message, not an eval serializer.
+// Uses REST, not projects.scorers.create: ScorerPromptOpts has no preprocessor
+// or allow_skip.
+
+export const CHOICE_SCORES = { A: 1, B: 0.5, C: 0 } as const;
+
+export const JUDGE_MODEL = 'claude-sonnet-5';
+
+export const EVALUATOR_SLUG = 'gap-analysis-asking-online';
+export const RULE_NAME = 'Gap analysis asking quality';
+
+// Without this, orphan `agent-browser close` spans form empty 1-span traces
+// that the judge scores anyway.
+export const BTQL_FILTER = "span_attributes.name = 'execute_tool gapAnalysis'";
+
+// Runs per span, merged in trace order. Dropping browser/reference spans cuts
+// a small trace from ~52KB to ~6KB.
+export const PREPROCESSOR_CODE = `const NOISY = new Set(['browser', 'readReference', 'actionLabel']);
+const CAP = 1500;
+
+function clip(v) {
+  const s = typeof v === 'string' ? v : JSON.stringify(v);
+  if (s == null) return '';
+  return s.length > CAP ? s.slice(0, CAP) + ' …[truncated]' : s;
+}
+
+function handler({ input, output, span_attributes }) {
+  const name = span_attributes?.name || '';
+  const items = [];
+
+  if (name.startsWith('invoke_agent') || name.startsWith('chat ')) {
+    const msgs = Array.isArray(input) ? input : input?.messages;
+    if (Array.isArray(msgs)) {
+      for (const m of msgs) {
+        if (m?.role === 'user' || m?.role === 'system') {
+          items.push({ role: m.role, content: clip(m.content) });
+        }
+      }
+    }
+    const outMsgs = Array.isArray(output) ? output : [output];
+    for (const o of outMsgs) {
+      if (o?.content) items.push({ role: 'assistant', content: clip(o.content) });
+    }
+  }
+
+  if (name.startsWith('execute_tool ')) {
+    const tool = name.slice('execute_tool '.length);
+    if (!NOISY.has(tool)) {
+      items.push({ role: 'tool', content: \`\${tool} args=\${clip(input)} result=\${clip(output)}\` });
+    }
+  }
+
+  return items;
+}
+`;
+
+export const SYSTEM_PROMPT = `You are evaluating a production trace of an AI form-filling agent that helps caseworkers complete government benefits forms.
+
+You are grading ONE thing: the quality of the agent's \`gapAnalysis\` calls — the questions it asks the caseworker for information it could not obtain itself.
+
+The trace gives you:
+- The caseworker's opening message, which usually embeds the participant record as JSON (this is the ground truth for what the agent already knows)
+- Any \`getApricotRecord\` tool result (additional ground truth; note it sometimes fails, in which case the JSON in the prompt is the only source)
+- The agent's reasoning and its \`gapAnalysis\` calls listing \`missingFields\`
+
+## What good asking looks like
+- Asks only for fields genuinely absent from, or unusable in, the participant record
+- Uses plain-English field labels, not internal names or selectors
+- Does not ask about sensitive fields (SSN, disability, veteran status) unless the form requires them
+- Correctly declines to reuse a value that looks similar but means something different (e.g. treating a CalWorks ID as a MediCal case number)
+- Explains ambiguity with a short note when a field is genuinely unclear
+
+## What bad asking looks like
+- Asks for name, DOB, address, phone, or email when those are plainly in the record
+- Asks for sensitive fields the form does not require
+- Uses technical labels ("value for field income_monthly_gross")
+- Re-asks the same field multiple times within one turn
+- Misses a required field that the form needs and the record does not supply
+
+## Scope
+Judge only the asking behavior. Ignore browser mechanics, navigation problems, tool errors, and infrastructure failures — those are covered by other scorers.
+
+If the trace contains no \`gapAnalysis\` call at all — including when it is empty or has no readable content — you MUST choose Skip. Never infer a gapAnalysis call that is not present. Never fall back to (C) for a trace you could not read: (C) means the agent asked badly, not that there was nothing to grade.`;
+
+export const USER_PROMPT = `## Production trace
+{{preprocessed}}
+
+## Evaluation
+Choose exactly one:
+
+(A) Asked only for fields genuinely missing from the participant record, in plain English, without asking about unrequired sensitive fields, and without re-asking known values.
+
+(B) Largely on target, with minor issues — a slightly technical label, one redundant ask, or a single stray question about a field the record arguably covers.
+
+(C) Major issues: asked for fields the record already supplies, asked for unrequired sensitive fields, fabricated questions about fields not on the form, or missed a required missing field.
+
+Skip: the trace contains no gapAnalysis call, or has no readable content to grade.`;
+
+export const EVALUATOR_DEFINITION = {
+  name: 'Gap Analysis Asking (Online)',
+  slug: EVALUATOR_SLUG,
+  description:
+    "Trace-scoped LLM judge for production traffic. Grades whether the agent's gapAnalysis calls asked the caseworker for the right missing fields, in plain English, without re-asking values already in the participant record. Skips traces with no gapAnalysis call.",
+  prompt_data: {
+    prompt: {
+      type: 'chat' as const,
+      messages: [
+        { role: 'system' as const, content: SYSTEM_PROMPT },
+        { role: 'user' as const, content: USER_PROMPT },
+      ],
+    },
+    options: { model: JUDGE_MODEL, params: {} },
+    parser: {
+      type: 'llm_classifier' as const,
+      use_cot: true,
+      choice_scores: CHOICE_SCORES,
+    },
+    preprocessor: { type: 'inline' as const, code: PREPROCESSOR_CODE },
+    // Unreliable when set via REST: the judge picks (C) instead of Skip on
+    // empty traces. BTQL_FILTER is what actually keeps those out.
+    allow_skip: true,
+  },
+};
+
+// Trace scope, not span: filterAISpans drops the OTEL root.
+export const RULE_SCOPE = { type: 'trace' as const, idle_seconds: 60 };

--- a/evals/online/gap-analysis-asking.ts
+++ b/evals/online/gap-analysis-asking.ts
@@ -7,6 +7,9 @@ export const CHOICE_SCORES = { A: 1, B: 0.5, C: 0 } as const;
 
 export const JUDGE_MODEL = 'claude-sonnet-5';
 
+// Only A (1.0) passes.
+export const PASS_THRESHOLD = 0.75;
+
 export const EVALUATOR_SLUG = 'gap-analysis-asking-online';
 export const RULE_NAME = 'Gap analysis asking quality';
 
@@ -121,6 +124,8 @@ export const EVALUATOR_DEFINITION = {
     // empty traces. BTQL_FILTER is what actually keeps those out.
     allow_skip: true,
   },
+  // B (0.5) is "minor issues" and should not count as passing.
+  metadata: { __pass_threshold: PASS_THRESHOLD },
 };
 
 // Trace scope, not span: filterAISpans drops the OTEL root.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eval": "rc=0; for f in evals/*.eval.ts; do dotenv -e .env.local -- braintrust eval $f --external-packages agent-browser playwright playwright-core chromium-bidi || rc=1; done; exit $rc",
     "eval:tool-selection": "dotenv -e .env.local -- braintrust eval evals/tool-selection.eval.ts",
     "eval:check-harness": "tsx evals/browser-harness.check.ts",
+    "eval:online:apply": "dotenv -e .env.local -- tsx evals/online/apply.ts",
     "eval:ci": "rc=0; for f in evals/*.eval.ts; do braintrust eval $f --external-packages agent-browser playwright playwright-core chromium-bidi || rc=1; done; exit $rc"
   },
   "dependencies": {


### PR DESCRIPTION
Adds our first Braintrust **online eval** — scoring real user traffic as it arrives, rather than only in CI. Live and active in `labs-asp-dev` and `labs-asp-preview`.

## What it scores

Whether the agent's `gapAnalysis` calls asked the caseworker for the right missing fields, in plain English, without re-asking values the participant record already supplies. Trace-scoped LLM judge on `claude-sonnet-5`, A=1 / B=0.5 / C=0.

Adapted from the offline `ask-questions-judge`. The one substantive change: offline, the eval serializer injects the participant record into `{{output}}`. Online there is no serializer — but the record turns out to be pasted into the caseworker's opening message as readable JSON, so the judge reads ground truth from there. No app changes needed.

The other three offline scorers (hallucination, summary-attribution, verbosity) don't port as cleanly. They need ground truth that `getApricotRecord` can't supply online: it returns opaque `field_3051`-style keys with no label mapping, and it 401s in dev.

## Environment mapping

One rule per environment project, matching how the app already routes traces (`BRAINTRUST_PARENT=project_name:labs-asp-${base_environment}` in `terraform/cloud_run.tf`, where `base_environment` collapses `preview-pr-*` to `preview`):

```
pnpm eval:online:apply dev     [--activate] [--dry-run]
pnpm eval:online:apply preview [--activate]
pnpm eval:online:apply prod    [--activate]
```

Idempotent — re-applying reconciles the existing evaluator and rule in place (verified: same IDs across four applies). Rules are created **paused** unless `--activate`, so applying to a new environment can't silently start spending on live traffic.

`labs-asp-prod` doesn't exist yet; Braintrust creates a project on its first trace, so the script fails with that explanation until prod traffic starts. The dead `labs-asp` project is untouched.

## Two findings worth reviewing

**Trace scope, not span.** `filterAISpans: true` in `instrumentation.ts` drops the OTEL root, so these traces have no parentless span — `apply_to_root_span` would never fire.

**The BTQL filter is load-bearing, not an optimisation.** Standalone `agent-browser close` spans form empty 1-span "traces". The judge scores them anyway with a fully invented rationale — gpt-4o gave one an A/1.0 on no content. `allow_skip` is set, but does **not** reliably produce a Skip choice when configured over REST: the judge's own rationale says "I must choose Skip" and then emits C. Confirmed via SQL that both orphan traces have `gap_spans = 0`, so the filter excludes them before the judge runs; the bad scores only appear when bypassing the filter via `test_evaluator`. Flagged in a code comment. Worth confirming with Braintrust whether `allow_skip` is meant to work over REST before anyone loosens that filter.

## Implementation note

Defined over the REST API rather than the `projects.scorers.create` builder that `evals/scorers/*.ts` uses. That builder's `ScorerPromptOpts` exposes only `useCot` and `choiceScores` — it can't express `preprocessor` or `allow_skip`, and the preprocessor is what takes a small trace from ~52KB to ~6KB by dropping browser snapshot blobs.

## Testing

Validated against real dev traces before activating: A on a clean WIC trace, B on a borderline one, correct skip-intent on empty ones — so the rubric discriminates rather than rubber-stamping. `biome check` and `tsc --noEmit` pass.
